### PR TITLE
feat(client-ui): ajouter le changement de mot de passe client

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
@@ -3,6 +3,7 @@ package net.nanthrax.moussaillon.services;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -30,6 +31,11 @@ public class ClientPortalResource {
         public String password;
     }
 
+    public static class ChangePasswordRequest {
+        public String currentPassword;
+        public String newPassword;
+    }
+
     @POST
     @Path("/login")
     public ClientEntity login(LoginRequest request) {
@@ -48,6 +54,27 @@ public class ClientPortalResource {
             throw new WebApplicationException("Mot de passe invalide", Response.Status.UNAUTHORIZED);
         }
         return client;
+    }
+
+    @POST
+    @Path("/clients/{id}/change-password")
+    @Transactional
+    public Response changePassword(@PathParam("id") long id, ChangePasswordRequest request) {
+        if (request == null || request.currentPassword == null || request.newPassword == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Mot de passe actuel et nouveau mot de passe requis.").build();
+        }
+        if (request.newPassword.trim().isEmpty()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Le nouveau mot de passe ne peut pas etre vide.").build();
+        }
+        ClientEntity client = ClientEntity.findById(id);
+        if (client == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Client non trouve.").build();
+        }
+        if (client.motDePasse == null || !client.motDePasse.equals(request.currentPassword)) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity("Mot de passe actuel invalide.").build();
+        }
+        client.motDePasse = request.newPassword;
+        return Response.noContent().build();
     }
 
     @GET

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/ClientPortalResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/ClientPortalResourceTest.java
@@ -106,4 +106,63 @@ public class ClientPortalResourceTest {
             .then()
             .statusCode(200);
     }
