### PR TITLE
Ajout des KPI par technicien

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienKpiResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienKpiResource.java
@@ -1,0 +1,86 @@
+package net.nanthrax.moussaillon.services;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import net.nanthrax.moussaillon.persistence.TaskEntity;
+import net.nanthrax.moussaillon.persistence.TechnicienEntity;
+
+@Path("/techniciens/{id}/kpi")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class TechnicienKpiResource {
+
+    @GET
+    public TechnicienKpi get(@PathParam("id") long id) {
+        TechnicienEntity technicien = TechnicienEntity.findById(id);
+        if (technicien == null) {
+            throw new WebApplicationException("Le technicien (" + id + ") n'est pas trouvé", 404);
+        }
+
+        List<TaskEntity> allTasks = TaskEntity.list("technicien.id = ?1", id);
+
+        LocalDate now = LocalDate.now();
+        LocalDate startOfMonth = now.withDayOfMonth(1);
+        Date monthStart = Date.valueOf(startOfMonth);
+
+        TechnicienKpi kpi = new TechnicienKpi();
+
+        kpi.totalTaches = allTasks.size();
+        kpi.tachesTerminees = (int) allTasks.stream().filter(t -> t.status == TaskEntity.Status.TERMINEE).count();
+        kpi.tachesEnCours = (int) allTasks.stream().filter(t -> t.status == TaskEntity.Status.EN_COURS).count();
+        kpi.tachesEnAttente = (int) allTasks.stream().filter(t -> t.status == TaskEntity.Status.EN_ATTENTE || t.status == TaskEntity.Status.PLANIFIEE).count();
+        kpi.tachesIncident = (int) allTasks.stream().filter(t -> t.status == TaskEntity.Status.INCIDENT).count();
+        kpi.tachesAnnulees = (int) allTasks.stream().filter(t -> t.status == TaskEntity.Status.ANNULEE).count();
+
+        kpi.tauxCompletion = kpi.totalTaches > 0 ? Math.round((double) kpi.tachesTerminees / kpi.totalTaches * 100.0 * 10) / 10.0 : 0;
+        kpi.tauxIncident = kpi.totalTaches > 0 ? Math.round((double) kpi.tachesIncident / kpi.totalTaches * 100.0 * 10) / 10.0 : 0;
+
+        kpi.heuresEstimees = allTasks.stream().mapToDouble(t -> t.dureeEstimee).sum();
+        kpi.heuresReelles = allTasks.stream().filter(t -> t.status == TaskEntity.Status.TERMINEE).mapToDouble(t -> t.dureeReelle).sum();
+        kpi.efficacite = kpi.heuresEstimees > 0 ? Math.round(kpi.heuresReelles / kpi.heuresEstimees * 100.0 * 10) / 10.0 : 0;
+
+        // KPIs du mois
+        List<TaskEntity> tachesDuMois = allTasks.stream()
+                .filter(t -> t.dateDebut != null && !t.dateDebut.before(monthStart))
+                .toList();
+        kpi.tachesMois = tachesDuMois.size();
+        kpi.tachesTermineesMois = (int) tachesDuMois.stream().filter(t -> t.status == TaskEntity.Status.TERMINEE).count();
+        kpi.heuresReellesMois = tachesDuMois.stream().filter(t -> t.status == TaskEntity.Status.TERMINEE).mapToDouble(t -> t.dureeReelle).sum();
+
+        // Retards > 48h
+        Date twoDaysAgo = Date.valueOf(now.minusDays(2));
+        kpi.retards48h = (int) allTasks.stream()
+                .filter(t -> t.status == TaskEntity.Status.EN_COURS && t.dateDebut != null && t.dateDebut.before(twoDaysAgo))
+                .count();
+
+        return kpi;
+    }
+
+    public static class TechnicienKpi {
+        public int totalTaches;
+        public int tachesTerminees;
+        public int tachesEnCours;
+        public int tachesEnAttente;
+        public int tachesIncident;
+        public int tachesAnnulees;
+        public double tauxCompletion;
+        public double tauxIncident;
+        public double heuresEstimees;
+        public double heuresReelles;
+        public double efficacite;
+        public int tachesMois;
+        public int tachesTermineesMois;
+        public double heuresReellesMois;
+        public int retards48h;
+    }
+
+}

