### PR TITLE
fix(backend): seed default data on startup when database is empty

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/DataInitializer.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/DataInitializer.java
@@ -1,0 +1,33 @@
+package net.nanthrax.moussaillon.services;
+
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.transaction.Transactional;
+import net.nanthrax.moussaillon.persistence.SocieteEntity;
+import net.nanthrax.moussaillon.persistence.UserEntity;
+
+@ApplicationScoped
+public class DataInitializer {
+
+    @Transactional
+    void onStart(@Observes StartupEvent event) {
+        if (UserEntity.count() == 0) {
+            UserEntity admin = new UserEntity();
+            admin.name = "admin";
+            admin.roles = "admin";
+            admin.password = "admin";
+            admin.email = "contact@msplaisance.com";
+            admin.persist();
+        }
+        if (SocieteEntity.count() == 0) {
+            SocieteEntity societe = new SocieteEntity();
+            societe.nom = "A changer";
+            societe.siren = "A changer";
+            societe.capital = 0;
+            societe.adresse = "A changer";
+            societe.persist();
+        }
+    }
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.sql-load-script=import.sql
 quarkus.hibernate-orm.schema-management.strategy=update
 
 quarkus.http.cors.enabled=true


### PR DESCRIPTION
## Summary
- Replace `import.sql` with a `DataInitializer` startup observer that seeds default admin user and societe only when tables are empty
- Fixes 401 login error caused by `import.sql` not being executed with Hibernate `update` schema strategy
- Works in both dev and production modes: fresh databases get seeded, existing ones are left untouched

## Test plan
- [x] Start backend with a fresh database (no `.mv.db` file) and verify the admin user is created
- [x] Restart backend with existing database and verify data is preserved (not duplicated)
- [x] Login on chantier-ui with `admin`/`admin` credentials