+
+    @Test
+    void testChangerMotDePasse() {
+        given()
+            .contentType("application/json")
+            .body("{\"currentPassword\":\"client123\",\"newPassword\":\"newpass456\"}")
+            .when().post("/portal/clients/100/change-password")
+            .then()
+            .statusCode(204);
+
+        // verifier que le nouveau mot de passe fonctionne
+        given()
+            .contentType("application/json")
+            .body("{\"email\":\"jean.dupont@test.com\",\"password\":\"newpass456\"}")
+            .when().post("/portal/login")
+            .then()
+            .statusCode(200)
+            .body("nom", is("Dupont"));
+    }
+
+    @Test
+    void testChangerMotDePasseActuelIncorrect() {
+        given()
+            .contentType("application/json")
+            .body("{\"currentPassword\":\"wrong\",\"newPassword\":\"newpass\"}")
+            .when().post("/portal/clients/100/change-password")
+            .then()
+            .statusCode(401);
+    }
+
+    @Test
+    void testChangerMotDePasseNouveauVide() {
+        given()
+            .contentType("application/json")
+            .body("{\"currentPassword\":\"client123\",\"newPassword\":\"  \"}")
+            .when().post("/portal/clients/100/change-password")
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void testChangerMotDePasseClientNonTrouve() {
+        given()
+            .contentType("application/json")
+            .body("{\"currentPassword\":\"test\",\"newPassword\":\"newpass\"}")
+            .when().post("/portal/clients/9999/change-password")
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void testChangerMotDePasseRequeteVide() {
+        given()
+            .contentType("application/json")
+            .body("{}")
+            .when().post("/portal/clients/100/change-password")
+            .then()
+            .statusCode(400);
+    }
 }

--- a/client-ui/src/mon-profil.test.tsx
+++ b/client-ui/src/mon-profil.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+jest.mock('axios', () => ({
+    __esModule: true,
+    default: {
+        get: (...args: any[]) => mockGet(...args),
+        post: (...args: any[]) => mockPost(...args),
+    },
+}));
+
+import MonProfil from './mon-profil.tsx';
+
+const mockClient = {
+    id: 1,
+    nom: 'Dupont',
+    prenom: 'Jean',
+    type: 'PARTICULIER',
+    email: 'jean@test.com',
+    telephone: '0612345678',
+    adresse: '1 rue du Port',
+};
+
+beforeEach(() => {
+    mockGet.mockResolvedValue({ data: mockClient });
+});
+
+describe('MonProfil', () => {
+    it('affiche les informations du profil', async () => {
+        render(<MonProfil clientId={1} />);
+        await waitFor(() => {
+            expect(screen.getByText('Dupont')).toBeInTheDocument();
+        });
+        expect(screen.getByText('Jean')).toBeInTheDocument();
+        expect(screen.getByText('jean@test.com')).toBeInTheDocument();
+    });
+
+    it('affiche le formulaire de changement de mot de passe', async () => {
+        render(<MonProfil clientId={1} />);
+        await waitFor(() => {
+            expect(screen.getByText('Changer le mot de passe')).toBeInTheDocument();
+        });
+        expect(screen.getByPlaceholderText('Mot de passe actuel')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Nouveau mot de passe')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Confirmer le mot de passe')).toBeInTheDocument();
+    });
+
+    it('envoie la requete de changement de mot de passe', async () => {
+        mockPost.mockResolvedValue({ data: {} });
+        const user = userEvent.setup();
+        render(<MonProfil clientId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Dupont')).toBeInTheDocument();
+        });
+
+        await user.type(screen.getByPlaceholderText('Mot de passe actuel'), 'oldpass');
+        await user.type(screen.getByPlaceholderText('Nouveau mot de passe'), 'newpass');
+        await user.type(screen.getByPlaceholderText('Confirmer le mot de passe'), 'newpass');
+        await user.click(screen.getByText('Modifier'));
+
+        await waitFor(() => {
+            expect(mockPost).toHaveBeenCalledWith('/portal/clients/1/change-password', {
+                currentPassword: 'oldpass',
+                newPassword: 'newpass',
+            });
+        });
+    });
+
+    it('affiche une erreur si le mot de passe actuel est incorrect', async () => {
+        mockPost.mockRejectedValue({
+            response: { data: 'Mot de passe actuel invalide.' },
+        });
+        const user = userEvent.setup();
+        render(<MonProfil clientId={1} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Dupont')).toBeInTheDocument();
+        });
+
+        await user.type(screen.getByPlaceholderText('Mot de passe actuel'), 'wrong');
+        await user.type(screen.getByPlaceholderText('Nouveau mot de passe'), 'newpass');
+        await user.type(screen.getByPlaceholderText('Confirmer le mot de passe'), 'newpass');
+        await user.click(screen.getByText('Modifier'));
+
+        await waitFor(() => {
+            expect(screen.getByText('Mot de passe actuel invalide.')).toBeInTheDocument();
+        });
+    });
+});

