### PR TITLE
feat: ajouter le champ Référence sur Main d'Oeuvre

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/MainOeuvreEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/MainOeuvreEntity.java
@@ -6,6 +6,8 @@ import jakarta.persistence.Entity;
 @Entity
 public class MainOeuvreEntity extends PanacheEntity {
 
+    public String reference;
+
     public String nom;
 
     public String description;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/MainOeuvreResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/MainOeuvreResource.java
@@ -35,7 +35,7 @@ public class MainOeuvreResource {
             return MainOeuvreEntity.listAll();
         }
         String likePattern = "%" + q.toLowerCase() + "%";
-        return MainOeuvreEntity.list("LOWER(nom) LIKE ?1 OR LOWER(description) LIKE ?1", likePattern);
+        return MainOeuvreEntity.list("LOWER(nom) LIKE ?1 OR LOWER(description) LIKE ?1 OR LOWER(reference) LIKE ?1", likePattern);
     }
 
     @POST
@@ -76,6 +76,7 @@ public class MainOeuvreResource {
             throw new WebApplicationException("La main d'oeuvre (" + id + ") n'est pas trouvée", 404);
         }
 
+        entity.reference = mainOeuvre.reference;
         entity.nom = mainOeuvre.nom;
         entity.description = mainOeuvre.description;
         entity.prixHT = mainOeuvre.prixHT;

