### PR TITLE
feat: ajouter la gestion des images sur les ventes

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
@@ -82,6 +82,8 @@ public class VenteEntity extends PanacheEntity {
 
     public ModePaiement modePaiement;
 
+    public List<String> images = new ArrayList<>();
+
     public boolean stockDecremented;
 
     // Configuration des rappels (en jours avant la date de la vente)

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -278,6 +278,7 @@ public class VenteResource {
             }
         }
 
+        entity.images = vente.images != null ? vente.images : new java.util.ArrayList<>();
         entity.date = vente.date;
         entity.remise = vente.remise;
         entity.montantTTC = vente.montantTTC;

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -259,6 +259,7 @@ interface VenteEntity {
     montantTVA?: number;
     prixVenteTTC?: number;
     modePaiement?: ModePaiement;
+    images?: string[];
     rappel1Jours?: number;
     rappel2Jours?: number;
     rappel3Jours?: number;
@@ -318,6 +319,7 @@ interface VenteFormValues {
     montantTTC: number;
     prixVenteTTC: number;
     modePaiement?: ModePaiement;
+    images?: string[];
     rappel1Jours?: number;
     rappel2Jours?: number;
     rappel3Jours?: number;
@@ -419,7 +421,8 @@ const defaultVente: VenteFormValues = {
     tva: 20,
     montantTVA: 0,
     montantTTC: 0,
-    prixVenteTTC: 0
+    prixVenteTTC: 0,
+    images: []
 };
 
 const formatEuro = (value?: number) => `${(value || 0).toFixed(2)} EUR`;
@@ -1097,6 +1100,7 @@ export default function Vente() {
             montantTTC: vente.montantTTC || 0,
             prixVenteTTC: vente.prixVenteTTC || 0,
             modePaiement: vente.modePaiement,
+            images: vente.images || [],
             rappel1Jours: vente.rappel1Jours,
             rappel2Jours: vente.rappel2Jours,
             rappel3Jours: vente.rappel3Jours
@@ -1204,6 +1208,7 @@ export default function Vente() {
         montantTTC: values.montantTTC || 0,
         prixVenteTTC: values.prixVenteTTC || 0,
         modePaiement: values.modePaiement,
+        images: values.images || [],
         rappel1Jours: values.rappel1Jours,
         rappel2Jours: values.rappel2Jours,
         rappel3Jours: values.rappel3Jours
@@ -2249,6 +2254,15 @@ export default function Vente() {
                                             </>
                                         )}
                                     </>
+                                )
+                            },
+                            {
+                                key: 'images',
+                                label: 'Images',
+                                children: (
+                                    <Form.Item name="images" label="Images">
+                                        <ImageUpload />
+                                    </Form.Item>
                                 )
                             },
                         ]}


### PR DESCRIPTION
## Résumé
- Ajout d'un champ `images` (`List<String>`) sur `VenteEntity` (backend) avec persistance dans le `VenteResource`
- Ajout d'un onglet "Images" dans le formulaire de vente (frontend) utilisant le composant `ImageUpload` existant
- Les images sont correctement chargées à l'édition et sauvegardées à la création/modification

## Plan de test
- [x] Créer une vente et ajouter des images via l'onglet "Images"
- [x] Modifier une vente existante et vérifier que les images sont bien chargées
- [x] Supprimer une image et sauvegarder, vérifier la persistance
- [x] Vérifier que les autres onglets (Lignes, Rappels) fonctionnent toujours correctement