### PR TITLE
feat(chantier-ui): colonne statut de relance sur les prestations

### DIFF
--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -285,6 +285,9 @@ interface VenteEntity {
     rappel1Jours?: number;
     rappel2Jours?: number;
     rappel3Jours?: number;
+    rappel1Envoye?: boolean;
+    rappel2Envoye?: boolean;
+    rappel3Envoye?: boolean;
 }
 
 interface RappelHistoriqueEntity {
@@ -2050,6 +2053,17 @@ export default function Vente() {
             title: 'Produits',
             dataIndex: 'produits',
             render: (values: ProduitCatalogueEntity[]) => values?.length || 0
+        },
+        {
+            title: 'Relance',
+            key: 'relance',
+            render: (_: unknown, record: VenteEntity) => {
+                if (record.rappel3Envoye) return <Tag color="red">Relance 3 envoyée</Tag>;
+                if (record.rappel2Envoye) return <Tag color="orange">Relance 2 envoyée</Tag>;
+                if (record.rappel1Envoye) return <Tag color="gold">Relance 1 envoyée</Tag>;
+                if (record.rappel1Jours || record.rappel2Jours || record.rappel3Jours) return <Tag color="blue">En attente</Tag>;
+                return null;
+            }
         },
         {
             title: 'Prix vente TTC',


### PR DESCRIPTION
## Résumé

- Expose les champs `rappel1Envoye`, `rappel2Envoye`, `rappel3Envoye` dans l'interface TypeScript `VenteEntity` (déjà présents côté backend)
- Ajoute une colonne **Relance** dans la table des prestations (`vente.tsx`) avec les états suivants :
  - `Relance 3 envoyée` (rouge)
  - `Relance 2 envoyée` (orange)
  - `Relance 1 envoyée` (doré)
  - `En attente` (bleu) — rappels configurés mais pas encore envoyés
  - rien — aucun rappel configuré

## Plan de test

- [ ] Vérifier qu'une prestation sans rappels configurés n'affiche rien dans la colonne
- [ ] Vérifier qu'une prestation avec rappels configurés mais non envoyés affiche `En attente`
- [ ] Vérifier qu'après envoi du rappel 1, la colonne affiche `Relance 1 envoyée`
- [ ] Vérifier l'enchaînement jusqu'à `Relance 3 envoyée`