--- a/backend/src/test/resources/import-test.sql
+++ b/backend/src/test/resources/import-test.sql
@@ -34,8 +34,8 @@ INSERT INTO ProduitCatalogueEntity (id, nom, marque, categorie, description, eva
 INSERT INTO ProduitCatalogueEntity (id, nom, marque, categorie, description, evaluation, stock, stockMini, prixPublic, frais, tauxMarge, tauxMarque, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (101, 'Filtre a huile', 'Mercury', 'Entretien', 'Filtre compatible Mercury', 0, 2, 5, 15.0, 0, 0, 0, 12.0, 20.0, 2.4, 14.4);
 
 -- Main d'oeuvres (all primitive fields included)
-INSERT INTO MainOeuvreEntity (id, nom, description, prixHT, tva, montantTVA, prixTTC) VALUES (100, 'Revision annuelle', 'Revision complete moteur', 150.0, 20.0, 30.0, 180.0);
-INSERT INTO MainOeuvreEntity (id, nom, description, prixHT, tva, montantTVA, prixTTC) VALUES (101, 'Vidange moteur', 'Vidange huile et filtre', 80.0, 20.0, 16.0, 96.0);
+INSERT INTO MainOeuvreEntity (id, reference, nom, description, prixHT, tva, montantTVA, prixTTC) VALUES (100, 'MO-001', 'Revision annuelle', 'Revision complete moteur', 150.0, 20.0, 30.0, 180.0);
+INSERT INTO MainOeuvreEntity (id, reference, nom, description, prixHT, tva, montantTVA, prixTTC) VALUES (101, 'MO-002', 'Vidange moteur', 'Vidange huile et filtre', 80.0, 20.0, 16.0, 96.0);
 
 -- Services (all primitive fields included)
 INSERT INTO ServiceEntity (id, nom, description, dureeEstimee, prixHT, tva, montantTVA, prixTTC) VALUES (100, 'Entretien complet', 'Service entretien complet moteur', 3.0, 230.0, 20.0, 46.0, 276.0);

--- a/chantier-ui/src/forfaits.tsx
+++ b/chantier-ui/src/forfaits.tsx
@@ -59,6 +59,7 @@ interface ProduitCatalogueEntity {
 
 interface MainOeuvreEntity {
     id: number;
+    reference?: string;
     nom: string;
     description?: string;
     prixHT?: number;
@@ -76,7 +77,7 @@ const defaultNewProduit = {
 };
 
 const defaultNewMainOeuvre = {
-    nom: '', description: '', prixHT: 0, tva: 20, montantTVA: 0, prixTTC: 0,
+    reference: '', nom: '', description: '', prixHT: 0, tva: 20, montantTVA: 0, prixTTC: 0,
 };
 
 interface ForfaitProduitEntity {
@@ -204,7 +205,7 @@ export default function Forfaits() {
     );
 
     const mainOeuvreOptions = useMemo(
-        () => mainOeuvresList.map((mo) => ({ value: mo.id, label: mo.nom })),
+        () => mainOeuvresList.map((mo) => ({ value: mo.id, label: mo.reference ? `${mo.reference} - ${mo.nom}` : mo.nom })),
         [mainOeuvresList]
     );
 
@@ -1113,6 +1114,9 @@ export default function Forfaits() {
                     destroyOnHidden
                 >
                     <Form form={newMainOeuvreForm} layout="vertical" initialValues={defaultNewMainOeuvre} onValuesChange={(...args) => { setNewMainOeuvreFormDirty(true); onNewMainOeuvreValuesChange(...args); }}>
+                        <Form.Item name="reference" label="Référence">
+                            <Input allowClear />
+                        </Form.Item>
                         <Form.Item name="nom" label="Nom" rules={[{ required: true, message: 'Le nom est requis' }]}>
                             <Input allowClear />
                         </Form.Item>

--- a/chantier-ui/src/main-oeuvres.tsx
+++ b/chantier-ui/src/main-oeuvres.tsx
@@ -5,6 +5,7 @@ import api from './api.ts';
 
 interface MainOeuvreEntity {
     id?: number;
+    reference?: string;
     nom: string;
     description?: string;
     prixHT?: number;
@@ -14,6 +15,7 @@ interface MainOeuvreEntity {
 }
 
 interface MainOeuvreFormValues {
+    reference?: string;
     nom: string;
     description?: string;
     prixHT?: number;
@@ -23,6 +25,7 @@ interface MainOeuvreFormValues {
 }
 
 const defaultMainOeuvre: MainOeuvreFormValues = {
+    reference: '',
     nom: '',
     description: '',
     prixHT: 0,
@@ -153,6 +156,12 @@ export default function MainOeuvres() {
 
     const columns = [
         {
+            title: 'Référence',
+            dataIndex: 'reference',
+            sorter: (a: MainOeuvreEntity, b: MainOeuvreEntity) => (a.reference || '').localeCompare(b.reference || ''),
+            render: (value: string) => value || '-'
+        },
+        {
             title: 'Nom',
             dataIndex: 'nom',
             sorter: (a: MainOeuvreEntity, b: MainOeuvreEntity) => (a.nom || '').localeCompare(b.nom || '')
@@ -241,6 +250,9 @@ export default function MainOeuvres() {
                     initialValues={defaultMainOeuvre}
                     onValuesChange={(...args) => { setFormDirty(true); onValuesChange(...args); }}
                 >
+                    <Form.Item name="reference" label="Référence">
+                        <Input allowClear />
+                    </Form.Item>
                     <Form.Item
                         name="nom"
                         label="Nom"

--- a/chantier-ui/src/services.tsx
+++ b/chantier-ui/src/services.tsx
@@ -8,6 +8,7 @@ import api from './api.ts';
 
 interface MainOeuvreEntity {
     id: number;
+    reference?: string;
     nom: string;
     description?: string;
     prixHT?: number;
@@ -73,7 +74,7 @@ const defaultService: ServiceFormValues = {
 };
 
 const defaultNewMainOeuvre = {
-    nom: '', description: '', prixHT: 0, tva: 20, montantTVA: 0, prixTTC: 0,
+    reference: '', nom: '', description: '', prixHT: 0, tva: 20, montantTVA: 0, prixTTC: 0,
 };
 
 const defaultNewProduit = {
@@ -109,7 +110,7 @@ export default function Services() {
     const [newProduitFormDirty, setNewProduitFormDirty] = useState(false);
 
     const mainOeuvreOptions = useMemo(
-        () => allMainOeuvres.map((mo) => ({ value: mo.id, label: mo.nom })),
+        () => allMainOeuvres.map((mo) => ({ value: mo.id, label: mo.reference ? `${mo.reference} - ${mo.nom}` : mo.nom })),
         [allMainOeuvres]
     );
 
@@ -750,6 +751,9 @@ export default function Services() {
                 width={700}
             >
                 <Form form={newMainOeuvreForm} layout="vertical" initialValues={defaultNewMainOeuvre} onValuesChange={(...args) => { setNewMainOeuvreFormDirty(true); onNewMainOeuvreValuesChange(...args); }}>
+                    <Form.Item name="reference" label="Référence">
+                        <Input allowClear />
+                    </Form.Item>
                     <Form.Item name="nom" label="Nom" rules={[{ required: true, message: 'Le nom est requis' }]}>
                         <Input allowClear />
                     </Form.Item>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -196,6 +196,7 @@ const defaultNewProduit = {
 
 interface MainOeuvreEntity {
     id: number;
+    reference?: string;
     nom: string;
     description?: string;
     prixHT?: number;
@@ -572,7 +573,7 @@ export default function Vente() {
     );
 
     const mainOeuvreOptions = useMemo(
-        () => mainOeuvres.map((mo) => ({ value: mo.id, label: mo.nom })),
+        () => mainOeuvres.map((mo) => ({ value: mo.id, label: mo.reference ? `${mo.reference} - ${mo.nom}` : mo.nom })),
         [mainOeuvres]
     );
 


### PR DESCRIPTION
## Résumé

- Ajout d'un champ `reference` sur l'entité `MainOeuvreEntity` (backend + frontend)
- Affichage de la référence dans le tableau de gestion des Main d'Oeuvres et dans les formulaires de création/édition
- Dans les sélecteurs de forfait, service et vente, les main d'oeuvres affichent `référence - nom` (ex: "MO-001 - Revision annuelle")
- La recherche inclut désormais le champ référence

## Plan de test

- [ ] Créer une main d'oeuvre avec une référence et vérifier qu'elle apparaît dans le tableau
- [ ] Modifier la référence d'une main d'oeuvre existante
- [ ] Vérifier que les sélecteurs dans forfait, service et vente affichent bien "référence - nom"
- [ ] Rechercher une main d'oeuvre par sa référence
- [ ] Créer une main d'oeuvre sans référence et vérifier que seul le nom s'affiche dans les sélecteurs