### PR TITLE
feat(chantier-ui): remplir Localisation avec les coordonnées GPS

### DIFF
--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -353,7 +353,11 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         destroyOnHidden
         width={1024}
       >
-        <Form layout="vertical" form={form} initialValues={defaultBateau}>
+        <Form layout="vertical" form={form} initialValues={defaultBateau} onValuesChange={(changedValues) => {
+            if (changedValues.localisationGps) {
+              form.setFieldsValue({ localisation: changedValues.localisationGps });
+            }
+          }}>
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item label="Nom" name="name" rules={[{ required: true, message: "Nom requis" }]}>


### PR DESCRIPTION
## Résumé

- Lors de la sélection d'un point sur la carte dans le formulaire "Ajouter un bateau", le champ **Localisation** est automatiquement rempli avec les coordonnées GPS sélectionnées.

## Plan de test

- [x] Ouvrir le formulaire "Ajouter un bateau"
- [x] Cliquer sur un point sur la carte
- [x] Vérifier que le champ "Localisation" est rempli avec les coordonnées GPS
- [x] Vérifier qu'un second clic écrase bien la valeur précédente