--- a/client-ui/src/mon-profil.tsx
+++ b/client-ui/src/mon-profil.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Card, Descriptions, Spin, Tag, message } from 'antd';
-import { ReloadOutlined } from '@ant-design/icons';
+import { Button, Card, Descriptions, Form, Input, Spin, Tag, message } from 'antd';
+import { LockOutlined, ReloadOutlined } from '@ant-design/icons';
 import axios from 'axios';
 
 interface Client {
@@ -31,6 +31,8 @@ const typeLabel: Record<string, string> = {
 export default function MonProfil({ clientId }: MonProfilProps) {
     const [client, setClient] = useState<Client | null>(null);
     const [loading, setLoading] = useState(false);
+    const [passwordForm] = Form.useForm();
+    const [changingPassword, setChangingPassword] = useState(false);
 
     const fetchProfile = () => {
         setLoading(true);
@@ -43,6 +45,23 @@ export default function MonProfil({ clientId }: MonProfilProps) {
     useEffect(() => {
         fetchProfile();
     }, [clientId]);
+
+    const handleChangePassword = async (values: { currentPassword: string; newPassword: string }) => {
+        setChangingPassword(true);
+        try {
+            await axios.post(`/portal/clients/${clientId}/change-password`, {
+                currentPassword: values.currentPassword,
+                newPassword: values.newPassword,
+            });
+            message.success('Mot de passe modifie avec succes');
+            passwordForm.resetFields();
+        } catch (err: any) {
+            const msg = err?.response?.data || 'Erreur lors du changement de mot de passe';
+            message.error(typeof msg === 'string' ? msg : 'Erreur lors du changement de mot de passe');
+        } finally {
+            setChangingPassword(false);
+        }
+    };
 
     return (
         <Card
@@ -71,6 +90,48 @@ export default function MonProfil({ clientId }: MonProfilProps) {
                     </Descriptions>
                 )}
             </Spin>
+            <Card title="Changer le mot de passe" style={{ marginTop: 16 }} size="small">
+                <Form
+                    form={passwordForm}
+                    layout="inline"
+                    onFinish={handleChangePassword}
+                >
+                    <Form.Item
+                        name="currentPassword"
+                        rules={[{ required: true, message: 'Requis' }]}
+                    >
+                        <Input.Password prefix={<LockOutlined />} placeholder="Mot de passe actuel" />
+                    </Form.Item>
+                    <Form.Item
+                        name="newPassword"
+                        rules={[{ required: true, message: 'Requis' }, { min: 4, message: 'Minimum 4 caracteres' }]}
+                    >
+                        <Input.Password prefix={<LockOutlined />} placeholder="Nouveau mot de passe" />
+                    </Form.Item>
+                    <Form.Item
+                        name="confirmPassword"
+                        dependencies={['newPassword']}
+                        rules={[
+                            { required: true, message: 'Requis' },
+                            ({ getFieldValue }) => ({
+                                validator(_, value) {
+                                    if (!value || getFieldValue('newPassword') === value) {
+                                        return Promise.resolve();
+                                    }
+                                    return Promise.reject(new Error('Les mots de passe ne correspondent pas'));
+                                },
+                            }),
+                        ]}
+                    >
+                        <Input.Password prefix={<LockOutlined />} placeholder="Confirmer le mot de passe" />
+                    </Form.Item>
+                    <Form.Item>
+                        <Button type="primary" htmlType="submit" loading={changingPassword}>
+                            Modifier
+                        </Button>
+                    </Form.Item>
+                </Form>
+            </Card>
         </Card>
     );
 }

--- a/client-ui/src/setupTests.ts
+++ b/client-ui/src/setupTests.ts
@@ -1,0 +1,21 @@
+// Polyfills for jsdom (required by Ant Design)
+window.matchMedia = window.matchMedia || function matchMediaMock(query: string) {
+    return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    };
+} as any;
+
+window.ResizeObserver = window.ResizeObserver || class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+} as any;
+
+window.getComputedStyle = window.getComputedStyle || (() => ({})) as any;


### PR DESCRIPTION
## Summary
- Ajout d'un endpoint `POST /portal/clients/{id}/change-password` dans le backend (verification du mot de passe actuel avant mise a jour)
- Ajout d'un formulaire de changement de mot de passe dans la page "Mon Profil" du client-ui (mot de passe actuel, nouveau, confirmation)
- Ajout de 5 tests backend (succes, mauvais mot de passe, mot de passe vide, client inexistant, requete vide)
- Ajout de 4 tests frontend (affichage profil, affichage formulaire, appel API, gestion erreur)
- Ajout d'un fichier `setupTests.ts` pour les polyfills jsdom (matchMedia, ResizeObserver)

## Test plan
- [x] Backend: 16/16 tests passent (`mvn test -Dtest=ClientPortalResourceTest`)
- [x] Frontend: 6/6 tests passent (`npm test`)
- [ ] Test manuel: se connecter sur le portail client, aller sur "Mon Profil", changer le mot de passe, se deconnecter et se reconnecter avec le nouveau mot de passe