### PR TITLE
fix(client-ui): changer le port par défaut à 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Le backend demarre sur `http://localhost:8080`.
 # Chantier UI (port 3000)
 cd chantier-ui && npm install && npm start
 
-# Client UI (port 3000)
+# Client UI (port 3001)
 cd client-ui && npm install && npm start
 
 # Technicien UI (port 3002)

--- a/client-ui/package.json
+++ b/client-ui/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3001 react-scripts start",
     "build": "BUILD_PATH=target/classes/META-INF/resources react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## Summary
- Change le port par défaut de `client-ui` de 3000 à 3001 pour éviter le conflit avec `chantier-ui`
- Met à jour le README avec le bon port

## Test plan
- [x] Vérifier que `cd client-ui && npm start` démarre bien sur le port 3001
- [x] Vérifier que le proxy vers le backend fonctionne toujours