### PR TITLE
feat: afficher le solde dû sur les fiches et la liste des clients

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/ClientEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/ClientEntity.java
@@ -52,4 +52,7 @@ public class ClientEntity extends PanacheEntity {
 
     public Timestamp dateCreation;
 
+    @jakarta.persistence.Transient
+    public Double soldeDu;
+
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import net.nanthrax.moussaillon.persistence.ClientEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
+import net.nanthrax.moussaillon.persistence.VenteEntity;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -26,7 +27,10 @@ public class ClientResource {
     @GET
     public List<ClientEntity> list() {
         List<ClientEntity> clients = ClientEntity.listAll();
-        clients.forEach(c -> c.motDePasse = null);
+        clients.forEach(c -> {
+            c.motDePasse = null;
+            c.soldeDu = computeSoldeDu(c.id);
+        });
         return clients;
     }
 
@@ -34,11 +38,19 @@ public class ClientResource {
     @Path("/search")
     public List<ClientEntity> search(@QueryParam("q") String q) {
         if (q == null || q.trim().isEmpty()) {
-            return ClientEntity.listAll();
+            List<ClientEntity> clients = ClientEntity.listAll();
+            clients.forEach(c -> {
+                c.motDePasse = null;
+                c.soldeDu = computeSoldeDu(c.id);
+            });
+            return clients;
         }
         String likePattern = "%" + q.toLowerCase() + "%";
         List<ClientEntity> clients = ClientEntity.list("LOWER(nom) LIKE ?1 OR LOWER(prenom) LIKE ?1 OR LOWER(type) LIKE ?1 OR LOWER(email) LIKE ?1 OR LOWER(telephone) LIKE ?1", likePattern);
-        clients.forEach(c -> c.motDePasse = null);
+        clients.forEach(c -> {
+            c.motDePasse = null;
+            c.soldeDu = computeSoldeDu(c.id);
+        });
         return clients;
     }
 
@@ -55,6 +67,7 @@ public class ClientResource {
         client.flush();
         ClientEntity.getEntityManager().detach(client);
         client.motDePasse = null;
+        client.soldeDu = 0.0;
         return client;
     }
 
@@ -66,6 +79,7 @@ public class ClientResource {
             throw new WebApplicationException("Le client (" + id + ") n'est pas trouvé", 404);
         }
         entity.motDePasse = null;
+        entity.soldeDu = computeSoldeDu(id);
         return entity;
     }
 
@@ -113,7 +127,16 @@ public class ClientResource {
         entity.flush();
         ClientEntity.getEntityManager().detach(entity);
         entity.motDePasse = null;
+        entity.soldeDu = computeSoldeDu(id);
         return entity;
+    }
+
+    private double computeSoldeDu(long clientId) {
+        List<VenteEntity> unpaid = VenteEntity.list(
+            "client.id = ?1 and (status = ?2 or status = ?3)",
+            clientId, VenteEntity.Status.FACTURE_EN_ATTENTE, VenteEntity.Status.FACTURE_PRETE
+        );
+        return unpaid.stream().mapToDouble(v -> v.prixVenteTTC).sum();
     }
 
     @POST

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -16,6 +16,7 @@ import {
   Row,
   Col,
   Checkbox,
+  Alert,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -60,6 +61,7 @@ interface Client {
   naf?: string;
   canalAcquisition?: string;
   documents?: string[];
+  soldeDu?: number;
 }
 
 const defaultClient = {
@@ -267,6 +269,16 @@ function Clients() {
       sorter: (a, b) => (a.evaluation || 0) - (b.evaluation || 0),
     },
     {
+      title: "Solde dû",
+      dataIndex: "soldeDu",
+      key: "soldeDu",
+      sorter: (a, b) => (a.soldeDu || 0) - (b.soldeDu || 0),
+      render: (val) => {
+        if (!val || val === 0) return <span style={{ color: "#52c41a" }}>0,00 €</span>;
+        return <span style={{ color: "#ff4d4f", fontWeight: 600 }}>{val.toLocaleString("fr-FR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €</span>;
+      },
+    },
+    {
       title: "Actions",
       key: "actions",
       render: (_, record) => (
@@ -335,6 +347,21 @@ function Clients() {
         destroyOnHidden
         width={1024}
       >
+        {editing && editing.id && editing.soldeDu != null && editing.soldeDu > 0 && (
+          <Alert
+            type="warning"
+            showIcon
+            style={{ marginBottom: 16 }}
+            message={
+              <span>
+                Solde dû :{" "}
+                <strong style={{ color: "#ff4d4f" }}>
+                  {editing.soldeDu.toLocaleString("fr-FR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €
+                </strong>
+              </span>
+            }
+          />
+        )}
         <Form layout="vertical" form={form} initialValues={defaultClient} onValuesChange={() => setFormDirty(true)}>
           <Form.Item name="id" hidden>
             <Input />


### PR DESCRIPTION
## Résumé

- Ajout d'un champ calculé `soldeDu` sur `ClientEntity` (transient, non persisté) représentant la somme des `prixVenteTTC` des ventes aux statuts `FACTURE_EN_ATTENTE` et `FACTURE_PRETE`
- `ClientResource` calcule et expose ce champ dans toutes les réponses (`list`, `search`, `get`, `create`, `update`)
- Dans `chantier-ui` : nouvelle colonne **Solde dû** dans la table clients (0 € en vert, montant impayé en rouge, triable) et alerte orange en haut de la fiche client si le solde est positif

## Plan de test

- [x] Créer un client sans facture → colonne affiche 0,00 € en vert
- [x] Ajouter des ventes `FACTURE_EN_ATTENTE` et `FACTURE_PRETE` pour un client → la colonne et l'alerte de la fiche affichent la somme correcte en rouge
- [x] Passer une vente à `FACTURE_PAYEE` → le montant est exclu du solde
- [x] Vérifier que les devis (`DEVIS`) ne sont pas comptabilisés dans le solde
- [x] Vérifier le tri de la colonne Solde dû