### PR TITLE
feat(bateau-client): équipements en texte libre

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/BateauClientEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/BateauClientEntity.java
@@ -43,8 +43,7 @@ public class BateauClientEntity extends PanacheEntity {
     @ManyToMany
     public List<MoteurCatalogueEntity> moteurs = new ArrayList<>();
 
-    @ManyToMany
-    public List<ProduitCatalogueEntity> equipements = new ArrayList<>();
+    public List<String> equipements = new ArrayList<>();
 
     public Timestamp dateCreation;
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/BateauClientResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/BateauClientResource.java
@@ -8,7 +8,6 @@ import net.nanthrax.moussaillon.persistence.BateauCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.BateauClientEntity;
 import net.nanthrax.moussaillon.persistence.ClientEntity;
 import net.nanthrax.moussaillon.persistence.MoteurCatalogueEntity;
-import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -82,20 +81,6 @@ public class BateauClientResource {
             entity.moteurs = moteursEntities;
         }
         
-        // Convert equipements IDs to entities
-        if (entity.equipements != null) {
-            List<ProduitCatalogueEntity> equipementsEntities = new ArrayList<>();
-            for (ProduitCatalogueEntity e : entity.equipements) {
-                if (e != null && e.id != null) {
-                    ProduitCatalogueEntity equipement = ProduitCatalogueEntity.findById(e.id);
-                    if (equipement != null) {
-                        equipementsEntities.add(equipement);
-                    }
-                }
-            }
-            entity.equipements = equipementsEntities;
-        }
-        
         if (entity.dateCreation == null) {
             entity.dateCreation = new Timestamp(System.currentTimeMillis());
         }
@@ -163,21 +148,7 @@ public class BateauClientResource {
             entity.moteurs = new ArrayList<>();
         }
         
-        // Convert equipements IDs to entities
-        if (updated.equipements != null) {
-            List<ProduitCatalogueEntity> equipementsEntities = new ArrayList<>();
-            for (ProduitCatalogueEntity e : updated.equipements) {
-                if (e != null && e.id != null) {
-                    ProduitCatalogueEntity equipement = ProduitCatalogueEntity.findById(e.id);
-                    if (equipement != null) {
-                        equipementsEntities.add(equipement);
-                    }
-                }
-            }
-            entity.equipements = equipementsEntities;
-        } else {
-            entity.equipements = new ArrayList<>();
-        }
+        entity.equipements = updated.equipements != null ? updated.equipements : new ArrayList<>();
 
         return Response.ok(entity).build();
     }

--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -88,6 +88,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
   const [bateaux, setBateaux] = useState<BateauClient[]>([]);
   const [bateauxCatalogue, setBateauxCatalogue] = useState<any[]>([]);
   const [moteursCatalogue, setMoteursCatalogue] = useState<any[]>([]);
+  const [produitsCatalogue, setProduitsCatalogue] = useState<any[]>([]);
   const [clients, setClients] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
@@ -588,7 +589,15 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
               />
             </Space.Compact>
           </Form.Item>
-          {/* moteurs, équipements could be handled by extra fields/components if needed */}
+          <Form.Item label="Équipements" name="equipements">
+            <Select
+              mode="tags"
+              style={{ width: '100%' }}
+              placeholder="Saisir les équipements (sondeur, GPS, VHF, ...)"
+              tokenSeparators={[',']}
+              allowClear
+            />
+          </Form.Item>
         </Form>
       </Modal>
       <Modal

--- a/client-ui/src/mes-bateaux.tsx
+++ b/client-ui/src/mes-bateaux.tsx
@@ -15,7 +15,7 @@ interface BateauClientEntity {
     images?: string[];
     modele?: { id: number; nom?: string; marque?: string };
     moteurs?: Array<{ id: number; nom?: string; marque?: string }>;
-    equipements?: Array<{ id: number; nom?: string }>;
+    equipements?: string[];
 }
 
 interface MesBateauxProps {
@@ -103,6 +103,14 @@ export default function MesBateaux({ clientId, onCreateAnnonce }: MesBateauxProp
             render: (_: unknown, record: BateauClientEntity) =>
                 (record.moteurs || []).map((m) => (
                     <Tag key={m.id}>{m.marque ? `${m.marque} ${m.nom || ''}` : m.nom || `#${m.id}`}</Tag>
+                )),
+        },
+        {
+            title: 'Équipements',
+            key: 'equipements',
+            render: (_: unknown, record: BateauClientEntity) =>
+                (record.equipements || []).map((e, i) => (
+                    <Tag key={i}>{e}</Tag>
                 )),
         },
         {


### PR DESCRIPTION
## Summary
- Remplacement de la relation `@ManyToMany` vers `ProduitCatalogueEntity` par une simple `List<String>` pour les équipements bateau client (sondeur, GPS, VHF, etc.)
- Ajout d'un champ `Select mode="tags"` dans le formulaire chantier-ui pour saisir les équipements en texte libre
- Ajout d'une colonne "Équipements" dans le tableau client-ui avec affichage en `Tag`

## Test plan
- [x] Créer un bateau client et ajouter des équipements (sondeur, GPS, VHF)
- [x] Modifier un bateau existant pour ajouter/supprimer des équipements
- [x] Vérifier l'affichage des équipements dans le portail client