### PR TITLE
fix(chantier-ui): inverser l'ordre des champs Prénom et Nom

### DIFF
--- a/chantier-ui/src/techniciens.tsx
+++ b/chantier-ui/src/techniciens.tsx
@@ -283,19 +283,19 @@ const Techniciens: React.FC = () => {
                             >
                                 <Row gutter={16}>
                                     <Col span={12}>
-                                        <Form.Item 
-                                            name="nom" 
-                                            label="Nom" 
-                                            rules={[{ required: true, message: "Le nom est requis" }]}
+                                        <Form.Item
+                                            name="prenom"
+                                            label="Prénom"
+                                            rules={[{ required: true, message: "Le prénom est requis" }]}
                                         >
                                             <Input />
                                         </Form.Item>
                                     </Col>
                                     <Col span={12}>
-                                        <Form.Item 
-                                            name="prenom" 
-                                            label="Prénom" 
-                                            rules={[{ required: true, message: "Le prénom est requis" }]}
+                                        <Form.Item
+                                            name="nom"
+                                            label="Nom"
+                                            rules={[{ required: true, message: "Le nom est requis" }]}
                                         >
                                             <Input />
                                         </Form.Item>


### PR DESCRIPTION
## Résumé
- Inverse l'ordre des champs Prénom et Nom dans la modale d'ajout/modification d'un technicien
- Le champ Prénom apparaît désormais en premier, suivi du champ Nom

## Plan de test
- [ ] Ouvrir la modale "Ajouter un technicien" et vérifier que Prénom est avant Nom
- [ ] Ouvrir la modale "Modifier un technicien" et vérifier le même ordre