--- a/chantier-ui/src/techniciens.tsx
+++ b/chantier-ui/src/techniciens.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Space, Table, Button, Input, Form, Modal, Card, Row, Col, Popconfirm, message } from 'antd';
-import { PlusCircleOutlined, EditOutlined, DeleteOutlined, UserOutlined } from '@ant-design/icons';
+import { Space, Table, Button, Input, Form, Modal, Card, Row, Col, Popconfirm, message, Drawer, Statistic, Progress, Divider, Spin } from 'antd';
+import { PlusCircleOutlined, EditOutlined, DeleteOutlined, UserOutlined, BarChartOutlined, CheckCircleOutlined, ClockCircleOutlined, ExclamationCircleOutlined, WarningOutlined } from '@ant-design/icons';
 import axios from 'axios';
 
 // --- Types ---
@@ -13,6 +13,24 @@ interface TechnicienEntity {
     email: string;
     telephone?: string;
     couleur?: string;
+}
+
+interface TechnicienKpi {
+    totalTaches: number;
+    tachesTerminees: number;
+    tachesEnCours: number;
+    tachesEnAttente: number;
+    tachesIncident: number;
+    tachesAnnulees: number;
+    tauxCompletion: number;
+    tauxIncident: number;
+    heuresEstimees: number;
+    heuresReelles: number;
+    efficacite: number;
+    tachesMois: number;
+    tachesTermineesMois: number;
+    heuresReellesMois: number;
+    retards48h: number;
 }
 
 interface TechnicienFormValues {
@@ -42,6 +60,10 @@ const Techniciens: React.FC = () => {
     const [currentTechnicien, setCurrentTechnicien] = useState<TechnicienEntity | null>(null);
     const [form] = Form.useForm();
     const [searchQuery, setSearchQuery] = useState<string>('');
+    const [kpiDrawerVisible, setKpiDrawerVisible] = useState<boolean>(false);
+    const [kpiLoading, setKpiLoading] = useState<boolean>(false);
+    const [kpiData, setKpiData] = useState<TechnicienKpi | null>(null);
+    const [kpiTechnicien, setKpiTechnicien] = useState<TechnicienEntity | null>(null);
 
     // Get all techniciens
     const fetchTechniciens = async (query: string = '') => {
@@ -119,6 +141,19 @@ const Techniciens: React.FC = () => {
         fetchTechniciens(value);
     };
 
+    const openKpiDrawer = async (technicien: TechnicienEntity) => {
+        setKpiTechnicien(technicien);
+        setKpiDrawerVisible(true);
+        setKpiLoading(true);
+        try {
+            const res = await axios.get(`/techniciens/${technicien.id}/kpi`);
+            setKpiData(res.data);
+        } catch {
+            message.error('Erreur lors du chargement des KPI.');
+        }
+        setKpiLoading(false);
+    };
+
     // Columns
     const columns = [
         {
@@ -180,6 +215,7 @@ const Techniciens: React.FC = () => {
             key: 'actions',
             render: (_: any, record: TechnicienEntity) => (
                 <Space>
+                    <Button onClick={() => openKpiDrawer(record)} icon={<BarChartOutlined/>} title="KPI" />
                     <Button onClick={() => openModal(record)} icon={<EditOutlined/>} />
                     <Popconfirm
                         title="Supprimer ce technicien ?"
@@ -312,6 +348,90 @@ const Techniciens: React.FC = () => {
                     </Col>
                 </Row>
             </Card>
+            <Drawer
+                title={kpiTechnicien ? `KPI — ${kpiTechnicien.prenom} ${kpiTechnicien.nom}` : 'KPI'}
+                open={kpiDrawerVisible}
+                onClose={() => { setKpiDrawerVisible(false); setKpiData(null); }}
+                width={520}
+            >
+                {kpiLoading ? (
+                    <div style={{ textAlign: 'center', padding: 40 }}><Spin size="large" /></div>
+                ) : kpiData ? (
+                    <>
+                        <Divider orientation="left">Vue globale</Divider>
+                        <Row gutter={[16, 16]}>
+                            <Col span={8}>
+                                <Statistic title="Total tâches" value={kpiData.totalTaches} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="Terminées" value={kpiData.tachesTerminees} valueStyle={{ color: '#52c41a' }} prefix={<CheckCircleOutlined />} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="En cours" value={kpiData.tachesEnCours} valueStyle={{ color: '#1677ff' }} prefix={<ClockCircleOutlined />} />
+                            </Col>
+                        </Row>
+                        <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+                            <Col span={8}>
+                                <Statistic title="En attente" value={kpiData.tachesEnAttente} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="Incidents" value={kpiData.tachesIncident} valueStyle={{ color: '#ff4d4f' }} prefix={<ExclamationCircleOutlined />} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="Annulées" value={kpiData.tachesAnnulees} valueStyle={{ color: '#999' }} />
+                            </Col>
+                        </Row>
+
+                        <Divider orientation="left">Taux</Divider>
+                        <Row gutter={[16, 16]}>
+                            <Col span={8}>
+                                <div style={{ textAlign: 'center' }}>
+                                    <Progress type="circle" percent={kpiData.tauxCompletion} size={80} strokeColor="#52c41a" />
+                                    <div style={{ marginTop: 8 }}>Complétion</div>
+                                </div>
+                            </Col>
+                            <Col span={8}>
+                                <div style={{ textAlign: 'center' }}>
+                                    <Progress type="circle" percent={kpiData.tauxIncident} size={80} strokeColor="#ff4d4f" />
+                                    <div style={{ marginTop: 8 }}>Incidents</div>
+                                </div>
+                            </Col>
+                            <Col span={8}>
+                                <div style={{ textAlign: 'center' }}>
+                                    <Progress type="circle" percent={kpiData.efficacite} size={80} strokeColor={kpiData.efficacite <= 100 ? '#52c41a' : '#faad14'} />
+                                    <div style={{ marginTop: 8 }}>Efficacité</div>
+                                </div>
+                            </Col>
+                        </Row>
+
+                        <Divider orientation="left">Heures</Divider>
+                        <Row gutter={[16, 16]}>
+                            <Col span={8}>
+                                <Statistic title="Estimées" value={kpiData.heuresEstimees} suffix="h" precision={1} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="Réelles" value={kpiData.heuresReelles} suffix="h" precision={1} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="Retards > 48h" value={kpiData.retards48h} valueStyle={kpiData.retards48h > 0 ? { color: '#ff4d4f' } : {}} prefix={kpiData.retards48h > 0 ? <WarningOutlined /> : undefined} />
+                            </Col>
+                        </Row>
+
+                        <Divider orientation="left">Ce mois</Divider>
+                        <Row gutter={[16, 16]}>
+                            <Col span={8}>
+                                <Statistic title="Tâches" value={kpiData.tachesMois} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="Terminées" value={kpiData.tachesTermineesMois} valueStyle={{ color: '#52c41a' }} />
+                            </Col>
+                            <Col span={8}>
+                                <Statistic title="Heures réelles" value={kpiData.heuresReellesMois} suffix="h" precision={1} />
+                            </Col>
+                        </Row>
+                    </>
+                ) : null}
+            </Drawer>
         </>
     );
 };


### PR DESCRIPTION
## Summary
- Nouvel endpoint REST `GET /techniciens/{id}/kpi` calculant les indicateurs de performance par technicien (tâches par statut, taux de complétion/incidents, heures estimées vs réelles, efficacité, retards > 48h, suivi mensuel)
- Drawer KPI dans la page Équipe (chantier-ui) avec jauges circulaires et statistiques, accessible via un bouton sur chaque ligne technicien

## Test plan
- [ ] Vérifier que l'endpoint `/techniciens/{id}/kpi` retourne les données correctes
- [ ] Vérifier l'affichage du drawer KPI en cliquant sur le bouton graphique d'un technicien
- [ ] Vérifier les jauges de complétion, incidents et efficacité
- [ ] Vérifier les données du mois en cours