### PR TITLE
fix: ajouter automatiquement une ligne vide après création d'un élément

### DIFF
--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -699,6 +699,11 @@ export default function Vente() {
                 const currentLines = form.getFieldValue('produits') || [];
                 const updated = [...currentLines];
                 updated[newProduitTargetLine] = { ...updated[newProduitTargetLine], produitId: created.id };
+                // Check if this was the last line and add a new empty line
+                const lastLine = updated[updated.length - 1];
+                if (!!lastLine?.produitId && (lastLine?.quantite || 0) > 0) {
+                    updated.push({ quantite: 1 });
+                }
                 form.setFieldValue('produits', updated);
                 recalculateFromLines('auto', { produits: [...produits, created] });
             }
@@ -811,6 +816,11 @@ export default function Vente() {
                     const currentLines = form.getFieldValue('venteServices') || [];
                     const updatedLines = [...currentLines];
                     updatedLines[newServiceTargetLine] = { ...updatedLines[newServiceTargetLine], serviceId: created.id };
+                    // Check if this was the last line and add a new empty line
+                    const lastLine = updatedLines[updatedLines.length - 1];
+                    if (!!lastLine?.serviceId && (lastLine?.quantite || 0) > 0) {
+                        updatedLines.push({ status: 'EN_ATTENTE', quantite: 1 });
+                    }
                     form.setFieldValue('venteServices', updatedLines);
                     recalculateFromLines('auto', { services: [...services, created] });
                 }
@@ -951,6 +961,11 @@ export default function Vente() {
                 const currentLines = form.getFieldValue('venteForfaits') || [];
                 const updated = [...currentLines];
                 updated[newForfaitTargetLine] = { ...updated[newForfaitTargetLine], forfaitId: created.id };
+                // Check if this was the last line and add a new empty line
+                const lastLine = updated[updated.length - 1];
+                if (!!lastLine?.forfaitId && (lastLine?.quantite || 0) > 0) {
+                    updated.push({ status: 'EN_ATTENTE', quantite: 1 });
+                }
                 form.setFieldValue('venteForfaits', updated);
                 recalculateFromLines('auto', { forfaits: [...forfaits, created] });
             }


### PR DESCRIPTION
## Résumé

- Corrige le bug où la création d'un service, forfait ou produit via la modale dans "Ajouter une vente" n'ajoutait pas automatiquement une nouvelle ligne vide
- `form.setFieldValue()` d'Ant Design ne déclenche pas `onValuesChange`, donc la logique d'auto-ajout était contournée lors de l'affectation programmatique de l'ID après création

## Plan de test

- [ ] Ouvrir "Ajouter une vente", cliquer sur le bouton "+" pour créer un nouveau service → une nouvelle ligne vide doit apparaître automatiquement
- [ ] Même vérification pour la création d'un forfait
- [ ] Même vérification pour la création d'un produit
- [ ] Vérifier que le comportement existant (auto-ajout via modification de quantité) fonctionne toujours