### PR TITLE
feat: réorganisation logique des champs de montants dans la fenêtre de vente

### DIFF
--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -935,22 +935,34 @@ export default function Comptoir() {
             return;
         }
 
+        if (changedValues.remisePourcentage !== undefined) {
+            const montantTTC = allValues.montantTTC || 0;
+            const remisePourcentage = changedValues.remisePourcentage || 0;
+            const remise = Math.round(((montantTTC * remisePourcentage / 100) + Number.EPSILON) * 100) / 100;
+            const prixVenteTTC = Math.round(((montantTTC - remise) + Number.EPSILON) * 100) / 100;
+            form.setFieldValue('remise', remise);
+            form.setFieldValue('prixVenteTTC', prixVenteTTC);
+            return;
+        }
+
+        if (changedValues.remise !== undefined) {
+            const montantTTC = allValues.montantTTC || 0;
+            const remise = changedValues.remise || 0;
+            const remisePourcentage = montantTTC > 0
+                ? Math.round((((remise / montantTTC) * 100) + Number.EPSILON) * 100) / 100
+                : 0;
+            const prixVenteTTC = Math.round(((montantTTC - remise) + Number.EPSILON) * 100) / 100;
+            form.setFieldValue('remisePourcentage', remisePourcentage);
+            form.setFieldValue('prixVenteTTC', prixVenteTTC);
+            return;
+        }
+
         if (
             changedValues.forfaits !== undefined ||
             changedValues.produits !== undefined ||
             changedValues.services !== undefined ||
-            changedValues.tva !== undefined ||
-            changedValues.remisePourcentage !== undefined ||
-            changedValues.remise !== undefined
+            changedValues.tva !== undefined
         ) {
-            if (changedValues.remisePourcentage !== undefined) {
-                recalculateFromLines('percentage');
-                return;
-            }
-            if (changedValues.remise !== undefined) {
-                recalculateFromLines('amount');
-                return;
-            }
             recalculateFromLines('auto');
         }
     };
@@ -1231,6 +1243,19 @@ export default function Comptoir() {
                             </Form.Item>
                         </Col>
                         <Col span={6}>
+                            <Form.Item name="montantTVA" label="Montant TVA">
+                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
+                            </Form.Item>
+                        </Col>
+                        <Col span={6}>
+                            <Form.Item name="montantTTC" label="Montant TTC">
+                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+
+                    <Row gutter={16}>
+                        <Col span={6} offset={6}>
                             <Form.Item name="remisePourcentage" label="Remise (%)">
                                 <InputNumber addonAfter="%" min={0} max={100} step={0.01} style={{ width: '100%' }} />
                             </Form.Item>
@@ -1240,20 +1265,7 @@ export default function Comptoir() {
                                 <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>
-                    </Row>
-
-                    <Row gutter={16}>
-                        <Col span={8}>
-                            <Form.Item name="montantTVA" label="Montant TVA">
-                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
-                            </Form.Item>
-                        </Col>
-                        <Col span={8}>
-                            <Form.Item name="montantTTC" label="Montant TTC">
-                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
-                            </Form.Item>
-                        </Col>
-                        <Col span={8}>
+                        <Col span={6}>
                             <Form.Item name="prixVenteTTC" label="Prix vente TTC">
                                 <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
                             </Form.Item>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -1982,20 +1982,29 @@ export default function Vente() {
             return;
         }
 
-        if (
-            changedValues.lignes !== undefined ||
-            changedValues.tva !== undefined ||
-            changedValues.remisePourcentage !== undefined ||
-            changedValues.remise !== undefined
-        ) {
-            if (changedValues.remisePourcentage !== undefined) {
-                recalculateFromLines('percentage');
-                return;
-            }
-            if (changedValues.remise !== undefined) {
-                recalculateFromLines('amount');
-                return;
-            }
+        if (changedValues.remisePourcentage !== undefined) {
+            const montantTTC = allValues.montantTTC || 0;
+            const remisePourcentage = changedValues.remisePourcentage || 0;
+            const remise = Math.round(((montantTTC * remisePourcentage / 100) + Number.EPSILON) * 100) / 100;
+            const prixVenteTTC = Math.round(((montantTTC - remise) + Number.EPSILON) * 100) / 100;
+            form.setFieldValue('remise', remise);
+            form.setFieldValue('prixVenteTTC', prixVenteTTC);
+            return;
+        }
+
+        if (changedValues.remise !== undefined) {
+            const montantTTC = allValues.montantTTC || 0;
+            const remise = changedValues.remise || 0;
+            const remisePourcentage = montantTTC > 0
+                ? Math.round((((remise / montantTTC) * 100) + Number.EPSILON) * 100) / 100
+                : 0;
+            const prixVenteTTC = Math.round(((montantTTC - remise) + Number.EPSILON) * 100) / 100;
+            form.setFieldValue('remisePourcentage', remisePourcentage);
+            form.setFieldValue('prixVenteTTC', prixVenteTTC);
+            return;
+        }
+
+        if (changedValues.lignes !== undefined || changedValues.tva !== undefined) {
             recalculateFromLines('auto');
         }
     };

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -2654,6 +2654,19 @@ export default function Vente() {
                             </Form.Item>
                         </Col>
                         <Col span={6}>
+                            <Form.Item name="montantTVA" label="Montant TVA">
+                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
+                            </Form.Item>
+                        </Col>
+                        <Col span={6}>
+                            <Form.Item name="montantTTC" label="Montant TTC">
+                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+
+                    <Row gutter={16}>
+                        <Col span={6} offset={6}>
                             <Form.Item name="remisePourcentage" label="Remise (%)">
                                 <InputNumber addonAfter="%" min={0} max={100} step={0.01} style={{ width: '100%' }} />
                             </Form.Item>
@@ -2663,20 +2676,7 @@ export default function Vente() {
                                 <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>
-                    </Row>
-
-                    <Row gutter={16}>
-                        <Col span={8}>
-                            <Form.Item name="montantTVA" label="Montant TVA">
-                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
-                            </Form.Item>
-                        </Col>
-                        <Col span={8}>
-                            <Form.Item name="montantTTC" label="Montant TTC">
-                                <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
-                            </Form.Item>
-                        </Col>
-                        <Col span={8}>
+                        <Col span={6}>
                             <Form.Item name="prixVenteTTC" label="Prix vente TTC">
                                 <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
                             </Form.Item>


### PR DESCRIPTION
## Changements

- Réorganisation des champs de montants dans la fenêtre de vente (`vente.tsx`) : alignement en deux lignes (Montant HT | TVA | Montant TVA | Montant TTC, puis Remise % | Remise EUR | Prix vente TTC)
- Même réorganisation appliquée dans la fenêtre comptoir (`comptoir.tsx`)
- Correction du recalcul lors de la saisie des remises : `remise` et `remisePourcentage` calculent désormais directement depuis le `montantTTC` courant au lieu de rappeler `recalculateFromLines`, ce qui évitait d'écraser les montants saisis manuellement