### PR TITLE
feat(ui): utiliser DatePicker pour tous les champs date

### DIFF
--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -13,6 +13,7 @@ import {
   Spin,
   Row,
   Col,
+  DatePicker,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -21,6 +22,7 @@ import {
   SearchOutlined,
 } from "@ant-design/icons";
 import axios from "axios";
+import dayjs from "dayjs";
 import clients from "./clients";
 
 const { Option } = Select;
@@ -52,9 +54,9 @@ const defaultBateau: BateauClient = {
   immatriculation: "",
   numeroSerie: "",
   numeroClef: "",
-  dateMeS: "",
-  dateAchat: "",
-  dateFinDeGuarantie: "",
+  dateMeS: null,
+  dateAchat: null,
+  dateFinDeGuarantie: null,
   proprietaires: [],
   modele: null,
   localisation: "",
@@ -143,6 +145,9 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
     setEditing(record);
     form.setFieldsValue({
       ...record,
+      dateMeS: record.dateMeS ? dayjs(record.dateMeS) : null,
+      dateAchat: record.dateAchat ? dayjs(record.dateAchat) : null,
+      dateFinDeGuarantie: record.dateFinDeGuarantie ? dayjs(record.dateFinDeGuarantie) : null,
       modeleId: record.modele?.id || undefined,
       proprietaires: record.proprietaires?.map((p: any) => p.id || p) || [],
       moteurs: record.moteurs?.map((m: any) => m.id || m) || [],
@@ -168,9 +173,12 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
       const values = await form.validateFields();
       setLoading(true);
       // Transform modeleId to modele object and proprietaires/moteurs IDs to objects
-      const { modeleId, proprietaires, moteurs, ...restValues } = values;
+      const { modeleId, proprietaires, moteurs, dateMeS, dateAchat, dateFinDeGuarantie, ...restValues } = values;
       const payload = {
         ...restValues,
+        dateMeS: dateMeS ? dateMeS.format("YYYY-MM-DD") : null,
+        dateAchat: dateAchat ? dateAchat.format("YYYY-MM-DD") : null,
+        dateFinDeGuarantie: dateFinDeGuarantie ? dateFinDeGuarantie.format("YYYY-MM-DD") : null,
         modele: modeleId ? { id: modeleId } : null,
         proprietaires: proprietaires && Array.isArray(proprietaires) 
           ? proprietaires.map((id: number) => ({ id }))
@@ -187,6 +195,9 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         setEditing(updated);
         form.setFieldsValue({
           ...updated,
+          dateMeS: updated.dateMeS ? dayjs(updated.dateMeS) : null,
+          dateAchat: updated.dateAchat ? dayjs(updated.dateAchat) : null,
+          dateFinDeGuarantie: updated.dateFinDeGuarantie ? dayjs(updated.dateFinDeGuarantie) : null,
           modeleId: updated.modele?.id || undefined,
           proprietaires: updated.proprietaires?.map((p: any) => p.id || p) || [],
           moteurs: updated.moteurs?.map((m: any) => m.id || m) || [],
@@ -199,6 +210,9 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         setEditing(created);
         form.setFieldsValue({
           ...created,
+          dateMeS: created.dateMeS ? dayjs(created.dateMeS) : null,
+          dateAchat: created.dateAchat ? dayjs(created.dateAchat) : null,
+          dateFinDeGuarantie: created.dateFinDeGuarantie ? dayjs(created.dateFinDeGuarantie) : null,
           modeleId: created.modele?.id || undefined,
           proprietaires: created.proprietaires?.map((p: any) => p.id || p) || [],
           moteurs: created.moteurs?.map((m: any) => m.id || m) || [],
@@ -301,19 +315,19 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item label="Date MeS" name="dateMeS">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
             <Col span={12}>
               <Form.Item label="Date achat" name="dateAchat">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
           </Row>
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item label="Date fin garantie" name="dateFinDeGuarantie">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
             <Col span={12}>

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -13,6 +13,7 @@ import {
   Spin,
   Row,
   Col,
+  DatePicker,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -21,6 +22,7 @@ import {
   SearchOutlined,
 } from "@ant-design/icons";
 import axios from "axios";
+import dayjs from "dayjs";
 
 const { Option } = Select;
 const { Search } = Input;
@@ -42,9 +44,9 @@ const defaultMoteur: MoteurClient = {
   images: [],
   numeroSerie: "",
   numeroClef: "",
-  dateMeS: "",
-  dateAchat: "",
-  dateFinDeGuarantie: "",
+  dateMeS: null,
+  dateAchat: null,
+  dateFinDeGuarantie: null,
   proprietaire: null,
   modele: null,
 };
@@ -120,6 +122,9 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
     setEditing(record);
     form.setFieldsValue({
       ...record,
+      dateMeS: record.dateMeS ? dayjs(record.dateMeS) : null,
+      dateAchat: record.dateAchat ? dayjs(record.dateAchat) : null,
+      dateFinDeGuarantie: record.dateFinDeGuarantie ? dayjs(record.dateFinDeGuarantie) : null,
       modeleId: record.modele?.id || undefined,
       proprietaireId: record.proprietaire?.id || record.proprietaire || undefined,
       images: record.images ?? [],
@@ -144,9 +149,12 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
     try {
       const values = await form.validateFields();
       setLoading(true);
-      const { modeleId, proprietaireId, ...restValues } = values;
+      const { modeleId, proprietaireId, dateMeS, dateAchat, dateFinDeGuarantie, ...restValues } = values;
       const payload = {
         ...restValues,
+        dateMeS: dateMeS ? dateMeS.format("YYYY-MM-DD") : null,
+        dateAchat: dateAchat ? dateAchat.format("YYYY-MM-DD") : null,
+        dateFinDeGuarantie: dateFinDeGuarantie ? dateFinDeGuarantie.format("YYYY-MM-DD") : null,
         modele: modeleId ? { id: modeleId } : null,
         proprietaire: proprietaireId ? { id: proprietaireId } : null,
       };
@@ -158,6 +166,9 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         setEditing(updated);
         form.setFieldsValue({
           ...updated,
+          dateMeS: updated.dateMeS ? dayjs(updated.dateMeS) : null,
+          dateAchat: updated.dateAchat ? dayjs(updated.dateAchat) : null,
+          dateFinDeGuarantie: updated.dateFinDeGuarantie ? dayjs(updated.dateFinDeGuarantie) : null,
           modeleId: updated.modele?.id || undefined,
           proprietaireId: updated.proprietaire?.id || undefined,
           images: updated.images ?? [],
@@ -170,6 +181,9 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         setEditing(created);
         form.setFieldsValue({
           ...created,
+          dateMeS: created.dateMeS ? dayjs(created.dateMeS) : null,
+          dateAchat: created.dateAchat ? dayjs(created.dateAchat) : null,
+          dateFinDeGuarantie: created.dateFinDeGuarantie ? dayjs(created.dateFinDeGuarantie) : null,
           modeleId: created.modele?.id || undefined,
           proprietaireId: created.proprietaire?.id || undefined,
           images: created.images ?? [],
@@ -284,17 +298,17 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item label="Date MeS" name="dateMeS">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
             <Col span={12}>
               <Form.Item label="Date achat" name="dateAchat">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
           </Row>
           <Form.Item label="Date fin garantie" name="dateFinDeGuarantie">
-            <Input placeholder="YYYY-MM-DD" />
+            <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
           </Form.Item>
           <Form.Item label="Modèle catalogue" name="modeleId">
             <Select

--- a/chantier-ui/src/clients-remorques.tsx
+++ b/chantier-ui/src/clients-remorques.tsx
@@ -13,6 +13,7 @@ import {
   Spin,
   Row,
   Col,
+  DatePicker,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -22,6 +23,7 @@ import {
   DeleteOutlined as DeleteIcon,
 } from "@ant-design/icons";
 import axios from "axios";
+import dayjs from "dayjs";
 
 const { Option } = Select;
 const { Search } = Input;
@@ -41,9 +43,9 @@ interface RemorqueClient {
 const defaultRemorque: RemorqueClient = {
   images: [],
   immatriculation: "",
-  dateMeS: "",
-  dateAchat: "",
-  dateFinDeGuarantie: "",
+  dateMeS: null,
+  dateAchat: null,
+  dateFinDeGuarantie: null,
   proprietaire: null,
   modele: null,
 };
@@ -120,6 +122,9 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
     setEditing(record);
     form.setFieldsValue({
       ...record,
+      dateMeS: record.dateMeS ? dayjs(record.dateMeS) : null,
+      dateAchat: record.dateAchat ? dayjs(record.dateAchat) : null,
+      dateFinDeGuarantie: record.dateFinDeGuarantie ? dayjs(record.dateFinDeGuarantie) : null,
       modeleId: record.modele?.id || undefined,
       proprietaireId: record.proprietaire?.id || undefined,
     });
@@ -143,9 +148,12 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
     try {
       const values = await form.validateFields();
       setLoading(true);
-      const { modeleId, proprietaireId, images, ...restValues } = values;
+      const { modeleId, proprietaireId, images, dateMeS, dateAchat, dateFinDeGuarantie, ...restValues } = values;
       const payload = {
         ...restValues,
+        dateMeS: dateMeS ? dateMeS.format("YYYY-MM-DD") : null,
+        dateAchat: dateAchat ? dateAchat.format("YYYY-MM-DD") : null,
+        dateFinDeGuarantie: dateFinDeGuarantie ? dateFinDeGuarantie.format("YYYY-MM-DD") : null,
         images: Array.isArray(images) ? images : [],
         modele: modeleId ? { id: modeleId } : null,
         proprietaire: proprietaireId ? { id: proprietaireId } : null,
@@ -158,6 +166,9 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
         setEditing(updated);
         form.setFieldsValue({
           ...updated,
+          dateMeS: updated.dateMeS ? dayjs(updated.dateMeS) : null,
+          dateAchat: updated.dateAchat ? dayjs(updated.dateAchat) : null,
+          dateFinDeGuarantie: updated.dateFinDeGuarantie ? dayjs(updated.dateFinDeGuarantie) : null,
           modeleId: updated.modele?.id || undefined,
           proprietaireId: updated.proprietaire?.id || undefined,
         });
@@ -169,6 +180,9 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
         setEditing(created);
         form.setFieldsValue({
           ...created,
+          dateMeS: created.dateMeS ? dayjs(created.dateMeS) : null,
+          dateAchat: created.dateAchat ? dayjs(created.dateAchat) : null,
+          dateFinDeGuarantie: created.dateFinDeGuarantie ? dayjs(created.dateFinDeGuarantie) : null,
           modeleId: created.modele?.id || undefined,
           proprietaireId: created.proprietaire?.id || undefined,
         });
@@ -256,19 +270,19 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
             </Col>
             <Col span={12}>
               <Form.Item label="Date MeS" name="dateMeS">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
           </Row>
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item label="Date achat" name="dateAchat">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
             <Col span={12}>
               <Form.Item label="Date fin garantie" name="dateFinDeGuarantie">
-                <Input placeholder="YYYY-MM-DD" />
+                <DatePicker format="YYYY-MM-DD" style={{ width: "100%" }} />
               </Form.Item>
             </Col>
           </Row>


### PR DESCRIPTION
## Résumé
- Remplacement des champs `Input` par des `DatePicker` antd pour tous les champs date (`dateMeS`, `dateAchat`, `dateFinDeGuarantie`) dans `clients-bateaux.tsx`, `clients-moteurs.tsx` et `clients-remorques.tsx`
- Ajout de la conversion `dayjs` entre les dates au format string (API) et les objets dayjs (DatePicker)
- Mise à jour des valeurs par défaut de chaînes vides vers `null` pour les champs date

## Plan de test
- [ ] Ouvrir chaque modale (bateaux, moteurs, remorques) et vérifier que le DatePicker s'affiche correctement
- [ ] Créer une nouvelle entrée avec des dates sélectionnées via le DatePicker
- [ ] Modifier une entrée existante et vérifier que les dates sont pré-remplies dans le DatePicker
- [ ] Sauvegarder et vérifier que les dates sont envoyées au format YYYY-MM-DD à l'API
- [ ] Vérifier que la suppression d'une date fonctionne correctement