### PR TITLE
feat(chantier-ui): colonne Mode de paiement triable et filtrable

### DIFF
--- a/chantier-ui/package-lock.json
+++ b/chantier-ui/package-lock.json
@@ -7017,9 +7017,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -974,6 +974,13 @@ export default function Comptoir() {
         {
             title: 'Mode paiement',
             dataIndex: 'modePaiement',
+            filters: modePaiementOptions.map((o) => ({ text: o.label, value: o.value })),
+            onFilter: (value: unknown, record: VenteEntity) => record.modePaiement === value,
+            sorter: (a: VenteEntity, b: VenteEntity) => {
+                const labelA = modePaiementOptions.find((item) => item.value === a.modePaiement)?.label || a.modePaiement || '';
+                const labelB = modePaiementOptions.find((item) => item.value === b.modePaiement)?.label || b.modePaiement || '';
+                return labelA.localeCompare(labelB);
+            },
             render: (value: ModePaiement) => modePaiementOptions.find((item) => item.value === value)?.label || value || '-'
         },
         {

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -2049,6 +2049,14 @@ export default function Vente() {
             render: (value: number) => formatEuro(value)
         },
         {
+            title: 'Mode de paiement',
+            dataIndex: 'modePaiement',
+            sorter: (a: VenteEntity, b: VenteEntity) => (a.modePaiement || '').localeCompare(b.modePaiement || ''),
+            filters: modePaiementOptions.map(opt => ({ text: opt.label, value: opt.value })),
+            onFilter: (value: unknown, record: VenteEntity) => record.modePaiement === value,
+            render: (value: ModePaiement) => value ? (modePaiementOptions.find(opt => opt.value === value)?.label || value) : '-'
+        },
+        {
             title: 'Actions',
             key: 'actions',
             render: (_: unknown, record: VenteEntity) => (


### PR DESCRIPTION
## Résumé

- Ajout d'une colonne **Mode de paiement** dans le tableau des ventes (`chantier-ui/src/vente.tsx`)
- La colonne est **triable** (ordre alphabétique) et **filtrable** (Chèque, Virement, Carte, Espèces)
- Affiche le libellé lisible, ou `-` si le mode de paiement n'est pas renseigné

## Plan de test

- [x] Vérifier que la colonne s'affiche bien dans le tableau des ventes
- [x] Tester le tri croissant et décroissant sur la colonne
- [x] Tester le filtre sur chacune des 4 valeurs (Chèque, Virement, Carte, Espèces)
- [x] Vérifier l'affichage `-` pour les ventes sans mode de paiement renseigné