### PR TITLE
feat: gestion des avoirs clients

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/AvoirEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/AvoirEntity.java
@@ -1,0 +1,76 @@
+package net.nanthrax.moussaillon.persistence;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.json.bind.annotation.JsonbTypeAdapter;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+@Entity
+public class AvoirEntity extends PanacheEntity {
+
+    public enum Status {
+        BROUILLON,
+        EMIS,
+        REMBOURSE,
+        ANNULE
+    }
+
+    public enum ModeRemboursement {
+        CHEQUE,
+        VIREMENT,
+        CARTE,
+        ESPÈCES
+    }
+
+    @Enumerated(EnumType.STRING)
+    public Status status = Status.BROUILLON;
+
+    @ManyToOne
+    public ClientEntity client;
+
+    @ManyToOne
+    public VenteEntity vente;
+
+    @Column(length = 1000)
+    public String motif;
+
+    @Column(length = 2000)
+    public String notes;
+
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp dateCreation;
+
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp dateEmission;
+
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp dateRemboursement;
+
+    public double montantHT;
+
+    public double tva;
+
+    public double montantTVA;
+
+    public double montantTTC;
+
+    @Enumerated(EnumType.STRING)
+    public ModeRemboursement modeRemboursement;
+
+    public double montantUtilise;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = jakarta.persistence.FetchType.EAGER)
+    @JoinColumn(name = "avoir_id")
+    public List<AvoirLigneEntity> lignes = new ArrayList<>();
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/AvoirLigneEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/AvoirLigneEntity.java
@@ -1,0 +1,23 @@
+package net.nanthrax.moussaillon.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+@Entity
+public class AvoirLigneEntity extends PanacheEntity {
+
+    @Column(nullable = false)
+    public String designation;
+
+    public int quantite = 1;
+
+    public double prixUnitaireHT;
+
+    public double tva;
+
+    public double montantTVA;
+
+    public double totalTTC;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/EmailTemplateEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/EmailTemplateEntity.java
@@ -12,7 +12,8 @@ public class EmailTemplateEntity extends PanacheEntity {
     public enum Type {
         RAPPEL,
         INCIDENT,
-        FACTURE
+        FACTURE,
+        AVOIR
     }
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.FetchType;
 
 @Entity
 public class VenteEntity extends PanacheEntity {
@@ -95,6 +96,10 @@ public class VenteEntity extends PanacheEntity {
     }
 
     public ModePaiement modePaiement;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "vente_paiement_vente_id")
+    public List<VentePaiementEntity> paiements = new ArrayList<>();
 
     public List<String> images = new ArrayList<>();
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VentePaiementEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VentePaiementEntity.java
@@ -1,0 +1,59 @@
+package net.nanthrax.moussaillon.persistence;
+
+import java.sql.Timestamp;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTransient;
+import jakarta.json.bind.annotation.JsonbTypeAdapter;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class VentePaiementEntity extends PanacheEntity {
+
+    public enum Mode {
+        CHEQUE,
+        VIREMENT,
+        CARTE,
+        ESPÈCES,
+        AVOIR
+    }
+
+    @Enumerated(EnumType.STRING)
+    public Mode mode;
+
+    public double montant;
+
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp date;
+
+    public String notes;
+
+    @ManyToOne
+    @JsonbTransient
+    public AvoirEntity avoir;
+
+    @JsonbProperty("avoirId")
+    public Long getAvoirId() {
+        return avoir != null ? avoir.id : null;
+    }
+
+    @JsonbProperty("avoirMotif")
+    public String getAvoirMotif() {
+        return avoir != null ? avoir.motif : null;
+    }
+
+    @JsonbProperty("avoirMontantTTC")
+    public Double getAvoirMontantTTC() {
+        return avoir != null ? avoir.montantTTC : null;
+    }
+
+    @JsonbProperty("avoirMontantUtilise")
+    public Double getAvoirMontantUtilise() {
+        return avoir != null ? avoir.montantUtilise : null;
+    }
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/AvoirResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/AvoirResource.java
@@ -1,0 +1,404 @@
+package net.nanthrax.moussaillon.services;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.Mailer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import net.nanthrax.moussaillon.persistence.AvoirEntity;
+import net.nanthrax.moussaillon.persistence.AvoirLigneEntity;
+import net.nanthrax.moussaillon.persistence.ClientEntity;
+import net.nanthrax.moussaillon.persistence.EmailTemplateEntity;
+import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.SocieteEntity;
+import net.nanthrax.moussaillon.persistence.VenteEntity;
+import net.nanthrax.moussaillon.persistence.VenteForfaitEntity;
+import net.nanthrax.moussaillon.persistence.VenteServiceEntity;
+
+@Path("/avoirs")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AvoirResource {
+
+    @Inject
+    Mailer mailer;
+
+    @GET
+    public List<AvoirEntity> list() {
+        return AvoirEntity.listAll();
+    }
+
+    @GET
+    @Path("/search")
+    public List<AvoirEntity> search(
+            @QueryParam("clientId") Long clientId,
+            @QueryParam("venteId") Long venteId,
+            @QueryParam("status") String status) {
+        if (clientId != null && venteId != null) {
+            return AvoirEntity.list("client.id = ?1 AND vente.id = ?2", clientId, venteId);
+        }
+        if (clientId != null) {
+            return AvoirEntity.list("client.id = ?1", clientId);
+        }
+        if (venteId != null) {
+            return AvoirEntity.list("vente.id = ?1", venteId);
+        }
+        if (status != null && !status.isBlank()) {
+            try {
+                AvoirEntity.Status s = AvoirEntity.Status.valueOf(status);
+                return AvoirEntity.list("status = ?1", s);
+            } catch (IllegalArgumentException e) {
+                throw new WebApplicationException("Statut invalide : " + status, 400);
+            }
+        }
+        return AvoirEntity.listAll();
+    }
+
+    @GET
+    @Path("{id}")
+    public AvoirEntity get(@PathParam("id") long id) {
+        AvoirEntity entity = AvoirEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("L'avoir (" + id + ") n'est pas trouvé", 404);
+        }
+        return entity;
+    }
+
+    @POST
+    @Transactional
+    public AvoirEntity create(AvoirEntity avoir) {
+        if (avoir.client == null || avoir.client.id == null) {
+            throw new WebApplicationException("Le client est requis", 400);
+        }
+        ClientEntity client = ClientEntity.findById(avoir.client.id);
+        if (client == null) {
+            throw new WebApplicationException("Le client (" + avoir.client.id + ") n'est pas trouvé", 404);
+        }
+        avoir.client = client;
+
+        if (avoir.vente != null && avoir.vente.id != null) {
+            VenteEntity vente = VenteEntity.findById(avoir.vente.id);
+            if (vente == null) {
+                throw new WebApplicationException("La vente (" + avoir.vente.id + ") n'est pas trouvée", 404);
+            }
+            avoir.vente = vente;
+        } else {
+            avoir.vente = null;
+        }
+
+        avoir.status = AvoirEntity.Status.BROUILLON;
+        avoir.dateCreation = new Timestamp(System.currentTimeMillis());
+
+        avoir.persist();
+        return avoir;
+    }
+
+    public static class GenerateAvoirRequest {
+        public String motif;
+        public String notes;
+    }
+
+    @POST
+    @Path("from-vente/{venteId}")
+    @Transactional
+    public AvoirEntity generateFromVente(@PathParam("venteId") long venteId, GenerateAvoirRequest request) {
+        VenteEntity vente = VenteEntity.findById(venteId);
+        if (vente == null) {
+            throw new WebApplicationException("La vente (" + venteId + ") n'est pas trouvée", 404);
+        }
+        if (vente.client == null) {
+            throw new WebApplicationException("La vente n'a pas de client associé", 400);
+        }
+        if (request == null || request.motif == null || request.motif.isBlank()) {
+            throw new WebApplicationException("Le motif est requis", 400);
+        }
+
+        AvoirEntity avoir = new AvoirEntity();
+        avoir.status = AvoirEntity.Status.BROUILLON;
+        avoir.client = vente.client;
+        avoir.vente = vente;
+        avoir.motif = request.motif.trim();
+        avoir.notes = request.notes;
+        avoir.dateCreation = new Timestamp(System.currentTimeMillis());
+
+        double tvaTaux = vente.tva > 0 ? vente.tva : 20.0;
+
+        // Lignes depuis les forfaits
+        if (vente.venteForfaits != null) {
+            for (VenteForfaitEntity vf : vente.venteForfaits) {
+                if (vf.forfait == null) continue;
+                AvoirLigneEntity ligne = new AvoirLigneEntity();
+                ligne.designation = vf.forfait.nom != null ? vf.forfait.nom : "Forfait";
+                ligne.quantite = Math.max(1, vf.quantite);
+                ligne.prixUnitaireHT = vf.forfait.prixHT;
+                ligne.tva = vf.forfait.tva > 0 ? vf.forfait.tva : tvaTaux;
+                ligne.montantTVA = round2(ligne.prixUnitaireHT * ligne.quantite * (ligne.tva / 100.0));
+                ligne.totalTTC = round2(vf.forfait.prixTTC * ligne.quantite);
+                avoir.lignes.add(ligne);
+            }
+        }
+
+        // Lignes depuis les services
+        if (vente.venteServices != null) {
+            for (VenteServiceEntity vs : vente.venteServices) {
+                if (vs.service == null) continue;
+                AvoirLigneEntity ligne = new AvoirLigneEntity();
+                ligne.designation = vs.service.nom != null ? vs.service.nom : "Service";
+                ligne.quantite = Math.max(1, vs.quantite);
+                ligne.prixUnitaireHT = vs.service.prixHT;
+                ligne.tva = vs.service.tva > 0 ? vs.service.tva : tvaTaux;
+                ligne.montantTVA = round2(ligne.prixUnitaireHT * ligne.quantite * (ligne.tva / 100.0));
+                ligne.totalTTC = round2(vs.service.prixTTC * ligne.quantite);
+                avoir.lignes.add(ligne);
+            }
+        }
+
+        // Lignes depuis les produits (regroupés par id)
+        if (vente.produits != null && !vente.produits.isEmpty()) {
+            java.util.Map<Long, int[]> counts = new java.util.LinkedHashMap<>();
+            java.util.Map<Long, ProduitCatalogueEntity> byId = new java.util.LinkedHashMap<>();
+            for (ProduitCatalogueEntity p : vente.produits) {
+                if (p == null || p.id == null) continue;
+                counts.computeIfAbsent(p.id, k -> new int[]{0});
+                counts.get(p.id)[0]++;
+                byId.putIfAbsent(p.id, p);
+            }
+            for (java.util.Map.Entry<Long, int[]> entry : counts.entrySet()) {
+                ProduitCatalogueEntity p = byId.get(entry.getKey());
+                if (p == null) continue;
+                int qty = entry.getValue()[0];
+                AvoirLigneEntity ligne = new AvoirLigneEntity();
+                String nom = p.nom != null ? p.nom : "Produit";
+                if (p.marque != null && !p.marque.isBlank()) nom += " (" + p.marque + ")";
+                ligne.designation = nom;
+                ligne.quantite = qty;
+                ligne.prixUnitaireHT = p.prixVenteHT;
+                ligne.tva = p.tva > 0 ? p.tva : tvaTaux;
+                ligne.montantTVA = round2(ligne.prixUnitaireHT * qty * (ligne.tva / 100.0));
+                ligne.totalTTC = round2(p.prixVenteTTC * qty);
+                avoir.lignes.add(ligne);
+            }
+        }
+
+        // Totaux globaux
+        avoir.tva = tvaTaux;
+        avoir.montantHT = round2(avoir.lignes.stream().mapToDouble(l -> l.prixUnitaireHT * l.quantite).sum());
+        avoir.montantTVA = round2(avoir.lignes.stream().mapToDouble(l -> l.montantTVA).sum());
+        avoir.montantTTC = round2(avoir.lignes.stream().mapToDouble(l -> l.totalTTC).sum());
+
+        avoir.persist();
+        return avoir;
+    }
+
+    private static double round2(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    @PUT
+    @Path("{id}")
+    @Transactional
+    public AvoirEntity update(@PathParam("id") long id, AvoirEntity data) {
+        AvoirEntity entity = AvoirEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("L'avoir (" + id + ") n'est pas trouvé", 404);
+        }
+        if (entity.status == AvoirEntity.Status.REMBOURSE || entity.status == AvoirEntity.Status.ANNULE) {
+            throw new WebApplicationException("Un avoir remboursé ou annulé ne peut pas être modifié", 400);
+        }
+
+        if (data.client != null && data.client.id != null) {
+            ClientEntity client = ClientEntity.findById(data.client.id);
+            if (client == null) {
+                throw new WebApplicationException("Le client (" + data.client.id + ") n'est pas trouvé", 404);
+            }
+            entity.client = client;
+        }
+
+        if (data.vente != null && data.vente.id != null) {
+            VenteEntity vente = VenteEntity.findById(data.vente.id);
+            if (vente == null) {
+                throw new WebApplicationException("La vente (" + data.vente.id + ") n'est pas trouvée", 404);
+            }
+            entity.vente = vente;
+        } else {
+            entity.vente = null;
+        }
+
+        entity.motif = data.motif;
+        entity.notes = data.notes;
+        entity.montantHT = data.montantHT;
+        entity.tva = data.tva;
+        entity.montantTVA = data.montantTVA;
+        entity.montantTTC = data.montantTTC;
+        entity.modeRemboursement = data.modeRemboursement;
+
+        entity.lignes.clear();
+        if (data.lignes != null) {
+            for (AvoirLigneEntity ligne : data.lignes) {
+                AvoirLigneEntity l = new AvoirLigneEntity();
+                l.designation = ligne.designation;
+                l.quantite = ligne.quantite;
+                l.prixUnitaireHT = ligne.prixUnitaireHT;
+                l.tva = ligne.tva;
+                l.montantTVA = ligne.montantTVA;
+                l.totalTTC = ligne.totalTTC;
+                entity.lignes.add(l);
+            }
+        }
+
+        return entity;
+    }
+
+    @POST
+    @Path("{id}/emettre")
+    @Transactional
+    public AvoirEntity emettre(@PathParam("id") long id) {
+        AvoirEntity entity = AvoirEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("L'avoir (" + id + ") n'est pas trouvé", 404);
+        }
+        if (entity.status != AvoirEntity.Status.BROUILLON) {
+            throw new WebApplicationException("Seul un avoir en brouillon peut être émis", 400);
+        }
+        entity.status = AvoirEntity.Status.EMIS;
+        entity.dateEmission = new Timestamp(System.currentTimeMillis());
+        return entity;
+    }
+
+    @POST
+    @Path("{id}/rembourser")
+    @Transactional
+    public AvoirEntity rembourser(@PathParam("id") long id) {
+        AvoirEntity entity = AvoirEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("L'avoir (" + id + ") n'est pas trouvé", 404);
+        }
+        if (entity.status != AvoirEntity.Status.EMIS) {
+            throw new WebApplicationException("Seul un avoir émis peut être marqué comme remboursé", 400);
+        }
+        entity.status = AvoirEntity.Status.REMBOURSE;
+        entity.dateRemboursement = new Timestamp(System.currentTimeMillis());
+        return entity;
+    }
+
+    @POST
+    @Path("{id}/annuler")
+    @Transactional
+    public AvoirEntity annuler(@PathParam("id") long id) {
+        AvoirEntity entity = AvoirEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("L'avoir (" + id + ") n'est pas trouvé", 404);
+        }
+        if (entity.status == AvoirEntity.Status.REMBOURSE) {
+            throw new WebApplicationException("Un avoir déjà remboursé ne peut pas être annulé", 400);
+        }
+        entity.status = AvoirEntity.Status.ANNULE;
+        return entity;
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Transactional
+    public Response delete(@PathParam("id") long id) {
+        AvoirEntity entity = AvoirEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("L'avoir (" + id + ") n'est pas trouvé", 404);
+        }
+        if (entity.status != AvoirEntity.Status.BROUILLON) {
+            throw new WebApplicationException("Seul un avoir en brouillon peut être supprimé", 400);
+        }
+        entity.delete();
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("{id}/email")
+    @Transactional
+    public Response envoyerEmail(@PathParam("id") long id) {
+        AvoirEntity entity = AvoirEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("L'avoir (" + id + ") n'est pas trouvé", 404);
+        }
+        if (entity.client == null || entity.client.email == null || entity.client.email.isBlank()) {
+            throw new WebApplicationException("Le client n'a pas d'adresse email", 400);
+        }
+
+        SocieteEntity societe = SocieteEntity.findById(1L);
+        String societeNom = societe != null ? societe.nom : "moussAIllon";
+        String clientName = entity.client.prenom != null ? entity.client.prenom : entity.client.nom;
+        String dateStr = entity.dateEmission != null
+                ? new Timestamp(entity.dateEmission.getTime()).toLocalDateTime().toLocalDate().toString()
+                : "-";
+        String montantTTC = String.format("%.2f EUR", entity.montantTTC);
+        String motif = entity.motif != null ? entity.motif : "-";
+        String venteRef = entity.vente != null ? "#" + entity.vente.id : "-";
+
+        StringBuilder lignes = new StringBuilder();
+        if (entity.lignes != null && !entity.lignes.isEmpty()) {
+            for (AvoirLigneEntity ligne : entity.lignes) {
+                lignes.append("- ").append(ligne.designation)
+                        .append(" x").append(ligne.quantite)
+                        .append(" = ").append(String.format("%.2f EUR", ligne.totalTTC))
+                        .append("\n");
+            }
+        } else {
+            lignes.append("Aucun élément");
+        }
+
+        EmailTemplateEntity template = EmailTemplateEntity.findByType(EmailTemplateEntity.Type.AVOIR);
+        String subject;
+        String body;
+        if (template != null) {
+            subject = template.sujet
+                    .replace("{client}", clientName)
+                    .replace("{reference}", String.valueOf(entity.id))
+                    .replace("{date}", dateStr)
+                    .replace("{motif}", motif)
+                    .replace("{montantTTC}", montantTTC)
+                    .replace("{venteRef}", venteRef)
+                    .replace("{lignes}", lignes.toString().trim())
+                    .replace("{societe}", societeNom);
+            body = template.contenu
+                    .replace("{client}", clientName)
+                    .replace("{reference}", String.valueOf(entity.id))
+                    .replace("{date}", dateStr)
+                    .replace("{motif}", motif)
+                    .replace("{montantTTC}", montantTTC)
+                    .replace("{venteRef}", venteRef)
+                    .replace("{lignes}", lignes.toString().trim())
+                    .replace("{societe}", societeNom);
+        } else {
+            subject = "Votre avoir #" + entity.id + " - " + societeNom;
+            body = "<p>Bonjour " + clientName + ",</p>"
+                    + "<p>Veuillez trouver ci-dessous les informations de votre avoir #" + entity.id + ".</p>"
+                    + "<table>"
+                    + "<tr><td><strong>Date</strong></td><td>" + dateStr + "</td></tr>"
+                    + "<tr><td><strong>Motif</strong></td><td>" + motif + "</td></tr>"
+                    + (entity.vente != null ? "<tr><td><strong>Facture d'origine</strong></td><td>" + venteRef + "</td></tr>" : "")
+                    + "<tr><td><strong>Montant TTC</strong></td><td>" + montantTTC + "</td></tr>"
+                    + "</table>"
+                    + "<p><strong>Lignes :</strong><br/>" + lignes.toString().trim().replace("\n", "<br/>") + "</p>"
+                    + "<p>Cordialement,<br/>" + societeNom + "</p>";
+        }
+
+        mailer.send(Mail.withHtml(entity.client.email, subject, body));
+        return Response.ok().build();
+    }
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.PUT;
 import net.nanthrax.moussaillon.persistence.AnnonceEntity;
+import net.nanthrax.moussaillon.persistence.AvoirEntity;
 import net.nanthrax.moussaillon.persistence.BateauClientEntity;
 import net.nanthrax.moussaillon.persistence.ClientEntity;
 import net.nanthrax.moussaillon.persistence.MoteurClientEntity;
@@ -195,6 +196,12 @@ public class ClientPortalResource {
         // Force initialization of lazy collections before serialization
         if (entity.produits != null) entity.produits.size();
         return entity;
+    }
+
+    @GET
+    @Path("/clients/{id}/avoirs")
+    public List<AvoirEntity> getClientAvoirs(@PathParam("id") long id) {
+        return AvoirEntity.list("client.id = ?1 AND status != ?2", id, AvoirEntity.Status.ANNULE);
     }
 
     @GET

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/EmailTemplateResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/EmailTemplateResource.java
@@ -67,6 +67,23 @@ public class EmailTemplateResource {
                 facture.description = "Variables disponibles : {client}, {typeVente}, {reference}, {date}, {statut}, {prixVenteTTC}, {modePaiement}, {lignes}, {societe}";
                 facture.persist();
             }
+            // Ajouter le template AVOIR s'il n'existe pas encore (migration)
+            if (EmailTemplateEntity.findByType(EmailTemplateEntity.Type.AVOIR) == null) {
+                EmailTemplateEntity avoir = new EmailTemplateEntity();
+                avoir.type = EmailTemplateEntity.Type.AVOIR;
+                avoir.sujet = "Votre avoir #{reference} - {societe}";
+                avoir.contenu = "<p>Bonjour {client},</p>"
+                        + "<p>Nous vous adressons votre avoir #{reference}.</p>"
+                        + "<table><tr><td><strong>Date</strong></td><td>{date}</td></tr>"
+                        + "<tr><td><strong>Motif</strong></td><td>{motif}</td></tr>"
+                        + "<tr><td><strong>Facture d'origine</strong></td><td>{venteRef}</td></tr>"
+                        + "<tr><td><strong>Montant TTC</strong></td><td>{montantTTC}</td></tr></table>"
+                        + "<p><strong>Lignes :</strong><br/>{lignes}</p>"
+                        + "<p>N'hésitez pas à nous contacter pour toute question.</p>"
+                        + "<p>Cordialement,<br/>{societe}</p>";
+                avoir.description = "Variables disponibles : {client}, {reference}, {date}, {motif}, {venteRef}, {montantTTC}, {lignes}, {societe}";
+                avoir.persist();
+            }
             return Response.ok().build();
         }
 
@@ -107,6 +124,21 @@ public class EmailTemplateResource {
                 + "<p>Cordialement,<br/>{societe}</p>";
         facture.description = "Variables disponibles : {client}, {typeVente}, {reference}, {date}, {statut}, {prixVenteTTC}, {modePaiement}, {lignes}, {societe}";
         facture.persist();
+
+        EmailTemplateEntity avoir = new EmailTemplateEntity();
+        avoir.type = EmailTemplateEntity.Type.AVOIR;
+        avoir.sujet = "Votre avoir #{reference} - {societe}";
+        avoir.contenu = "<p>Bonjour {client},</p>"
+                + "<p>Nous vous adressons votre avoir #{reference}.</p>"
+                + "<table><tr><td><strong>Date</strong></td><td>{date}</td></tr>"
+                + "<tr><td><strong>Motif</strong></td><td>{motif}</td></tr>"
+                + "<tr><td><strong>Facture d'origine</strong></td><td>{venteRef}</td></tr>"
+                + "<tr><td><strong>Montant TTC</strong></td><td>{montantTTC}</td></tr></table>"
+                + "<p><strong>Lignes :</strong><br/>{lignes}</p>"
+                + "<p>N'hésitez pas à nous contacter pour toute question.</p>"
+                + "<p>Cordialement,<br/>{societe}</p>";
+        avoir.description = "Variables disponibles : {client}, {reference}, {date}, {motif}, {venteRef}, {montantTTC}, {lignes}, {societe}";
+        avoir.persist();
 
         return Response.status(Response.Status.CREATED).build();
     }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import net.nanthrax.moussaillon.persistence.AvoirEntity;
 import net.nanthrax.moussaillon.persistence.EmailTemplateEntity;
 import net.nanthrax.moussaillon.persistence.ForfaitEntity;
 import net.nanthrax.moussaillon.persistence.ForfaitProduitEntity;
@@ -32,6 +33,7 @@ import net.nanthrax.moussaillon.persistence.SocieteEntity;
 import net.nanthrax.moussaillon.persistence.TaskEntity;
 import net.nanthrax.moussaillon.persistence.VenteEntity;
 import net.nanthrax.moussaillon.persistence.VenteForfaitEntity;
+import net.nanthrax.moussaillon.persistence.VentePaiementEntity;
 import net.nanthrax.moussaillon.persistence.VenteServiceEntity;
 
 @Path("/ventes")
@@ -70,7 +72,20 @@ public class VenteResource {
         String typeLabel = isOrdreReparation ? "Ordre de Réparation" : (isDevis ? "Devis" : "Facture");
         String statutLabel = entity.status != null ? entity.status.name() : "-";
         String prixVenteTTC = String.format("%.2f EUR", entity.prixVenteTTC);
-        String modePaiement = entity.modePaiement != null ? entity.modePaiement.name() : "-";
+        String modePaiement;
+        if (entity.paiements != null && !entity.paiements.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            for (VentePaiementEntity p : entity.paiements) {
+                if (sb.length() > 0) sb.append(", ");
+                sb.append(p.mode.name()).append(" ").append(String.format("%.2f", p.montant)).append(" EUR");
+                if (p.mode == VentePaiementEntity.Mode.AVOIR && p.avoir != null) {
+                    sb.append(" (avoir #").append(p.avoir.id).append(")");
+                }
+            }
+            modePaiement = sb.toString();
+        } else {
+            modePaiement = entity.modePaiement != null ? entity.modePaiement.name() : "-";
+        }
 
         // Build invoice lines
         StringBuilder lignes = new StringBuilder();
@@ -547,6 +562,99 @@ public class VenteResource {
         entity.rappel3Jours = vente.rappel3Jours;
 
         return entity;
+    }
+
+    public static class AjouterPaiementRequest {
+        public String mode;
+        public double montant;
+        public String notes;
+        public Long avoirId;
+    }
+
+    @POST
+    @Path("{id}/paiements")
+    @Transactional
+    public VentePaiementEntity addPaiement(@PathParam("id") long id, AjouterPaiementRequest request) {
+        VenteEntity entity = VenteEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("La vente (" + id + ") n'est pas trouvée", 404);
+        }
+        if (entity.status == VenteEntity.Status.FACTURE_PAYEE) {
+            throw new WebApplicationException("Une vente payée ne peut plus être modifiée", 400);
+        }
+        if (entity.status != VenteEntity.Status.FACTURE_PRETE) {
+            throw new WebApplicationException("Les paiements ne peuvent être ajoutés qu'à une facture prête", 400);
+        }
+        if (request.montant <= 0) {
+            throw new WebApplicationException("Le montant doit être supérieur à zéro", 400);
+        }
+
+        VentePaiementEntity.Mode mode;
+        try {
+            mode = VentePaiementEntity.Mode.valueOf(request.mode);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new WebApplicationException("Mode de paiement invalide : " + request.mode, 400);
+        }
+
+        VentePaiementEntity paiement = new VentePaiementEntity();
+        paiement.mode = mode;
+        paiement.montant = request.montant;
+        paiement.date = new Timestamp(System.currentTimeMillis());
+        paiement.notes = request.notes;
+
+        if (mode == VentePaiementEntity.Mode.AVOIR) {
+            if (request.avoirId == null) {
+                throw new WebApplicationException("Un avoir doit être sélectionné pour le mode AVOIR", 400);
+            }
+            AvoirEntity avoir = AvoirEntity.findById(request.avoirId);
+            if (avoir == null) {
+                throw new WebApplicationException("L'avoir (" + request.avoirId + ") n'est pas trouvé", 404);
+            }
+            if (avoir.status != AvoirEntity.Status.EMIS) {
+                throw new WebApplicationException("Seul un avoir émis peut être appliqué", 400);
+            }
+            double restant = Math.round((avoir.montantTTC - avoir.montantUtilise) * 100.0) / 100.0;
+            if (request.montant > restant + 0.005) {
+                throw new WebApplicationException(
+                    "Le montant appliqué (" + String.format("%.2f", request.montant) +
+                    ") dépasse le solde disponible de l'avoir (" + String.format("%.2f", restant) + ")", 400);
+            }
+            avoir.montantUtilise = Math.min(avoir.montantTTC,
+                Math.round((avoir.montantUtilise + request.montant) * 100.0) / 100.0);
+            paiement.avoir = avoir;
+        }
+
+        entity.paiements.add(paiement);
+        return paiement;
+    }
+
+    @DELETE
+    @Path("{id}/paiements/{paiementId}")
+    @Transactional
+    public Response removePaiement(@PathParam("id") long id, @PathParam("paiementId") long paiementId) {
+        VenteEntity entity = VenteEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("La vente (" + id + ") n'est pas trouvée", 404);
+        }
+        if (entity.status == VenteEntity.Status.FACTURE_PAYEE) {
+            throw new WebApplicationException("Une vente payée ne peut plus être modifiée", 400);
+        }
+
+        VentePaiementEntity toRemove = entity.paiements.stream()
+            .filter(p -> p.id != null && p.id == paiementId)
+            .findFirst()
+            .orElseThrow(() -> new WebApplicationException("Paiement (" + paiementId + ") non trouvé", 404));
+
+        if (toRemove.mode == VentePaiementEntity.Mode.AVOIR && toRemove.avoir != null) {
+            AvoirEntity avoir = AvoirEntity.findById(toRemove.avoir.id);
+            if (avoir != null) {
+                avoir.montantUtilise = Math.max(0,
+                    Math.round((avoir.montantUtilise - toRemove.montant) * 100.0) / 100.0);
+            }
+        }
+
+        entity.paiements.remove(toRemove);
+        return Response.noContent().build();
     }
 
     private void sendIncidentNotification(VenteEntity vente, String itemNom, String incidentDetails, java.sql.Date incidentDate) {

--- a/chantier-ui/package-lock.json
+++ b/chantier-ui/package-lock.json
@@ -9425,9 +9425,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.345",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
+      "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -20770,6 +20770,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -21055,9 +21056,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
-      "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
+      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"

--- a/chantier-ui/src/annonces.tsx
+++ b/chantier-ui/src/annonces.tsx
@@ -73,6 +73,7 @@ export default function Annonces() {
     const [clients, setClients] = useState<ClientEntity[]>([]);
     const [bateaux, setBateaux] = useState<BateauClientEntity[]>([]);
     const [loading, setLoading] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
     const [modalOpen, setModalOpen] = useState(false);
     const [detailOpen, setDetailOpen] = useState(false);
     const [detailAnnonce, setDetailAnnonce] = useState<Annonce | null>(null);
@@ -321,18 +322,34 @@ export default function Annonces() {
         },
     ];
 
+    const filteredAnnonces = (() => {
+        const q = searchQuery.trim().toLowerCase();
+        if (!q) return annonces;
+        return annonces.filter((a) => {
+            const titre = (a.titre ?? '').toLowerCase();
+            const description = (a.description ?? '').toLowerCase();
+            const clientLabel = a.client ? `${a.client.prenom ?? ''} ${a.client.nom ?? ''}`.toLowerCase() : '';
+            return titre.includes(q) || description.includes(q) || clientLabel.includes(q);
+        });
+    })();
+
     return (
-        <Card
-            title="Petites annonces - Bateaux a vendre"
-            extra={
-                <Button type="primary" icon={<PlusCircleOutlined />} onClick={openCreate}>
-                    Nouvelle annonce
-                </Button>
-            }
-        >
+        <Card title="Petites annonces - Bateaux a vendre">
+            <Space style={{ marginBottom: 16 }}>
+                <Input.Search
+                    placeholder="Recherche"
+                    enterButton
+                    allowClear
+                    style={{ width: 600 }}
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onSearch={(value) => setSearchQuery(value)}
+                />
+                <Button type="primary" icon={<PlusCircleOutlined />} onClick={openCreate} />
+            </Space>
             <Table
                 rowKey="id"
-                dataSource={annonces}
+                dataSource={filteredAnnonces}
                 columns={columns}
                 loading={loading}
                 pagination={{ pageSize: 10 }}

--- a/chantier-ui/src/avoirs.tsx
+++ b/chantier-ui/src/avoirs.tsx
@@ -160,6 +160,30 @@ export default function Avoirs() {
 
     const [filterClientId, setFilterClientId] = useState<number | null>(null);
     const [filterStatus, setFilterStatus] = useState<string | null>(null);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [clientSearchTimeout, setClientSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+    const mergeClientsById = (prev: ClientRef[], next: ClientRef[]): ClientRef[] => {
+        const map = new Map<number, ClientRef>();
+        prev.forEach((c) => { if (c?.id !== undefined) map.set(c.id, c); });
+        next.forEach((c) => { if (c?.id !== undefined) map.set(c.id, c); });
+        return Array.from(map.values());
+    };
+
+    const handleClientSearch = (value: string) => {
+        if (clientSearchTimeout) clearTimeout(clientSearchTimeout);
+        if (!value || value.trim() === '') return;
+        const timeout = setTimeout(async () => {
+            try {
+                const res = await fetchWithAuth(`./clients/search?q=${encodeURIComponent(value)}`);
+                const data = await res.json();
+                setClients((prev) => mergeClientsById(prev, Array.isArray(data) ? data : []));
+            } catch {
+                // ignore
+            }
+        }, 300);
+        setClientSearchTimeout(timeout);
+    };
 
     // Modal "Appliquer un avoir à une facture"
     const [appliquerModalOpen, setAppliquerModalOpen] = useState(false);
@@ -393,6 +417,23 @@ export default function Avoirs() {
 
     const totauxFormLignes = computeAvoirTotals(formLignes, formLignes[0]?.tva ?? 20);
 
+    const filteredAvoirs = (() => {
+        const q = searchQuery.trim().toLowerCase();
+        if (!q) return avoirs;
+        return avoirs.filter((a) => {
+            const clientLabel = a.client ? `${a.client.prenom ?? ''} ${a.client.nom ?? ''}`.toLowerCase() : '';
+            const motif = (a.motif ?? '').toLowerCase();
+            const idStr = a.id !== undefined ? `#${a.id}` : '';
+            const venteStr = a.vente ? `#${a.vente.id}` : '';
+            return (
+                clientLabel.includes(q) ||
+                motif.includes(q) ||
+                idStr.includes(q) ||
+                venteStr.includes(q)
+            );
+        });
+    })();
+
     const columns = [
         {
             title: '#',
@@ -586,14 +627,20 @@ export default function Avoirs() {
     ];
 
     return (
-        <Card
-            title="Gestion des avoirs"
-            extra={
-                <Button type="primary" icon={<PlusCircleOutlined />} onClick={openCreate}>
-                    Nouvel avoir
-                </Button>
-            }
-        >
+        <Card title="Gestion des avoirs">
+            <Space style={{ marginBottom: 16 }}>
+                <Input.Search
+                    placeholder="Recherche"
+                    enterButton
+                    allowClear
+                    style={{ width: 600 }}
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onSearch={(value) => setSearchQuery(value)}
+                />
+                <Button type="primary" icon={<PlusCircleOutlined />} onClick={openCreate} />
+            </Space>
+
             {/* Filtres */}
             <Row gutter={16} style={{ marginBottom: 16 }}>
                 <Col span={8}>
@@ -628,7 +675,7 @@ export default function Avoirs() {
             <Table
                 rowKey="id"
                 loading={loading}
-                dataSource={avoirs}
+                dataSource={filteredAvoirs}
                 columns={columns}
                 pagination={{ pageSize: 15 }}
                 bordered
@@ -651,12 +698,12 @@ export default function Avoirs() {
                             <Form.Item label="Client" required>
                                 <Select
                                     showSearch
-                                    placeholder="Sélectionner un client"
+                                    placeholder="Rechercher un client par prénom ou nom"
                                     value={formClientId ?? undefined}
                                     onChange={handleClientChange}
-                                    filterOption={(input, opt) =>
-                                        (opt?.label ?? '').toLowerCase().includes(input.toLowerCase())
-                                    }
+                                    filterOption={false}
+                                    onSearch={handleClientSearch}
+                                    notFoundContent={null}
                                     options={clients.map((c) => ({
                                         value: c.id,
                                         label: `${c.prenom ?? ''} ${c.nom}`.trim(),

--- a/chantier-ui/src/avoirs.tsx
+++ b/chantier-ui/src/avoirs.tsx
@@ -1,0 +1,813 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+    Button,
+    Card,
+    Col,
+    Divider,
+    Form,
+    Input,
+    InputNumber,
+    Modal,
+    Popconfirm,
+    Row,
+    Select,
+    Space,
+    Table,
+    Tag,
+    message,
+} from 'antd';
+import {
+    CheckOutlined,
+    DeleteOutlined,
+    EditOutlined,
+    LinkOutlined,
+    MailOutlined,
+    MinusCircleOutlined,
+    PlusCircleOutlined,
+    RollbackOutlined,
+    StopOutlined,
+} from '@ant-design/icons';
+import { fetchWithAuth } from './api.ts';
+
+const { TextArea } = Input;
+
+interface ClientRef {
+    id: number;
+    prenom?: string;
+    nom: string;
+    email?: string;
+}
+
+interface VenteRef {
+    id: number;
+    status?: string;
+    montantTTC?: number;
+    prixVenteTTC?: number;
+}
+
+interface AvoirLigne {
+    id?: number;
+    designation: string;
+    quantite: number;
+    prixUnitaireHT: number;
+    tva: number;
+    montantTVA: number;
+    totalTTC: number;
+}
+
+interface AvoirEntity {
+    id?: number;
+    status?: string;
+    client?: ClientRef;
+    vente?: VenteRef;
+    motif?: string;
+    notes?: string;
+    dateCreation?: string;
+    dateEmission?: string;
+    dateRemboursement?: string;
+    montantHT?: number;
+    tva?: number;
+    montantTVA?: number;
+    montantTTC?: number;
+    montantUtilise?: number;
+    modeRemboursement?: string;
+    lignes?: AvoirLigne[];
+}
+
+const STATUS_LABEL: Record<string, string> = {
+    BROUILLON: 'Brouillon',
+    EMIS: 'Émis',
+    REMBOURSE: 'Remboursé',
+    ANNULE: 'Annulé',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+    BROUILLON: 'default',
+    EMIS: 'blue',
+    REMBOURSE: 'green',
+    ANNULE: 'red',
+};
+
+const MODE_REMBOURSEMENT_OPTIONS = [
+    { value: 'CHEQUE', label: 'Chèque' },
+    { value: 'VIREMENT', label: 'Virement' },
+    { value: 'CARTE', label: 'Carte' },
+    { value: 'ESPÈCES', label: 'Espèces' },
+];
+
+const TVA_OPTIONS = [
+    { value: 0, label: '0%' },
+    { value: 5.5, label: '5,5%' },
+    { value: 10, label: '10%' },
+    { value: 20, label: '20%' },
+];
+
+const formatDate = (value?: string) => {
+    if (!value) return '-';
+    const parsed = new Date(value);
+    if (isNaN(parsed.getTime())) return value;
+    return parsed.toLocaleDateString('fr-FR');
+};
+
+const formatEuro = (value?: number) => `${(value ?? 0).toFixed(2)} EUR`;
+
+function computeLigneTotals(ligne: Partial<AvoirLigne>): Partial<AvoirLigne> {
+    const prixUnitaireHT = ligne.prixUnitaireHT ?? 0;
+    const quantite = ligne.quantite ?? 1;
+    const tva = ligne.tva ?? 0;
+    const totalHT = prixUnitaireHT * quantite;
+    const montantTVA = Math.round(totalHT * (tva / 100) * 100) / 100;
+    const totalTTC = Math.round((totalHT + montantTVA) * 100) / 100;
+    return { ...ligne, montantTVA, totalTTC };
+}
+
+function computeAvoirTotals(lignes: AvoirLigne[], tauxTva: number): Pick<AvoirEntity, 'montantHT' | 'tva' | 'montantTVA' | 'montantTTC'> {
+    const montantHT = lignes.reduce((sum, l) => sum + (l.prixUnitaireHT ?? 0) * (l.quantite ?? 1), 0);
+    const montantTVA = lignes.reduce((sum, l) => sum + (l.montantTVA ?? 0), 0);
+    const montantTTC = lignes.reduce((sum, l) => sum + (l.totalTTC ?? 0), 0);
+    return {
+        montantHT: Math.round(montantHT * 100) / 100,
+        tva: tauxTva,
+        montantTVA: Math.round(montantTVA * 100) / 100,
+        montantTTC: Math.round(montantTTC * 100) / 100,
+    };
+}
+
+const defaultLigne = (): AvoirLigne => ({
+    designation: '',
+    quantite: 1,
+    prixUnitaireHT: 0,
+    tva: 20,
+    montantTVA: 0,
+    totalTTC: 0,
+});
+
+export default function Avoirs() {
+    const [avoirs, setAvoirs] = useState<AvoirEntity[]>([]);
+    const [clients, setClients] = useState<ClientRef[]>([]);
+    const [ventes, setVentes] = useState<VenteRef[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    const [modalOpen, setModalOpen] = useState(false);
+    const [editingAvoir, setEditingAvoir] = useState<AvoirEntity | null>(null);
+    const [formClientId, setFormClientId] = useState<number | null>(null);
+    const [formVenteId, setFormVenteId] = useState<number | null>(null);
+    const [formMotif, setFormMotif] = useState('');
+    const [formNotes, setFormNotes] = useState('');
+    const [formModeRemboursement, setFormModeRemboursement] = useState<string | null>(null);
+    const [formLignes, setFormLignes] = useState<AvoirLigne[]>([defaultLigne()]);
+    const [saving, setSaving] = useState(false);
+
+    const [filterClientId, setFilterClientId] = useState<number | null>(null);
+    const [filterStatus, setFilterStatus] = useState<string | null>(null);
+
+    // Modal "Appliquer un avoir à une facture"
+    const [appliquerModalOpen, setAppliquerModalOpen] = useState(false);
+    const [appliquerAvoir, setAppliquerAvoir] = useState<AvoirEntity | null>(null);
+    const [appliquerVentes, setAppliquerVentes] = useState<VenteRef[]>([]);
+    const [appliquerVenteId, setAppliquerVenteId] = useState<number | null>(null);
+    const [appliquerMontant, setAppliquerMontant] = useState<number>(0);
+    const [appliquerNotes, setAppliquerNotes] = useState('');
+    const [applying, setApplying] = useState(false);
+
+    const fetchAvoirs = useCallback(() => {
+        setLoading(true);
+        const params = new URLSearchParams();
+        if (filterClientId) params.set('clientId', String(filterClientId));
+        if (filterStatus) params.set('status', filterStatus);
+        const url = './avoirs/search?' + params.toString();
+        fetchWithAuth(url)
+            .then((res) => res.json())
+            .then((data) => setAvoirs(Array.isArray(data) ? data : []))
+            .catch(() => message.error('Erreur lors du chargement des avoirs'))
+            .finally(() => setLoading(false));
+    }, [filterClientId, filterStatus]);
+
+    const fetchClients = useCallback(() => {
+        fetchWithAuth('./clients')
+            .then((res) => res.json())
+            .then((data) => setClients(Array.isArray(data) ? data : []))
+            .catch(() => {});
+    }, []);
+
+    const fetchVentesForClient = useCallback((clientId: number) => {
+        fetchWithAuth(`./ventes/search?clientId=${clientId}`)
+            .then((res) => res.json())
+            .then((data) => setVentes(Array.isArray(data) ? data : []))
+            .catch(() => setVentes([]));
+    }, []);
+
+    useEffect(() => {
+        fetchAvoirs();
+    }, [fetchAvoirs]);
+
+    useEffect(() => {
+        fetchClients();
+    }, [fetchClients]);
+
+    const openCreate = () => {
+        setEditingAvoir(null);
+        setFormClientId(null);
+        setFormVenteId(null);
+        setFormMotif('');
+        setFormNotes('');
+        setFormModeRemboursement(null);
+        setFormLignes([defaultLigne()]);
+        setVentes([]);
+        setModalOpen(true);
+    };
+
+    const openEdit = (avoir: AvoirEntity) => {
+        setEditingAvoir(avoir);
+        setFormClientId(avoir.client?.id ?? null);
+        setFormVenteId(avoir.vente?.id ?? null);
+        setFormMotif(avoir.motif ?? '');
+        setFormNotes(avoir.notes ?? '');
+        setFormModeRemboursement(avoir.modeRemboursement ?? null);
+        setFormLignes(avoir.lignes && avoir.lignes.length > 0 ? [...avoir.lignes] : [defaultLigne()]);
+        if (avoir.client?.id) fetchVentesForClient(avoir.client.id);
+        setModalOpen(true);
+    };
+
+    const handleClientChange = (clientId: number) => {
+        setFormClientId(clientId);
+        setFormVenteId(null);
+        fetchVentesForClient(clientId);
+    };
+
+    const updateLigne = (index: number, field: keyof AvoirLigne, value: number | string) => {
+        setFormLignes((prev) => {
+            const updated = [...prev];
+            const ligne = { ...updated[index], [field]: value };
+            updated[index] = computeLigneTotals(ligne) as AvoirLigne;
+            return updated;
+        });
+    };
+
+    const addLigne = () => setFormLignes((prev) => [...prev, defaultLigne()]);
+
+    const removeLigne = (index: number) =>
+        setFormLignes((prev) => prev.filter((_, i) => i !== index));
+
+    const handleSave = async () => {
+        if (!formClientId) { message.warning('Veuillez sélectionner un client'); return; }
+        if (!formMotif.trim()) { message.warning('Le motif est requis'); return; }
+        if (formLignes.length === 0) { message.warning('Au moins une ligne est requise'); return; }
+        for (const l of formLignes) {
+            if (!l.designation.trim()) { message.warning('Toutes les lignes doivent avoir une désignation'); return; }
+        }
+
+        const tauxTva = formLignes[0]?.tva ?? 20;
+        const totals = computeAvoirTotals(formLignes, tauxTva);
+
+        const payload: AvoirEntity = {
+            client: { id: formClientId } as ClientRef,
+            vente: formVenteId ? { id: formVenteId } as VenteRef : undefined,
+            motif: formMotif,
+            notes: formNotes,
+            modeRemboursement: formModeRemboursement ?? undefined,
+            lignes: formLignes,
+            ...totals,
+        };
+
+        setSaving(true);
+        try {
+            if (editingAvoir?.id) {
+                await fetchWithAuth(`./avoirs/${editingAvoir.id}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                message.success('Avoir mis à jour');
+            } else {
+                await fetchWithAuth('./avoirs', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                message.success('Avoir créé');
+            }
+            setModalOpen(false);
+            fetchAvoirs();
+        } catch {
+            message.error("Erreur lors de l'enregistrement de l'avoir");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleEmettre = async (id: number) => {
+        try {
+            await fetchWithAuth(`./avoirs/${id}/emettre`, { method: 'POST' });
+            message.success('Avoir émis');
+            fetchAvoirs();
+        } catch {
+            message.error("Erreur lors de l'émission de l'avoir");
+        }
+    };
+
+    const handleRembourser = async (id: number) => {
+        try {
+            await fetchWithAuth(`./avoirs/${id}/rembourser`, { method: 'POST' });
+            message.success('Avoir marqué comme remboursé');
+            fetchAvoirs();
+        } catch {
+            message.error("Erreur lors du remboursement de l'avoir");
+        }
+    };
+
+    const handleAnnuler = async (id: number) => {
+        try {
+            await fetchWithAuth(`./avoirs/${id}/annuler`, { method: 'POST' });
+            message.success('Avoir annulé');
+            fetchAvoirs();
+        } catch {
+            message.error("Erreur lors de l'annulation de l'avoir");
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        try {
+            await fetchWithAuth(`./avoirs/${id}`, { method: 'DELETE' });
+            message.success('Avoir supprimé');
+            fetchAvoirs();
+        } catch {
+            message.error("Erreur lors de la suppression de l'avoir");
+        }
+    };
+
+    const handleEmail = async (id: number) => {
+        try {
+            await fetchWithAuth(`./avoirs/${id}/email`, { method: 'POST' });
+            message.success('Email envoyé');
+        } catch {
+            message.error("Erreur lors de l'envoi de l'email");
+        }
+    };
+
+    const openAppliquerModal = async (avoir: AvoirEntity) => {
+        setAppliquerAvoir(avoir);
+        setAppliquerVenteId(null);
+        setAppliquerNotes('');
+        const restant = Math.round(((avoir.montantTTC ?? 0) - (avoir.montantUtilise ?? 0)) * 100) / 100;
+        setAppliquerMontant(restant);
+        // Charger les ventes FACTURE_PRETE du client
+        try {
+            const res = await fetchWithAuth(`./ventes/search?clientId=${avoir.client?.id}&status=FACTURE_PRETE`);
+            const data = await res.json();
+            setAppliquerVentes(Array.isArray(data) ? data : []);
+        } catch {
+            setAppliquerVentes([]);
+        }
+        setAppliquerModalOpen(true);
+    };
+
+    const handleAppliquer = async () => {
+        if (!appliquerAvoir?.id || !appliquerVenteId) { message.warning('Veuillez sélectionner une facture'); return; }
+        if (appliquerMontant <= 0) { message.warning('Le montant doit être supérieur à zéro'); return; }
+        setApplying(true);
+        try {
+            const res = await fetchWithAuth(`./ventes/${appliquerVenteId}/paiements`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    mode: 'AVOIR',
+                    montant: appliquerMontant,
+                    notes: appliquerNotes || undefined,
+                    avoirId: appliquerAvoir.id,
+                }),
+            });
+            if (!res.ok) {
+                const err = await res.text();
+                throw new Error(err);
+            }
+            message.success('Avoir appliqué à la facture');
+            setAppliquerModalOpen(false);
+            fetchAvoirs();
+        } catch (err: unknown) {
+            message.error((err as Error).message || "Erreur lors de l'application de l'avoir");
+        } finally {
+            setApplying(false);
+        }
+    };
+
+    const totauxFormLignes = computeAvoirTotals(formLignes, formLignes[0]?.tva ?? 20);
+
+    const columns = [
+        {
+            title: '#',
+            dataIndex: 'id',
+            width: 60,
+            render: (v: number) => `#${v}`,
+        },
+        {
+            title: 'Client',
+            key: 'client',
+            render: (_: unknown, r: AvoirEntity) =>
+                r.client ? `${r.client.prenom ?? ''} ${r.client.nom}`.trim() : '-',
+        },
+        {
+            title: 'Facture liée',
+            key: 'vente',
+            width: 110,
+            render: (_: unknown, r: AvoirEntity) => r.vente ? `#${r.vente.id}` : '-',
+        },
+        {
+            title: 'Motif',
+            dataIndex: 'motif',
+            ellipsis: true,
+        },
+        {
+            title: 'Statut',
+            dataIndex: 'status',
+            width: 120,
+            render: (v: string) => <Tag color={STATUS_COLOR[v] ?? 'default'}>{STATUS_LABEL[v] ?? v}</Tag>,
+        },
+        {
+            title: 'Montant TTC',
+            dataIndex: 'montantTTC',
+            width: 130,
+            align: 'right' as const,
+            render: (v: number) => formatEuro(v),
+        },
+        {
+            title: 'Solde restant',
+            key: 'solde',
+            width: 130,
+            align: 'right' as const,
+            render: (_: unknown, r: AvoirEntity) => {
+                const restant = Math.round(((r.montantTTC ?? 0) - (r.montantUtilise ?? 0)) * 100) / 100;
+                const color = restant <= 0.005 ? '#8c8c8c' : restant < (r.montantTTC ?? 0) ? '#faad14' : undefined;
+                return <span style={{ color }}>{formatEuro(restant)}</span>;
+            },
+        },
+        {
+            title: 'Date émission',
+            dataIndex: 'dateEmission',
+            width: 120,
+            render: (v: string) => formatDate(v),
+        },
+        {
+            title: 'Actions',
+            key: 'actions',
+            width: 280,
+            render: (_: unknown, r: AvoirEntity) => (
+                <Space size="small" wrap>
+                    {r.status === 'BROUILLON' && (
+                        <Button size="small" icon={<EditOutlined />} onClick={() => openEdit(r)}>
+                            Modifier
+                        </Button>
+                    )}
+                    {r.status === 'BROUILLON' && (
+                        <Button size="small" type="primary" icon={<CheckOutlined />} onClick={() => handleEmettre(r.id!)}>
+                            Émettre
+                        </Button>
+                    )}
+                    {r.status === 'EMIS' && (
+                        <Button size="small" icon={<RollbackOutlined />} onClick={() => handleRembourser(r.id!)}>
+                            Rembourser
+                        </Button>
+                    )}
+                    {r.status === 'EMIS' && (() => {
+                        const restant = Math.round(((r.montantTTC ?? 0) - (r.montantUtilise ?? 0)) * 100) / 100;
+                        return restant > 0.005 ? (
+                            <Button size="small" icon={<LinkOutlined />} onClick={() => openAppliquerModal(r)}>
+                                Appliquer
+                            </Button>
+                        ) : null;
+                    })()}
+                    {r.status === 'EMIS' && r.client?.email && (
+                        <Button size="small" icon={<MailOutlined />} onClick={() => handleEmail(r.id!)}>
+                            Email
+                        </Button>
+                    )}
+                    {(r.status === 'BROUILLON' || r.status === 'EMIS') && (
+                        <Popconfirm
+                            title="Annuler cet avoir ?"
+                            onConfirm={() => handleAnnuler(r.id!)}
+                            okText="Confirmer"
+                            cancelText="Non"
+                        >
+                            <Button size="small" icon={<StopOutlined />} danger>
+                                Annuler
+                            </Button>
+                        </Popconfirm>
+                    )}
+                    {r.status === 'BROUILLON' && (
+                        <Popconfirm
+                            title="Supprimer définitivement cet avoir ?"
+                            onConfirm={() => handleDelete(r.id!)}
+                            okText="Supprimer"
+                            cancelText="Non"
+                        >
+                            <Button size="small" icon={<DeleteOutlined />} danger />
+                        </Popconfirm>
+                    )}
+                </Space>
+            ),
+        },
+    ];
+
+    const lignesColumns = [
+        {
+            title: 'Désignation',
+            key: 'designation',
+            render: (_: unknown, _r: AvoirLigne, index: number) => (
+                <Input
+                    value={formLignes[index].designation}
+                    onChange={(e) => updateLigne(index, 'designation', e.target.value)}
+                    placeholder="Désignation"
+                />
+            ),
+        },
+        {
+            title: 'Qté',
+            key: 'quantite',
+            width: 80,
+            render: (_: unknown, _r: AvoirLigne, index: number) => (
+                <InputNumber
+                    min={1}
+                    value={formLignes[index].quantite}
+                    onChange={(v) => updateLigne(index, 'quantite', v ?? 1)}
+                    style={{ width: '100%' }}
+                />
+            ),
+        },
+        {
+            title: 'P.U. HT',
+            key: 'prixUnitaireHT',
+            width: 110,
+            render: (_: unknown, _r: AvoirLigne, index: number) => (
+                <InputNumber
+                    min={0}
+                    precision={2}
+                    value={formLignes[index].prixUnitaireHT}
+                    onChange={(v) => updateLigne(index, 'prixUnitaireHT', v ?? 0)}
+                    style={{ width: '100%' }}
+                    addonAfter="€"
+                />
+            ),
+        },
+        {
+            title: 'TVA',
+            key: 'tva',
+            width: 90,
+            render: (_: unknown, _r: AvoirLigne, index: number) => (
+                <Select
+                    value={formLignes[index].tva}
+                    onChange={(v) => updateLigne(index, 'tva', v)}
+                    options={TVA_OPTIONS}
+                    style={{ width: '100%' }}
+                />
+            ),
+        },
+        {
+            title: 'Total TTC',
+            key: 'totalTTC',
+            width: 110,
+            align: 'right' as const,
+            render: (_: unknown, _r: AvoirLigne, index: number) =>
+                formatEuro(formLignes[index].totalTTC),
+        },
+        {
+            title: '',
+            key: 'remove',
+            width: 40,
+            render: (_: unknown, _r: AvoirLigne, index: number) => (
+                <Button
+                    type="text"
+                    danger
+                    icon={<MinusCircleOutlined />}
+                    onClick={() => removeLigne(index)}
+                    disabled={formLignes.length <= 1}
+                />
+            ),
+        },
+    ];
+
+    return (
+        <Card
+            title="Gestion des avoirs"
+            extra={
+                <Button type="primary" icon={<PlusCircleOutlined />} onClick={openCreate}>
+                    Nouvel avoir
+                </Button>
+            }
+        >
+            {/* Filtres */}
+            <Row gutter={16} style={{ marginBottom: 16 }}>
+                <Col span={8}>
+                    <Select
+                        allowClear
+                        showSearch
+                        placeholder="Filtrer par client"
+                        style={{ width: '100%' }}
+                        value={filterClientId ?? undefined}
+                        onChange={(v) => setFilterClientId(v ?? null)}
+                        filterOption={(input, opt) =>
+                            (opt?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                        }
+                        options={clients.map((c) => ({
+                            value: c.id,
+                            label: `${c.prenom ?? ''} ${c.nom}`.trim(),
+                        }))}
+                    />
+                </Col>
+                <Col span={6}>
+                    <Select
+                        allowClear
+                        placeholder="Filtrer par statut"
+                        style={{ width: '100%' }}
+                        value={filterStatus ?? undefined}
+                        onChange={(v) => setFilterStatus(v ?? null)}
+                        options={Object.entries(STATUS_LABEL).map(([k, v]) => ({ value: k, label: v }))}
+                    />
+                </Col>
+            </Row>
+
+            <Table
+                rowKey="id"
+                loading={loading}
+                dataSource={avoirs}
+                columns={columns}
+                pagination={{ pageSize: 15 }}
+                bordered
+            />
+
+            {/* Modal création / édition */}
+            <Modal
+                title={editingAvoir ? `Modifier l'avoir #${editingAvoir.id}` : 'Nouvel avoir'}
+                open={modalOpen}
+                onCancel={() => setModalOpen(false)}
+                onOk={handleSave}
+                okText={editingAvoir ? 'Enregistrer' : 'Créer'}
+                confirmLoading={saving}
+                width={860}
+                destroyOnHidden
+            >
+                <Form layout="vertical">
+                    <Row gutter={16}>
+                        <Col span={12}>
+                            <Form.Item label="Client" required>
+                                <Select
+                                    showSearch
+                                    placeholder="Sélectionner un client"
+                                    value={formClientId ?? undefined}
+                                    onChange={handleClientChange}
+                                    filterOption={(input, opt) =>
+                                        (opt?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                                    }
+                                    options={clients.map((c) => ({
+                                        value: c.id,
+                                        label: `${c.prenom ?? ''} ${c.nom}`.trim(),
+                                    }))}
+                                    style={{ width: '100%' }}
+                                />
+                            </Form.Item>
+                        </Col>
+                        <Col span={12}>
+                            <Form.Item label="Facture liée (optionnel)">
+                                <Select
+                                    allowClear
+                                    placeholder="Sélectionner une facture"
+                                    value={formVenteId ?? undefined}
+                                    onChange={(v) => setFormVenteId(v ?? null)}
+                                    disabled={!formClientId}
+                                    options={ventes.map((v) => ({
+                                        value: v.id,
+                                        label: `#${v.id} — ${v.status ?? ''} — ${formatEuro(v.prixVenteTTC ?? v.montantTTC)}`,
+                                    }))}
+                                    style={{ width: '100%' }}
+                                />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+
+                    <Form.Item label="Motif" required>
+                        <Input
+                            value={formMotif}
+                            onChange={(e) => setFormMotif(e.target.value)}
+                            placeholder="Motif de l'avoir"
+                        />
+                    </Form.Item>
+
+                    <Form.Item label="Notes">
+                        <TextArea
+                            rows={2}
+                            value={formNotes}
+                            onChange={(e) => setFormNotes(e.target.value)}
+                            placeholder="Notes internes"
+                        />
+                    </Form.Item>
+
+                    <Form.Item label="Mode de remboursement">
+                        <Select
+                            allowClear
+                            placeholder="Sélectionner un mode"
+                            value={formModeRemboursement ?? undefined}
+                            onChange={(v) => setFormModeRemboursement(v ?? null)}
+                            options={MODE_REMBOURSEMENT_OPTIONS}
+                            style={{ width: 200 }}
+                        />
+                    </Form.Item>
+
+                    <Divider orientation="left">Lignes de l'avoir</Divider>
+
+                    <Table
+                        rowKey={(_, i) => String(i)}
+                        dataSource={formLignes}
+                        columns={lignesColumns}
+                        pagination={false}
+                        size="small"
+                        bordered
+                        style={{ marginBottom: 8 }}
+                    />
+
+                    <Button
+                        type="dashed"
+                        icon={<PlusCircleOutlined />}
+                        onClick={addLigne}
+                        style={{ marginBottom: 16 }}
+                    >
+                        Ajouter une ligne
+                    </Button>
+
+                    <Row justify="end">
+                        <Col>
+                            <Space direction="vertical" align="end">
+                                <span>Montant HT : <strong>{formatEuro(totauxFormLignes.montantHT)}</strong></span>
+                                <span>TVA : <strong>{formatEuro(totauxFormLignes.montantTVA)}</strong></span>
+                                <span style={{ fontSize: 16 }}>
+                                    Total TTC : <strong>{formatEuro(totauxFormLignes.montantTTC)}</strong>
+                                </span>
+                            </Space>
+                        </Col>
+                    </Row>
+                </Form>
+            </Modal>
+
+            {/* Modal application d'un avoir à une facture */}
+            <Modal
+                title={appliquerAvoir ? `Appliquer l'avoir #${appliquerAvoir.id}` : 'Appliquer un avoir'}
+                open={appliquerModalOpen}
+                onCancel={() => setAppliquerModalOpen(false)}
+                onOk={handleAppliquer}
+                okText="Appliquer"
+                confirmLoading={applying}
+                destroyOnHidden
+                width={500}
+            >
+                {appliquerAvoir && (
+                    <Form layout="vertical">
+                        <div style={{ marginBottom: 12, padding: '8px 12px', background: '#f6ffed', border: '1px solid #b7eb8f', borderRadius: 6 }}>
+                            <strong>Avoir #{appliquerAvoir.id}</strong> — {appliquerAvoir.motif}<br />
+                            Solde disponible : <strong>{formatEuro(Math.round(((appliquerAvoir.montantTTC ?? 0) - (appliquerAvoir.montantUtilise ?? 0)) * 100) / 100)}</strong>
+                        </div>
+
+                        <Form.Item label="Facture à régler" required>
+                            <Select
+                                placeholder="Sélectionner une facture prête"
+                                value={appliquerVenteId ?? undefined}
+                                onChange={(v) => {
+                                    setAppliquerVenteId(v);
+                                    const vente = appliquerVentes.find((vt) => vt.id === v);
+                                    if (vente) {
+                                        const restantAvoir = Math.round(((appliquerAvoir.montantTTC ?? 0) - (appliquerAvoir.montantUtilise ?? 0)) * 100) / 100;
+                                        const totalFacture = (vente as { prixVenteTTC?: number }).prixVenteTTC ?? 0;
+                                        setAppliquerMontant(Math.min(restantAvoir, totalFacture));
+                                    }
+                                }}
+                                notFoundContent="Aucune facture prête pour ce client"
+                                options={appliquerVentes.map((v) => ({
+                                    value: v.id,
+                                    label: `Facture #${v.id} — ${formatEuro((v as { prixVenteTTC?: number }).prixVenteTTC ?? 0)}`,
+                                }))}
+                                style={{ width: '100%' }}
+                            />
+                        </Form.Item>
+
+                        <Form.Item label="Montant à imputer" required>
+                            <InputNumber
+                                min={0.01}
+                                max={Math.round(((appliquerAvoir.montantTTC ?? 0) - (appliquerAvoir.montantUtilise ?? 0)) * 100) / 100}
+                                precision={2}
+                                value={appliquerMontant}
+                                onChange={(v) => setAppliquerMontant(v ?? 0)}
+                                addonAfter="€"
+                                style={{ width: '100%' }}
+                            />
+                        </Form.Item>
+
+                        <Form.Item label="Notes (optionnel)">
+                            <Input
+                                value={appliquerNotes}
+                                onChange={(e) => setAppliquerNotes(e.target.value)}
+                                placeholder="Ex: application partielle"
+                            />
+                        </Form.Item>
+                    </Form>
+                )}
+            </Modal>
+        </Card>
+    );
+}

--- a/chantier-ui/src/campagnes.tsx
+++ b/chantier-ui/src/campagnes.tsx
@@ -101,6 +101,7 @@ const formatDate = (value?: string) => {
 export default function Campagnes() {
     const [campagnes, setCampagnes] = useState<Campagne[]>([]);
     const [loading, setLoading] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
     const [modalOpen, setModalOpen] = useState(false);
     const [editing, setEditing] = useState<Campagne | null>(null);
     const [detailOpen, setDetailOpen] = useState(false);
@@ -372,18 +373,35 @@ export default function Campagnes() {
         { title: 'Erreur', dataIndex: 'erreur', key: 'erreur', render: (val?: string) => val || '-' },
     ];
 
+    const filteredCampagnes = (() => {
+        const q = searchQuery.trim().toLowerCase();
+        if (!q) return campagnes;
+        return campagnes.filter((c) => {
+            const nom = (c.nom ?? '').toLowerCase();
+            const sujet = (c.sujet ?? '').toLowerCase();
+            const canal = (canalLabel[c.canal] ?? c.canal ?? '').toLowerCase();
+            const cible = (cibleLabel[c.cible] ?? c.cible ?? '').toLowerCase();
+            return nom.includes(q) || sujet.includes(q) || canal.includes(q) || cible.includes(q);
+        });
+    })();
+
     return (
-        <Card
-            title="Campagnes marketing"
-            extra={
-                <Button type="primary" icon={<PlusCircleOutlined />} onClick={openCreate}>
-                    Nouvelle campagne
-                </Button>
-            }
-        >
+        <Card title="Campagnes marketing">
+            <Space style={{ marginBottom: 16 }}>
+                <Input.Search
+                    placeholder="Recherche"
+                    enterButton
+                    allowClear
+                    style={{ width: 600 }}
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onSearch={(value) => setSearchQuery(value)}
+                />
+                <Button type="primary" icon={<PlusCircleOutlined />} onClick={openCreate} />
+            </Space>
             <Table
                 rowKey="id"
-                dataSource={campagnes}
+                dataSource={filteredCampagnes}
                 columns={columns}
                 loading={loading}
                 pagination={{ pageSize: 10 }}

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -120,6 +120,26 @@ interface TaskEntity {
 
 type VenteStatus = 'DEVIS' | 'FACTURE_EN_ATTENTE' | 'FACTURE_PRETE' | 'FACTURE_PAYEE';
 type ModePaiement = 'CHEQUE' | 'VIREMENT' | 'CARTE' | 'ESPÈCES';
+type ModeReglement = 'CHEQUE' | 'VIREMENT' | 'CARTE' | 'ESPÈCES' | 'AVOIR';
+
+interface VentePaiement {
+    id?: number;
+    mode: ModeReglement;
+    montant: number;
+    date?: string;
+    notes?: string;
+    avoirId?: number;
+    avoirMotif?: string;
+    avoirMontantTTC?: number;
+    avoirMontantUtilise?: number;
+}
+
+interface AvoirDisponible {
+    id: number;
+    motif?: string;
+    montantTTC: number;
+    montantUtilise: number;
+}
 
 interface VenteEntity {
     id?: number;
@@ -148,6 +168,7 @@ interface VenteEntity {
     montantTVA?: number;
     prixVenteTTC?: number;
     modePaiement?: ModePaiement;
+    paiements?: VentePaiement[];
 }
 
 interface VenteFormValues {
@@ -278,6 +299,13 @@ export default function Comptoir() {
     const [newProduitFormDirty, setNewProduitFormDirty] = useState(false);
     const [clientSearchTimeout, setClientSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
     const [produitSearchTimeout, setProduitSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+    const [paiementModalVisible, setPaiementModalVisible] = useState(false);
+    const [paiementMode, setPaiementMode] = useState<ModeReglement>('CARTE');
+    const [paiementMontant, setPaiementMontant] = useState<number>(0);
+    const [paiementNotes, setPaiementNotes] = useState('');
+    const [paiementAvoirId, setPaiementAvoirId] = useState<number | null>(null);
+    const [avoirsDisponibles, setAvoirsDisponibles] = useState<AvoirDisponible[]>([]);
+    const [addingPaiement, setAddingPaiement] = useState(false);
 
     const mergeById = <T extends { id: number }>(prev: T[], next: T[]): T[] => {
         const map = new Map<number, T>();
@@ -406,6 +434,76 @@ export default function Comptoir() {
         fetchVentes();
         fetchOptions();
     }, []);
+
+    const refreshCurrentVente = async (id: number) => {
+        try {
+            const res = await api.get<VenteEntity>(`/ventes/${id}`);
+            setCurrentVente(res.data);
+        } catch {
+            message.error('Erreur lors du rechargement de la vente');
+        }
+    };
+
+    const openPaiementModal = async () => {
+        const restant = (currentVente?.prixVenteTTC ?? 0) -
+            (currentVente?.paiements ?? []).reduce((s, p) => s + p.montant, 0);
+        setPaiementMode('CARTE');
+        setPaiementMontant(Math.max(0, Math.round(restant * 100) / 100));
+        setPaiementNotes('');
+        setPaiementAvoirId(null);
+        setAvoirsDisponibles([]);
+        setPaiementModalVisible(true);
+    };
+
+    const loadAvoirsDisponibles = async (mode: ModeReglement) => {
+        if (mode !== 'AVOIR' || !currentVente?.client?.id) return;
+        try {
+            const res = await api.get<AvoirDisponible[]>(
+                `/avoirs/search?clientId=${currentVente.client.id}&status=EMIS`
+            );
+            setAvoirsDisponibles((res.data || []).filter(
+                (a) => Math.round((a.montantTTC - a.montantUtilise) * 100) / 100 > 0.005
+            ));
+        } catch {
+            setAvoirsDisponibles([]);
+        }
+    };
+
+    const handleAddPaiement = async () => {
+        if (!currentVente?.id) return;
+        if (paiementMontant <= 0) { message.warning('Le montant doit être supérieur à zéro'); return; }
+        if (paiementMode === 'AVOIR' && !paiementAvoirId) { message.warning('Veuillez sélectionner un avoir'); return; }
+        setAddingPaiement(true);
+        try {
+            await api.post(`/ventes/${currentVente.id}/paiements`, {
+                mode: paiementMode,
+                montant: paiementMontant,
+                notes: paiementNotes || undefined,
+                avoirId: paiementMode === 'AVOIR' ? paiementAvoirId : undefined,
+            });
+            message.success('Paiement ajouté');
+            setPaiementModalVisible(false);
+            await refreshCurrentVente(currentVente.id);
+            fetchVentes();
+        } catch (err: unknown) {
+            const msg = (err as { response?: { data?: string } })?.response?.data || "Erreur lors de l'ajout du paiement";
+            message.error(msg);
+        } finally {
+            setAddingPaiement(false);
+        }
+    };
+
+    const handleRemovePaiement = async (paiementId: number) => {
+        if (!currentVente?.id) return;
+        try {
+            await api.delete(`/ventes/${currentVente.id}/paiements/${paiementId}`);
+            message.success('Paiement supprimé');
+            await refreshCurrentVente(currentVente.id);
+            fetchVentes();
+        } catch {
+            message.error('Erreur lors de la suppression du paiement');
+        }
+    };
 
     const openNewProduitModal = (lineIndex: number) => {
         setNewProduitTargetLine(lineIndex);
@@ -628,8 +726,11 @@ export default function Comptoir() {
     const handleMarkPaid = async () => {
         if (!currentVente?.id) return;
         const values = await form.validateFields();
-        if (!values.modePaiement) {
-            message.warning('Veuillez sélectionner un mode de paiement');
+        const totalPaiements = (currentVente.paiements ?? []).reduce((s, p) => s + p.montant, 0);
+        const prixVenteTTC = currentVente.prixVenteTTC ?? 0;
+        if (totalPaiements < prixVenteTTC - 0.005) {
+            const restant = Math.round((prixVenteTTC - totalPaiements) * 100) / 100;
+            message.warning(`Montant restant à régler : ${formatEuro(restant)}. Ajoutez un paiement avant de marquer comme payée.`);
             return;
         }
         form.setFieldsValue({ status: 'FACTURE_PAYEE' });
@@ -692,6 +793,20 @@ export default function Comptoir() {
         setTimeout(cleanup, 1000);
     };
 
+    const renderPaiementsHtml = (vente: VenteEntity) => {
+        const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+        const ps = vente.paiements ?? [];
+        if (ps.length > 0) {
+            return ps.map((p) => {
+                const label = modeLabels[p.mode] ?? p.mode;
+                const avoir = p.avoirId ? ` (avoir #${p.avoirId})` : '';
+                return `<div class="row">${escapeHtml(label)}${escapeHtml(avoir)} : ${escapeHtml(formatEuro(p.montant))}</div>`;
+            }).join('');
+        }
+        if (vente.modePaiement) return `<div class="row"><strong>Mode de paiement:</strong> ${escapeHtml(vente.modePaiement)}</div>`;
+        return '';
+    };
+
     const handlePrintInvoice = (vente: VenteEntity) => {
         const title = `Facture #${vente.id || '-'}`;
         const produitRows = getProduitLines(vente)
@@ -728,7 +843,7 @@ export default function Comptoir() {
                     <h1>${escapeHtml(title)}</h1>
                     <div class="meta">Date: ${escapeHtml(formatDate(vente.date))}</div>
                     <div class="row"><strong>Client:</strong> ${escapeHtml(getClientLabel(vente.client))}</div>
-                    <div class="row"><strong>Mode de paiement:</strong> ${escapeHtml(vente.modePaiement || '-')}</div>
+                    ${renderPaiementsHtml(vente) ? `<div><strong>Règlements :</strong>${renderPaiementsHtml(vente)}</div>` : ''}
                     <div class="row"><strong>Montant HT:</strong> ${escapeHtml(formatEuro(vente.montantHT))}</div>
                     <div class="row"><strong>Montant TVA:</strong> ${escapeHtml(formatEuro(vente.montantTVA))}</div>
                     <div class="row"><strong>Montant TTC:</strong> ${escapeHtml(formatEuro(vente.montantTTC))}</div>
@@ -794,7 +909,14 @@ export default function Comptoir() {
                     ${produitRows || '<div class="line"><span>Aucun produit</span><span>-</span></div>'}
                     <div class="separator"></div>
                     <div class="line"><strong>TOTAL TTC</strong><strong>${escapeHtml(formatEuro(vente.prixVenteTTC))}</strong></div>
-                    <div class="line"><span>Paiement</span><span>${escapeHtml(vente.modePaiement || '-')}</span></div>
+                    ${(vente.paiements ?? []).length > 0
+                        ? (vente.paiements ?? []).map((p) => {
+                            const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+                            const label = modeLabels[p.mode] ?? p.mode;
+                            const avoir = p.avoirId ? ` (avoir #${p.avoirId})` : '';
+                            return `<div class="line"><span>${escapeHtml(label)}${escapeHtml(avoir)}</span><span>${escapeHtml(formatEuro(p.montant))}</span></div>`;
+                        }).join('')
+                        : `<div class="line"><span>Paiement</span><span>${escapeHtml(vente.modePaiement || '-')}</span></div>`}
                     <div class="center" style="margin-top:12px;">Merci de votre visite</div>
                 </body>
                 </html>
@@ -985,15 +1107,16 @@ export default function Comptoir() {
         },
         {
             title: 'Mode paiement',
-            dataIndex: 'modePaiement',
-            filters: modePaiementOptions.map((o) => ({ text: o.label, value: o.value })),
-            onFilter: (value: unknown, record: VenteEntity) => record.modePaiement === value,
-            sorter: (a: VenteEntity, b: VenteEntity) => {
-                const labelA = modePaiementOptions.find((item) => item.value === a.modePaiement)?.label || a.modePaiement || '';
-                const labelB = modePaiementOptions.find((item) => item.value === b.modePaiement)?.label || b.modePaiement || '';
-                return labelA.localeCompare(labelB);
-            },
-            render: (value: ModePaiement) => modePaiementOptions.find((item) => item.value === value)?.label || value || '-'
+            key: 'modePaiement',
+            render: (_: unknown, record: VenteEntity) => {
+                const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+                const ps = record.paiements ?? [];
+                if (ps.length > 0) {
+                    const uniques = Array.from(new Set(ps.map((p) => modeLabels[p.mode] ?? p.mode)));
+                    return uniques.join(', ');
+                }
+                return modePaiementOptions.find((item) => item.value === record.modePaiement)?.label || record.modePaiement || '-';
+            }
         },
         {
             title: 'Prix vente TTC',
@@ -1028,22 +1151,18 @@ export default function Comptoir() {
 
     return (
         <Card title="Comptoir">
-            <Row gutter={16} align="middle">
-                <Col flex="auto">
-                    <Input.Search
-                        placeholder="Rechercher par client, date, mode de paiement..."
-                        allowClear
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        onSearch={(value) => setSearchQuery(value)}
-                    />
-                </Col>
-                <Col>
-                    <Button type="primary" icon={<PlusCircleOutlined />} onClick={() => openModal()} />
-                </Col>
-            </Row>
-
-            <div style={{ marginTop: 16 }} />
+            <Space style={{ marginBottom: 16 }}>
+                <Input.Search
+                    placeholder="Recherche"
+                    enterButton
+                    allowClear
+                    style={{ width: 600 }}
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onSearch={(value) => setSearchQuery(value)}
+                />
+                <Button type="primary" icon={<PlusCircleOutlined />} onClick={() => openModal()} />
+            </Space>
 
             <Table
                 rowKey="id"
@@ -1114,11 +1233,6 @@ export default function Comptoir() {
                         <Col span={8}>
                             <Form.Item name="date" label="Date">
                                 <DatePicker showTime format="DD/MM/YYYY HH:mm" style={{ width: '100%' }} />
-                            </Form.Item>
-                        </Col>
-                        <Col span={8}>
-                            <Form.Item name="modePaiement" label="Mode de paiement">
-                                <Select allowClear options={modePaiementOptions} />
                             </Form.Item>
                         </Col>
                     </Row>
@@ -1271,6 +1385,83 @@ export default function Comptoir() {
                             </Form.Item>
                         </Col>
                     </Row>
+
+                    {isEdit && currentVente?.id && (() => {
+                        const ps = currentVente?.paiements ?? [];
+                        const totalPaye = ps.reduce((s, p) => s + p.montant, 0);
+                        const totalFacture = currentVente?.prixVenteTTC ?? 0;
+                        const restant = Math.round((totalFacture - totalPaye) * 100) / 100;
+                        const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+                        return (
+                            <div style={{ borderTop: '1px solid #f0f0f0', marginTop: 16, paddingTop: 16 }}>
+                                <Row justify="space-between" align="middle" style={{ marginBottom: 12 }}>
+                                    <Col>
+                                        <Space>
+                                            <strong>Paiements</strong>
+                                            <span>Total : <strong>{formatEuro(totalFacture)}</strong></span>
+                                            <span>Payé : <strong style={{ color: totalPaye >= totalFacture - 0.005 ? '#52c41a' : '#faad14' }}>{formatEuro(totalPaye)}</strong></span>
+                                            {restant > 0.005 && <span>Restant : <strong style={{ color: '#ff4d4f' }}>{formatEuro(restant)}</strong></span>}
+                                        </Space>
+                                    </Col>
+                                    <Col>
+                                        <Button
+                                            type="primary"
+                                            icon={<PlusCircleOutlined />}
+                                            onClick={openPaiementModal}
+                                            disabled={isReadOnly}
+                                        >
+                                            Ajouter un paiement
+                                        </Button>
+                                    </Col>
+                                </Row>
+                                <Table
+                                    rowKey="id"
+                                    size="small"
+                                    bordered
+                                    pagination={false}
+                                    dataSource={ps}
+                                    locale={{ emptyText: 'Aucun paiement enregistré' }}
+                                    columns={[
+                                        { title: 'Mode', dataIndex: 'mode', width: 110, render: (v: string) => modeLabels[v] ?? v },
+                                        {
+                                            title: 'Avoir',
+                                            key: 'avoir',
+                                            render: (_: unknown, r: VentePaiement) =>
+                                                r.avoirId ? `#${r.avoirId} — ${r.avoirMotif ?? ''}` : '-',
+                                        },
+                                        { title: 'Montant', dataIndex: 'montant', width: 120, align: 'right' as const, render: (v: number) => formatEuro(v) },
+                                        { title: 'Notes', dataIndex: 'notes', render: (v: string) => v ?? '-' },
+                                        {
+                                            title: '',
+                                            key: 'remove',
+                                            width: 50,
+                                            render: (_: unknown, r: VentePaiement) => (
+                                                <Popconfirm
+                                                    title="Supprimer ce paiement ?"
+                                                    onConfirm={() => r.id && handleRemovePaiement(r.id)}
+                                                    okText="Supprimer"
+                                                    cancelText="Annuler"
+                                                    disabled={isReadOnly}
+                                                >
+                                                    <Button
+                                                        size="small"
+                                                        danger
+                                                        icon={<DeleteOutlined />}
+                                                        disabled={isReadOnly}
+                                                    />
+                                                </Popconfirm>
+                                            ),
+                                        },
+                                    ]}
+                                />
+                            </div>
+                        );
+                    })()}
+                    {!isEdit && (
+                        <div style={{ borderTop: '1px solid #f0f0f0', marginTop: 16, paddingTop: 16, color: '#8c8c8c' }}>
+                            Enregistrez d'abord la vente pour ajouter un paiement (espèces, carte, avoir client...).
+                        </div>
+                    )}
                 </Form>
 
                 <Modal
@@ -1409,6 +1600,84 @@ export default function Comptoir() {
                                 </Form.Item>
                             </Col>
                         </Row>
+                    </Form>
+                </Modal>
+
+                <Modal
+                    title="Ajouter un paiement"
+                    open={paiementModalVisible}
+                    onCancel={() => setPaiementModalVisible(false)}
+                    onOk={handleAddPaiement}
+                    okText="Valider"
+                    confirmLoading={addingPaiement}
+                    destroyOnHidden
+                    width={480}
+                >
+                    <Form layout="vertical">
+                        <Form.Item label="Mode de règlement" required>
+                            <Select
+                                value={paiementMode}
+                                onChange={(v) => {
+                                    setPaiementMode(v);
+                                    setPaiementAvoirId(null);
+                                    loadAvoirsDisponibles(v);
+                                }}
+                                options={[
+                                    { value: 'CARTE', label: 'Carte' },
+                                    { value: 'ESPÈCES', label: 'Espèces' },
+                                    { value: 'CHEQUE', label: 'Chèque' },
+                                    { value: 'VIREMENT', label: 'Virement' },
+                                    { value: 'AVOIR', label: 'Avoir client' },
+                                ]}
+                                style={{ width: '100%' }}
+                            />
+                        </Form.Item>
+
+                        {paiementMode === 'AVOIR' && (
+                            <Form.Item label="Avoir à appliquer" required>
+                                <Select
+                                    placeholder="Sélectionner un avoir"
+                                    value={paiementAvoirId ?? undefined}
+                                    onChange={(v) => {
+                                        setPaiementAvoirId(v);
+                                        const avoir = avoirsDisponibles.find((a) => a.id === v);
+                                        if (avoir) {
+                                            const restantAvoir = Math.round((avoir.montantTTC - avoir.montantUtilise) * 100) / 100;
+                                            const restantFacture = Math.max(0, Math.round(
+                                                ((currentVente?.prixVenteTTC ?? 0) -
+                                                (currentVente?.paiements ?? []).reduce((s, p) => s + p.montant, 0)) * 100
+                                            ) / 100);
+                                            setPaiementMontant(Math.min(restantAvoir, restantFacture));
+                                        }
+                                    }}
+                                    options={avoirsDisponibles.map((a) => ({
+                                        value: a.id,
+                                        label: `#${a.id} — ${a.motif ?? '(sans motif)'} — solde ${formatEuro(Math.round((a.montantTTC - a.montantUtilise) * 100) / 100)}`,
+                                    }))}
+                                    notFoundContent="Aucun avoir disponible pour ce client"
+                                    style={{ width: '100%' }}
+                                />
+                            </Form.Item>
+                        )}
+
+                        <Form.Item label="Montant" required>
+                            <InputNumber
+                                min={0.01}
+                                precision={2}
+                                value={paiementMontant}
+                                onChange={(v) => setPaiementMontant(v ?? 0)}
+                                addonAfter="€"
+                                style={{ width: '100%' }}
+                            />
+                        </Form.Item>
+
+                        <Form.Item label="Notes (optionnel)">
+                            <Input
+                                value={paiementNotes}
+                                onChange={(e) => setPaiementNotes(e.target.value)}
+                                placeholder="Ex: chèque n°12345"
+                            />
+                        </Form.Item>
                     </Form>
                 </Modal>
             </Modal>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -1664,13 +1664,22 @@ export default function Vente() {
         if (step >= 3 && currentStep < 3) {
             const currentLignes: LigneUnifiee[] = form.getFieldValue('lignes') || [];
             const allLines = currentLignes.filter((l) => (l.type === 'forfait' || l.type === 'service') && l.itemId);
-            const allDone = allLines.length > 0 && allLines.every((l: { status?: PlanningStatus }) =>
-                l.status === 'TERMINEE' || l.status === 'ANNULEE'
-            );
-            const hasTerminee = allLines.some((l: { status?: PlanningStatus }) => l.status === 'TERMINEE');
-            if (!allDone || !hasTerminee) {
-                message.warning('Toutes les prestations doivent être terminées avant de passer en facture complète');
-                return;
+            const totalDureeEstimee = allLines.reduce((sum, l) => {
+                const duree = l.type === 'forfait'
+                    ? forfaits.find((f) => f.id === l.itemId)?.dureeEstimee
+                    : services.find((s) => s.id === l.itemId)?.dureeEstimee;
+                return sum + (duree || 0);
+            }, 0);
+            const skipCheck = allLines.length === 0 || totalDureeEstimee === 0;
+            if (!skipCheck) {
+                const allDone = allLines.every((l: { status?: PlanningStatus }) =>
+                    l.status === 'TERMINEE' || l.status === 'ANNULEE'
+                );
+                const hasTerminee = allLines.some((l: { status?: PlanningStatus }) => l.status === 'TERMINEE');
+                if (!allDone || !hasTerminee) {
+                    message.warning('Toutes les prestations doivent être terminées avant de passer en facture complète');
+                    return;
+                }
             }
         }
         form.setFieldsValue(steps[step]);

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -22,7 +22,7 @@ import {
     Dropdown,
     message
 } from 'antd';
-import { CalendarOutlined, CheckCircleOutlined, CreditCardOutlined, DeleteOutlined, EditOutlined, FileDoneOutlined, FileTextOutlined, LeftOutlined, MailOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, RightOutlined, SendOutlined, SolutionOutlined, WalletOutlined } from '@ant-design/icons';
+import { CalendarOutlined, CheckCircleOutlined, CreditCardOutlined, DeleteOutlined, EditOutlined, FileDoneOutlined, FileTextOutlined, LeftOutlined, MailOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, RightOutlined, RollbackOutlined, SendOutlined, SolutionOutlined, WalletOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import api from './api.ts';
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
@@ -252,6 +252,26 @@ const defaultNewService = {
 
 type VenteStatus = 'DEVIS' | 'FACTURE_EN_ATTENTE' | 'FACTURE_PRETE' | 'FACTURE_PAYEE';
 type ModePaiement = 'CHEQUE' | 'VIREMENT' | 'CARTE' | 'ESPÈCES';
+type ModeReglement = 'CHEQUE' | 'VIREMENT' | 'CARTE' | 'ESPÈCES' | 'AVOIR';
+
+interface VentePaiement {
+    id?: number;
+    mode: ModeReglement;
+    montant: number;
+    date?: string;
+    notes?: string;
+    avoirId?: number;
+    avoirMotif?: string;
+    avoirMontantTTC?: number;
+    avoirMontantUtilise?: number;
+}
+
+interface AvoirDisponible {
+    id: number;
+    motif?: string;
+    montantTTC: number;
+    montantUtilise: number;
+}
 
 interface VenteEntity {
     id?: number;
@@ -280,6 +300,7 @@ interface VenteEntity {
     montantTVA?: number;
     prixVenteTTC?: number;
     modePaiement?: ModePaiement;
+    paiements?: VentePaiement[];
     images?: string[];
     documents?: string[];
     rappel1Jours?: number;
@@ -563,6 +584,21 @@ export default function Vente() {
         }, 300);
         setProduitSearchTimeout(timeout);
     };
+
+    // Paiements multiples
+    const [paiementModalVisible, setPaiementModalVisible] = useState(false);
+    const [paiementMode, setPaiementMode] = useState<ModeReglement>('CHEQUE');
+    const [paiementMontant, setPaiementMontant] = useState<number>(0);
+    const [paiementNotes, setPaiementNotes] = useState('');
+    const [paiementAvoirId, setPaiementAvoirId] = useState<number | null>(null);
+    const [avoirsDisponibles, setAvoirsDisponibles] = useState<AvoirDisponible[]>([]);
+    const [addingPaiement, setAddingPaiement] = useState(false);
+
+    // Génération d'avoir depuis une vente
+    const [genAvoirModalVente, setGenAvoirModalVente] = useState<VenteEntity | null>(null);
+    const [genAvoirMotif, setGenAvoirMotif] = useState('');
+    const [genAvoirNotes, setGenAvoirNotes] = useState('');
+    const [generatingAvoir, setGeneratingAvoir] = useState(false);
 
     const marqueOptions = useMemo(() => {
         const unique = Array.from(new Set(produits.map((p) => p.marque).filter(Boolean))) as string[];
@@ -1655,6 +1691,101 @@ export default function Vente() {
         }
     };
 
+    const refreshCurrentVente = async (id: number) => {
+        try {
+            const res = await api.get<VenteEntity>(`/ventes/${id}`);
+            setCurrentVente(res.data);
+        } catch {
+            message.error('Erreur lors du rechargement de la vente');
+        }
+    };
+
+    const openPaiementModal = async () => {
+        const restant = (currentVente?.prixVenteTTC ?? 0) -
+            (currentVente?.paiements ?? []).reduce((s, p) => s + p.montant, 0);
+        setPaiementMode('CHEQUE');
+        setPaiementMontant(Math.max(0, Math.round(restant * 100) / 100));
+        setPaiementNotes('');
+        setPaiementAvoirId(null);
+        setAvoirsDisponibles([]);
+        setPaiementModalVisible(true);
+    };
+
+    const loadAvoirsDisponibles = async (mode: ModeReglement) => {
+        if (mode !== 'AVOIR' || !currentVente?.client?.id) return;
+        try {
+            const res = await api.get<AvoirDisponible[]>(
+                `/avoirs/search?clientId=${currentVente.client.id}&status=EMIS`
+            );
+            setAvoirsDisponibles((res.data || []).filter(
+                (a) => Math.round((a.montantTTC - a.montantUtilise) * 100) / 100 > 0.005
+            ));
+        } catch {
+            setAvoirsDisponibles([]);
+        }
+    };
+
+    const handleAddPaiement = async () => {
+        if (!currentVente?.id) return;
+        if (paiementMontant <= 0) { message.warning('Le montant doit être supérieur à zéro'); return; }
+        if (paiementMode === 'AVOIR' && !paiementAvoirId) { message.warning('Veuillez sélectionner un avoir'); return; }
+        setAddingPaiement(true);
+        try {
+            await api.post(`/ventes/${currentVente.id}/paiements`, {
+                mode: paiementMode,
+                montant: paiementMontant,
+                notes: paiementNotes || undefined,
+                avoirId: paiementMode === 'AVOIR' ? paiementAvoirId : undefined,
+            });
+            message.success('Paiement ajouté');
+            setPaiementModalVisible(false);
+            await refreshCurrentVente(currentVente.id);
+        } catch (err: unknown) {
+            const msg = (err as { response?: { data?: string } })?.response?.data || 'Erreur lors de l\'ajout du paiement';
+            message.error(msg);
+        } finally {
+            setAddingPaiement(false);
+        }
+    };
+
+    const handleRemovePaiement = async (paiementId: number) => {
+        if (!currentVente?.id) return;
+        try {
+            await api.delete(`/ventes/${currentVente.id}/paiements/${paiementId}`);
+            message.success('Paiement supprimé');
+            await refreshCurrentVente(currentVente.id);
+        } catch {
+            message.error('Erreur lors de la suppression du paiement');
+        }
+    };
+
+    const handleGenerateAvoir = async () => {
+        if (!genAvoirModalVente?.id) return;
+        if (!genAvoirMotif.trim()) { message.warning('Le motif est requis'); return; }
+        setGeneratingAvoir(true);
+        try {
+            await api.post(`/avoirs/from-vente/${genAvoirModalVente.id}`, {
+                motif: genAvoirMotif.trim(),
+                notes: genAvoirNotes || undefined,
+            });
+            setGenAvoirModalVente(null);
+            setGenAvoirMotif('');
+            setGenAvoirNotes('');
+            Modal.confirm({
+                title: 'Avoir généré',
+                content: 'L\'avoir a été créé en brouillon. Voulez-vous accéder à la gestion des avoirs ?',
+                okText: 'Aller aux avoirs',
+                cancelText: 'Rester ici',
+                onOk: () => navigate('/avoirs'),
+            });
+        } catch (err: unknown) {
+            const msg = (err as { response?: { data?: string } })?.response?.data || 'Erreur lors de la génération de l\'avoir';
+            message.error(msg);
+        } finally {
+            setGeneratingAvoir(false);
+        }
+    };
+
     const openPrintDocument = (_title: string, contentHtml: string, _width: number = 900) => {
         // Print through a hidden iframe to avoid opening a new tab/window.
         const iframe = document.createElement('iframe');
@@ -1770,8 +1901,22 @@ export default function Vente() {
                 <div class="row"><strong>Prix vente TTC:</strong> ${escapeHtml(formatEuro(vente.prixVenteTTC))}</div>
             </div>` : '';
 
-        const paymentHtml = docType === 'facture' && vente.modePaiement
-            ? `<div class="row"><strong>Mode de paiement:</strong> ${escapeHtml(vente.modePaiement)}</div>` : '';
+        const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+        const paiementsHtml = (() => {
+            if (!showPrices) return '';
+            const ps = vente.paiements ?? [];
+            if (ps.length > 0) {
+                return ps.map(p => {
+                    const label = modeLabels[p.mode] ?? p.mode;
+                    const avoir = p.avoirId ? ` (avoir #${p.avoirId})` : '';
+                    return `<div class="row">${escapeHtml(label)}${escapeHtml(avoir)} : ${escapeHtml(formatEuro(p.montant))}</div>`;
+                }).join('');
+            }
+            if (vente.modePaiement) return `<div class="row"><strong>Mode de paiement:</strong> ${escapeHtml(vente.modePaiement)}</div>`;
+            return '';
+        })();
+        const paymentHtml = docType === 'facture' && paiementsHtml
+            ? `<div class="section"><strong>Règlements :</strong>${paiementsHtml}</div>` : '';
 
         const signatureHtml = docType !== 'facture' && vente.signatureBonPourAccord
             ? `<div class="section"><h3>Signature client</h3><img src="${vente.signatureBonPourAccord}" style="max-width:300px;border:1px solid #d9d9d9;border-radius:4px;" /></div>` : '';
@@ -2090,6 +2235,17 @@ export default function Vente() {
                         <Button title="Lien de paiement" icon={<CreditCardOutlined />} disabled={record.status !== 'FACTURE_PRETE'} />
                     </Dropdown>
                     <Button icon={<EditOutlined />} onClick={() => openModal(record)} />
+                    {(record.status === 'FACTURE_PRETE' || record.status === 'FACTURE_PAYEE') && (
+                        <Button
+                            title="Générer un avoir"
+                            icon={<RollbackOutlined />}
+                            onClick={() => {
+                                setGenAvoirMotif('');
+                                setGenAvoirNotes('');
+                                setGenAvoirModalVente(record);
+                            }}
+                        />
+                    )}
                     <Popconfirm
                         title="Supprimer cette vente ?"
                         onConfirm={() => handleDelete(record.id)}
@@ -2194,15 +2350,30 @@ export default function Vente() {
                     >
                         Envoyer par email
                     </Button>,
-                    ...(watchedStatus === 'FACTURE_PRETE' || watchedStatus === 'FACTURE_PAYEE' ? [<Dropdown
-                        key="payment"
-                        menu={{ items: currentVente ? paymentMenuItems(currentVente) : [] }}
-                        placement="topRight"
-                    >
-                        <Button icon={<CreditCardOutlined />}>
-                            Lien de paiement
-                        </Button>
-                    </Dropdown>] : []),
+                    ...(watchedStatus === 'FACTURE_PRETE' || watchedStatus === 'FACTURE_PAYEE' ? [
+                        <Dropdown
+                            key="payment"
+                            menu={{ items: currentVente ? paymentMenuItems(currentVente) : [] }}
+                            placement="topRight"
+                        >
+                            <Button icon={<CreditCardOutlined />}>
+                                Lien de paiement
+                            </Button>
+                        </Dropdown>,
+                        <Button
+                            key="genAvoir"
+                            icon={<RollbackOutlined />}
+                            disabled={!currentVente}
+                            onClick={() => {
+                                if (!currentVente) return;
+                                setGenAvoirMotif('');
+                                setGenAvoirNotes('');
+                                setGenAvoirModalVente(currentVente);
+                            }}
+                        >
+                            Générer un avoir
+                        </Button>,
+                    ] : []),
                     ...(!isReadOnly ? [<div key="step-nav" style={{ flex: 1, textAlign: 'left' }}>
                         <Button
                             icon={<LeftOutlined />}
@@ -2272,13 +2443,7 @@ export default function Vente() {
                                 <DatePicker showTime format="DD/MM/YYYY HH:mm" style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>
-                        {(watchedStatus === 'FACTURE_PRETE' || watchedStatus === 'FACTURE_PAYEE') && (
-                            <Col span={8}>
-                                <Form.Item name="modePaiement" label="Mode de paiement">
-                                    <Select allowClear options={modePaiementOptions} />
-                                </Form.Item>
-                            </Col>
-                        )}
+                        {/* modePaiement géré via l'onglet Paiements */}
                     </Row>
 
                     <Row gutter={16}>
@@ -2596,6 +2761,96 @@ export default function Vente() {
                                     </>
                                 )
                             },
+                            ...(watchedStatus === 'FACTURE_PRETE' || watchedStatus === 'FACTURE_PAYEE' ? [{
+                                key: 'paiements',
+                                label: (() => {
+                                    const ps = currentVente?.paiements ?? [];
+                                    const total = ps.reduce((s, p) => s + p.montant, 0);
+                                    const restant = (currentVente?.prixVenteTTC ?? 0) - total;
+                                    return `Paiements${ps.length > 0 ? ` (${ps.length})` : ''}${restant > 0.005 ? ` — ${restant.toFixed(2)} € restant` : ' ✓'}`;
+                                })(),
+                                children: (
+                                    <div>
+                                        {isEdit && (
+                                            <>
+                                                {(() => {
+                                                    const ps = currentVente?.paiements ?? [];
+                                                    const totalPaye = ps.reduce((s, p) => s + p.montant, 0);
+                                                    const totalFacture = currentVente?.prixVenteTTC ?? 0;
+                                                    const restant = Math.round((totalFacture - totalPaye) * 100) / 100;
+                                                    const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+                                                    return (
+                                                        <>
+                                                            <Row justify="space-between" align="middle" style={{ marginBottom: 12 }}>
+                                                                <Col>
+                                                                    <Space>
+                                                                        <span>Total facture : <strong>{formatEuro(totalFacture)}</strong></span>
+                                                                        <span>Total payé : <strong style={{ color: totalPaye >= totalFacture - 0.005 ? '#52c41a' : '#faad14' }}>{formatEuro(totalPaye)}</strong></span>
+                                                                        {restant > 0.005 && <span>Restant : <strong style={{ color: '#ff4d4f' }}>{formatEuro(restant)}</strong></span>}
+                                                                    </Space>
+                                                                </Col>
+                                                                <Col>
+                                                                    <Button
+                                                                        type="primary"
+                                                                        icon={<PlusCircleOutlined />}
+                                                                        onClick={openPaiementModal}
+                                                                        disabled={watchedStatus === 'FACTURE_PAYEE'}
+                                                                    >
+                                                                        Ajouter un paiement
+                                                                    </Button>
+                                                                </Col>
+                                                            </Row>
+                                                            <Table
+                                                                rowKey="id"
+                                                                size="small"
+                                                                bordered
+                                                                pagination={false}
+                                                                dataSource={ps}
+                                                                locale={{ emptyText: 'Aucun paiement enregistré' }}
+                                                                columns={[
+                                                                    { title: 'Mode', dataIndex: 'mode', width: 110, render: (v: string) => modeLabels[v] ?? v },
+                                                                    {
+                                                                        title: 'Avoir',
+                                                                        key: 'avoir',
+                                                                        render: (_: unknown, r: VentePaiement) =>
+                                                                            r.avoirId ? `#${r.avoirId} — ${r.avoirMotif ?? ''}` : '-',
+                                                                    },
+                                                                    { title: 'Montant', dataIndex: 'montant', width: 120, align: 'right' as const, render: (v: number) => formatEuro(v) },
+                                                                    { title: 'Notes', dataIndex: 'notes', render: (v: string) => v ?? '-' },
+                                                                    {
+                                                                        title: '',
+                                                                        key: 'remove',
+                                                                        width: 50,
+                                                                        render: (_: unknown, r: VentePaiement) => (
+                                                                            <Popconfirm
+                                                                                title="Supprimer ce paiement ?"
+                                                                                onConfirm={() => r.id && handleRemovePaiement(r.id)}
+                                                                                okText="Supprimer"
+                                                                                cancelText="Annuler"
+                                                                                disabled={watchedStatus === 'FACTURE_PAYEE'}
+                                                                            >
+                                                                                <Button
+                                                                                    size="small"
+                                                                                    danger
+                                                                                    icon={<DeleteOutlined />}
+                                                                                    disabled={watchedStatus === 'FACTURE_PAYEE'}
+                                                                                />
+                                                                            </Popconfirm>
+                                                                        ),
+                                                                    },
+                                                                ]}
+                                                            />
+                                                        </>
+                                                    );
+                                                })()}
+                                            </>
+                                        )}
+                                        {!isEdit && (
+                                            <div style={{ color: '#8c8c8c' }}>Enregistrez d'abord la facture pour gérer les paiements.</div>
+                                        )}
+                                    </div>
+                                ),
+                            }] : []),
                             {
                                 key: 'images',
                                 label: 'Images & Documents',
@@ -3655,6 +3910,118 @@ export default function Vente() {
                         touchAction: 'none',
                     }}
                 />
+            </Modal>
+
+            {/* Modal génération avoir */}
+            <Modal
+                title="Générer un avoir depuis cette facture"
+                open={!!genAvoirModalVente}
+                onCancel={() => setGenAvoirModalVente(null)}
+                onOk={handleGenerateAvoir}
+                okText="Générer"
+                confirmLoading={generatingAvoir}
+                destroyOnHidden
+                width={480}
+            >
+                <p style={{ marginBottom: 16, color: '#595959' }}>
+                    Un avoir en brouillon sera créé avec les lignes de la facture <strong>#{genAvoirModalVente?.id}</strong>.
+                </p>
+                <Form layout="vertical">
+                    <Form.Item label="Motif" required>
+                        <Input
+                            value={genAvoirMotif}
+                            onChange={(e) => setGenAvoirMotif(e.target.value)}
+                            placeholder="Ex: Retour marchandise, erreur de facturation..."
+                        />
+                    </Form.Item>
+                    <Form.Item label="Notes (optionnel)">
+                        <Input.TextArea
+                            rows={3}
+                            value={genAvoirNotes}
+                            onChange={(e) => setGenAvoirNotes(e.target.value)}
+                            placeholder="Informations complémentaires..."
+                        />
+                    </Form.Item>
+                </Form>
+            </Modal>
+
+            {/* Modal ajout paiement */}
+            <Modal
+                title="Ajouter un paiement"
+                open={paiementModalVisible}
+                onCancel={() => setPaiementModalVisible(false)}
+                onOk={handleAddPaiement}
+                okText="Valider"
+                confirmLoading={addingPaiement}
+                destroyOnHidden
+                width={480}
+            >
+                <Form layout="vertical">
+                    <Form.Item label="Mode de règlement" required>
+                        <Select
+                            value={paiementMode}
+                            onChange={(v) => {
+                                setPaiementMode(v);
+                                setPaiementAvoirId(null);
+                                loadAvoirsDisponibles(v);
+                            }}
+                            options={[
+                                { value: 'CHEQUE', label: 'Chèque' },
+                                { value: 'VIREMENT', label: 'Virement' },
+                                { value: 'CARTE', label: 'Carte' },
+                                { value: 'ESPÈCES', label: 'Espèces' },
+                                { value: 'AVOIR', label: 'Avoir client' },
+                            ]}
+                            style={{ width: '100%' }}
+                        />
+                    </Form.Item>
+
+                    {paiementMode === 'AVOIR' && (
+                        <Form.Item label="Avoir à appliquer" required>
+                            <Select
+                                placeholder="Sélectionner un avoir"
+                                value={paiementAvoirId ?? undefined}
+                                onChange={(v) => {
+                                    setPaiementAvoirId(v);
+                                    const avoir = avoirsDisponibles.find((a) => a.id === v);
+                                    if (avoir) {
+                                        const restantAvoir = Math.round((avoir.montantTTC - avoir.montantUtilise) * 100) / 100;
+                                        const restantFacture = Math.max(0, Math.round(
+                                            ((currentVente?.prixVenteTTC ?? 0) -
+                                            (currentVente?.paiements ?? []).reduce((s, p) => s + p.montant, 0)) * 100
+                                        ) / 100);
+                                        setPaiementMontant(Math.min(restantAvoir, restantFacture));
+                                    }
+                                }}
+                                options={avoirsDisponibles.map((a) => ({
+                                    value: a.id,
+                                    label: `#${a.id} — ${a.motif ?? '(sans motif)'} — solde ${formatEuro(Math.round((a.montantTTC - a.montantUtilise) * 100) / 100)}`,
+                                }))}
+                                notFoundContent="Aucun avoir disponible pour ce client"
+                                style={{ width: '100%' }}
+                            />
+                        </Form.Item>
+                    )}
+
+                    <Form.Item label="Montant" required>
+                        <InputNumber
+                            min={0.01}
+                            precision={2}
+                            value={paiementMontant}
+                            onChange={(v) => setPaiementMontant(v ?? 0)}
+                            addonAfter="€"
+                            style={{ width: '100%' }}
+                        />
+                    </Form.Item>
+
+                    <Form.Item label="Notes (optionnel)">
+                        <Input
+                            value={paiementNotes}
+                            onChange={(e) => setPaiementNotes(e.target.value)}
+                            placeholder="Ex: chèque n°12345"
+                        />
+                    </Form.Item>
+                </Form>
             </Modal>
         </Card>
     );

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -1,7 +1,7 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Layout, Input, Col, Row, Image, Menu, Form, Modal, message, ConfigProvider, theme as antdTheme, Switch as AntSwitch } from 'antd';
-import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, DashboardOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined } from '@ant-design/icons';
+import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, DashboardOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined, RollbackOutlined } from '@ant-design/icons';
 import { NavigationContext } from './navigation-context.tsx';
 import Icon from '@ant-design/icons';
 import { ReactComponent as BoatOutlined } from './boat.svg';
@@ -27,6 +27,7 @@ import RemorquesClients from './clients-remorques.tsx';
 import Techniciens from './techniciens.tsx';
 import MainOeuvres from './main-oeuvres.tsx';
 import Vente from './vente.tsx';
+import Avoirs from './avoirs.tsx';
 import Planning from './planning.tsx';
 import Comptoir from './comptoir.tsx';
 import Dashboard from './dashboard.tsx';
@@ -91,6 +92,7 @@ function SideMenu(props) {
       { key: 'Vente', label: 'Vente', icon: <DollarOutlined/>, requiredRole: 'vendeur', children: [
         { key: '/comptoir', label: 'Comptoir', icon: <ShopOutlined/> },
         { key: '/prestations', label: 'Prestations', icon: <SolutionOutlined/> },
+        { key: '/avoirs', label: 'Avoirs', icon: <RollbackOutlined/> },
         { key: '/clients', label: 'Clients', icon: <TeamOutlined /> },
       ]},
       { key: 'parc', label: 'Parc', icon: <Icon component={ ParcOutlined } />, requiredRole: 'manager', children: [
@@ -483,6 +485,8 @@ export default function Workspace(props) {
                 return <ProtectedRoute roles={props.roles} requiredRole="vendeur"><Vente /></ProtectedRoute>;
             case '/comptoir':
                 return <ProtectedRoute roles={props.roles} requiredRole="vendeur"><Comptoir /></ProtectedRoute>;
+            case '/avoirs':
+                return <ProtectedRoute roles={props.roles} requiredRole="vendeur"><Avoirs /></ProtectedRoute>;
             case '/forfaits':
                 return <ProtectedRoute roles={props.roles} requiredRole="admin"><Forfaits /></ProtectedRoute>;
             case '/techniciens':

--- a/client-ui/src/app.tsx
+++ b/client-ui/src/app.tsx
@@ -8,6 +8,7 @@ import {
     FileTextOutlined,
     UserOutlined,
     LogoutOutlined,
+    RollbackOutlined,
     TagsOutlined,
     ScheduleOutlined,
 } from '@ant-design/icons';
@@ -17,6 +18,7 @@ import MesBateaux from './mes-bateaux.tsx';
 import MesMoteurs from './mes-moteurs.tsx';
 import MesRemorques from './mes-remorques.tsx';
 import MesFactures from './mes-factures.tsx';
+import MesAvoirs from './mes-avoirs.tsx';
 import MesPrestations from './mes-prestations.tsx';
 import MonProfil from './mon-profil.tsx';
 import PetitesAnnonces from './petites-annonces.tsx';
@@ -74,6 +76,7 @@ export default function App() {
         { key: 'moteurs', icon: <ToolOutlined />, label: 'Mes moteurs' },
         { key: 'remorques', icon: <CarOutlined />, label: 'Mes remorques' },
         { key: 'factures', icon: <FileTextOutlined />, label: 'Mes ventes & prestations' },
+        { key: 'avoirs', icon: <RollbackOutlined />, label: 'Mes avoirs' },
         { key: 'prestations', icon: <ScheduleOutlined />, label: 'Interventions' },
         { key: 'annonces', icon: <TagsOutlined />, label: 'Petites annonces' },
         { key: 'profil', icon: <UserOutlined />, label: 'Mon profil' },
@@ -94,6 +97,8 @@ export default function App() {
                 return <MesRemorques clientId={user.id} onCreateAnnonce={handleCreateAnnonceWithImages} />;
             case 'factures':
                 return <MesFactures clientId={user.id} />;
+            case 'avoirs':
+                return <MesAvoirs clientId={user.id} />;
             case 'prestations':
                 return <MesPrestations clientId={user.id} />;
             case 'annonces': {

--- a/client-ui/src/mes-avoirs.tsx
+++ b/client-ui/src/mes-avoirs.tsx
@@ -1,0 +1,289 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, Card, Divider, Modal, Space, Spin, Table, Tag, message } from 'antd';
+import { EyeOutlined, PrinterOutlined } from '@ant-design/icons';
+import api from './api.ts';
+
+interface ClientRef { id: number; prenom?: string; nom: string }
+interface VenteRef { id: number; status?: string }
+
+interface AvoirLigne {
+    id?: number;
+    designation: string;
+    quantite: number;
+    prixUnitaireHT: number;
+    tva: number;
+    montantTVA: number;
+    totalTTC: number;
+}
+
+interface AvoirEntity {
+    id: number;
+    status: string;
+    client?: ClientRef;
+    vente?: VenteRef;
+    motif?: string;
+    notes?: string;
+    dateEmission?: string;
+    dateRemboursement?: string;
+    montantHT?: number;
+    tva?: number;
+    montantTVA?: number;
+    montantTTC?: number;
+    montantUtilise?: number;
+    modeRemboursement?: string;
+    lignes?: AvoirLigne[];
+}
+
+interface MesAvoirsProps {
+    clientId: number;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+    BROUILLON: 'Brouillon',
+    EMIS: 'Émis',
+    REMBOURSE: 'Remboursé',
+    ANNULE: 'Annulé',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+    BROUILLON: 'default',
+    EMIS: 'blue',
+    REMBOURSE: 'green',
+    ANNULE: 'red',
+};
+
+const MODE_LABELS: Record<string, string> = {
+    CHEQUE: 'Chèque',
+    VIREMENT: 'Virement',
+    CARTE: 'Carte',
+    'ESPÈCES': 'Espèces',
+};
+
+const formatDate = (value?: string) => {
+    if (!value) return '-';
+    const parsed = new Date(value);
+    if (isNaN(parsed.getTime())) return value;
+    return parsed.toLocaleDateString('fr-FR');
+};
+
+const formatEuro = (value?: number) => `${(value ?? 0).toFixed(2)} EUR`;
+
+const escapeHtml = (value: string) =>
+    value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+
+export default function MesAvoirs({ clientId }: MesAvoirsProps) {
+    const [avoirs, setAvoirs] = useState<AvoirEntity[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [detailAvoir, setDetailAvoir] = useState<AvoirEntity | null>(null);
+
+    const fetchAvoirs = useCallback(() => {
+        setLoading(true);
+        api.get(`/portal/clients/${clientId}/avoirs`)
+            .then((res) => setAvoirs(res.data || []))
+            .catch(() => message.error('Erreur lors du chargement des avoirs'))
+            .finally(() => setLoading(false));
+    }, [clientId]);
+
+    useEffect(() => { fetchAvoirs(); }, [fetchAvoirs]);
+
+    const handlePrint = (avoir: AvoirEntity) => {
+        const title = `Avoir #${avoir.id}`;
+        const tableRows = (avoir.lignes ?? []).map((ligne) =>
+            `<tr>
+                <td>${escapeHtml(ligne.designation)}</td>
+                <td style="text-align:center;">${ligne.quantite}</td>
+                <td style="text-align:right;">${escapeHtml(formatEuro(ligne.prixUnitaireHT))}</td>
+                <td style="text-align:right;">${escapeHtml(formatEuro(ligne.totalTTC))}</td>
+            </tr>`
+        ).join('');
+
+        const html = `<html><head><title>${escapeHtml(title)}</title>
+            <style>
+                body { font-family: Arial, sans-serif; margin: 24px; color: #1f1f1f; }
+                h1 { margin-bottom: 8px; }
+                .meta p { margin: 4px 0; }
+                table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+                th, td { border: 1px solid #d9d9d9; padding: 6px 8px; }
+                th { background: #fafafa; text-align: left; }
+                .totals { margin-top: 16px; text-align: right; }
+                .totals p { margin: 4px 0; }
+            </style></head><body>
+            <h1>${escapeHtml(title)}</h1>
+            <div class="meta">
+                <p><strong>Date d'émission :</strong> ${escapeHtml(formatDate(avoir.dateEmission))}</p>
+                <p><strong>Motif :</strong> ${escapeHtml(avoir.motif ?? '-')}</p>
+                ${avoir.vente ? `<p><strong>Facture d'origine :</strong> #${avoir.vente.id}</p>` : ''}
+                ${avoir.modeRemboursement ? `<p><strong>Mode de remboursement :</strong> ${escapeHtml(MODE_LABELS[avoir.modeRemboursement] ?? avoir.modeRemboursement)}</p>` : ''}
+            </div>
+            <table>
+                <thead><tr>
+                    <th>Désignation</th>
+                    <th style="text-align:center;">Qté</th>
+                    <th style="text-align:right;">P.U. HT</th>
+                    <th style="text-align:right;">Total TTC</th>
+                </tr></thead>
+                <tbody>${tableRows || '<tr><td colspan="4">Aucun élément</td></tr>'}</tbody>
+            </table>
+            <div class="totals">
+                <p>Montant HT : ${escapeHtml(formatEuro(avoir.montantHT))}</p>
+                <p>TVA : ${escapeHtml(formatEuro(avoir.montantTVA))}</p>
+                <p><strong style="font-size:16px;">Total TTC : ${escapeHtml(formatEuro(avoir.montantTTC))}</strong></p>
+            </div>
+        </body></html>`;
+
+        const iframe = document.createElement('iframe');
+        iframe.style.cssText = 'position:fixed;right:0;bottom:0;width:0;height:0;border:0;';
+        document.body.appendChild(iframe);
+        const win = iframe.contentWindow;
+        if (!win) { iframe.remove(); return; }
+        win.document.open();
+        win.document.write(html);
+        win.document.close();
+        win.focus();
+        win.print();
+        setTimeout(() => iframe.remove(), 1000);
+    };
+
+    const columns = [
+        {
+            title: '#',
+            dataIndex: 'id',
+            width: 60,
+            render: (v: number) => `#${v}`,
+        },
+        {
+            title: 'Date d\'émission',
+            dataIndex: 'dateEmission',
+            render: (v: string) => formatDate(v),
+        },
+        {
+            title: 'Facture liée',
+            key: 'vente',
+            width: 110,
+            render: (_: unknown, r: AvoirEntity) => r.vente ? `#${r.vente.id}` : '-',
+        },
+        {
+            title: 'Motif',
+            dataIndex: 'motif',
+            ellipsis: true,
+        },
+        {
+            title: 'Statut',
+            dataIndex: 'status',
+            width: 120,
+            render: (v: string) => <Tag color={STATUS_COLOR[v] ?? 'default'}>{STATUS_LABEL[v] ?? v}</Tag>,
+        },
+        {
+            title: 'Montant TTC',
+            dataIndex: 'montantTTC',
+            width: 120,
+            align: 'right' as const,
+            render: (v: number) => formatEuro(v),
+        },
+        {
+            title: 'Solde restant',
+            key: 'solde',
+            width: 120,
+            align: 'right' as const,
+            render: (_: unknown, r: AvoirEntity) => {
+                const restant = Math.round(((r.montantTTC ?? 0) - (r.montantUtilise ?? 0)) * 100) / 100;
+                const color = restant <= 0.005 ? '#8c8c8c' : restant < (r.montantTTC ?? 0) ? '#faad14' : '#52c41a';
+                return <span style={{ color }}>{formatEuro(restant)}</span>;
+            },
+        },
+        {
+            title: 'Actions',
+            key: 'actions',
+            render: (_: unknown, r: AvoirEntity) => (
+                <Space size="small">
+                    <Button size="small" icon={<EyeOutlined />} onClick={() => setDetailAvoir(r)}>
+                        Détail
+                    </Button>
+                    <Button size="small" icon={<PrinterOutlined />} onClick={() => handlePrint(r)}>
+                        Imprimer
+                    </Button>
+                </Space>
+            ),
+        },
+    ];
+
+    const detailColumns = [
+        { title: 'Désignation', dataIndex: 'designation' },
+        { title: 'Qté', dataIndex: 'quantite', width: 60, align: 'center' as const },
+        { title: 'P.U. HT', dataIndex: 'prixUnitaireHT', width: 110, align: 'right' as const, render: (v: number) => formatEuro(v) },
+        { title: 'TVA', dataIndex: 'tva', width: 70, align: 'center' as const, render: (v: number) => `${v}%` },
+        { title: 'Total TTC', dataIndex: 'totalTTC', width: 110, align: 'right' as const, render: (v: number) => formatEuro(v) },
+    ];
+
+    return (
+        <Card title="Mes avoirs">
+            <Spin spinning={loading}>
+                <Table
+                    rowKey="id"
+                    dataSource={avoirs}
+                    columns={columns}
+                    pagination={{ pageSize: 10 }}
+                    bordered
+                    locale={{ emptyText: 'Aucun avoir à afficher' }}
+                />
+            </Spin>
+
+            <Modal
+                title={detailAvoir ? `Avoir #${detailAvoir.id}` : ''}
+                open={!!detailAvoir}
+                onCancel={() => setDetailAvoir(null)}
+                width={750}
+                footer={detailAvoir ? [
+                    <Button key="print" icon={<PrinterOutlined />} onClick={() => handlePrint(detailAvoir)}>
+                        Imprimer
+                    </Button>,
+                    <Button key="close" onClick={() => setDetailAvoir(null)}>Fermer</Button>,
+                ] : null}
+            >
+                {detailAvoir && (
+                    <div>
+                        <p><strong>Statut :</strong>{' '}
+                            <Tag color={STATUS_COLOR[detailAvoir.status]}>
+                                {STATUS_LABEL[detailAvoir.status] ?? detailAvoir.status}
+                            </Tag>
+                        </p>
+                        <p><strong>Date d'émission :</strong> {formatDate(detailAvoir.dateEmission)}</p>
+                        {detailAvoir.dateRemboursement && (
+                            <p><strong>Date de remboursement :</strong> {formatDate(detailAvoir.dateRemboursement)}</p>
+                        )}
+                        {detailAvoir.vente && (
+                            <p><strong>Facture d'origine :</strong> #{detailAvoir.vente.id}</p>
+                        )}
+                        <p><strong>Motif :</strong> {detailAvoir.motif ?? '-'}</p>
+                        {detailAvoir.modeRemboursement && (
+                            <p><strong>Mode de remboursement :</strong>{' '}
+                                {MODE_LABELS[detailAvoir.modeRemboursement] ?? detailAvoir.modeRemboursement}
+                            </p>
+                        )}
+
+                        <Divider />
+
+                        <Table
+                            dataSource={detailAvoir.lignes ?? []}
+                            columns={detailColumns}
+                            rowKey={(_, i) => String(i)}
+                            pagination={false}
+                            size="small"
+                            bordered
+                            style={{ marginBottom: 16 }}
+                        />
+
+                        <p><strong>Montant HT :</strong> {formatEuro(detailAvoir.montantHT)}</p>
+                        <p><strong>TVA :</strong> {formatEuro(detailAvoir.montantTVA)}</p>
+                        <p style={{ fontSize: 16 }}><strong>Total TTC : {formatEuro(detailAvoir.montantTTC)}</strong></p>
+                    </div>
+                )}
+            </Modal>
+        </Card>
+    );
+}

--- a/client-ui/src/mes-factures.tsx
+++ b/client-ui/src/mes-factures.tsx
@@ -19,6 +19,16 @@ interface VenteServiceEntry {
     quantite?: number;
 }
 
+interface VentePaiement {
+    id?: number;
+    mode: string;
+    montant: number;
+    date?: string;
+    notes?: string;
+    avoirId?: number;
+    avoirMotif?: string;
+}
+
 interface VenteEntity {
     id: number;
     status: string;
@@ -32,6 +42,7 @@ interface VenteEntity {
     remise?: number;
     prixVenteTTC?: number;
     modePaiement?: string;
+    paiements?: VentePaiement[];
     venteForfaits?: VenteForfaitEntry[];
     venteServices?: VenteServiceEntry[];
     produits?: ProduitRef[];
@@ -258,8 +269,21 @@ export default function MesFactures({ clientId }: MesFacturesProps) {
                 <p style="font-size:16px;"><strong>Total à payer : ${escapeHtml(formatEuro(vente.prixVenteTTC))}</strong></p>
             </div>` : '';
 
-        const paymentHtml = docType === 'facture' && vente.modePaiement
-            ? `<p><strong>Mode de paiement :</strong> ${escapeHtml(vente.modePaiement)}</p>` : '';
+        const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+        const paymentHtml = (() => {
+            if (docType !== 'facture') return '';
+            const ps = vente.paiements ?? [];
+            if (ps.length > 0) {
+                const rows = ps.map(p => {
+                    const label = modeLabels[p.mode] ?? p.mode;
+                    const avoir = p.avoirId ? ` (avoir #${p.avoirId})` : '';
+                    return `<p>${escapeHtml(label)}${escapeHtml(avoir)} : <strong>${escapeHtml(formatEuro(p.montant))}</strong></p>`;
+                }).join('');
+                return `<p><strong>Règlements :</strong></p>${rows}`;
+            }
+            if (vente.modePaiement) return `<p><strong>Mode de paiement :</strong> ${escapeHtml(vente.modePaiement)}</p>`;
+            return '';
+        })();
 
         const signatureHtml = docType === 'devis' && vente.signatureBonPourAccord
             ? `<div style="margin-top:24px;"><p><strong>Bon pour accord &mdash; Signature client :</strong></p><img src="${vente.signatureBonPourAccord}" style="max-width:300px;border:1px solid #d9d9d9;border-radius:4px;" /></div>`
@@ -424,9 +448,23 @@ export default function MesFactures({ clientId }: MesFacturesProps) {
                         <p><strong>Statut :</strong> <Tag color={detailVente.status === 'DEVIS' && detailVente.bonPourAccord ? 'cyan' : statusColor[detailVente.status]}>
                             {detailVente.status === 'DEVIS' && detailVente.bonPourAccord ? 'Bon pour accord' : statusLabel[detailVente.status] || detailVente.status}
                         </Tag></p>
-                        {detailDocType === 'facture' && detailVente.modePaiement && (
-                            <p><strong>Mode de paiement :</strong> {detailVente.modePaiement}</p>
-                        )}
+                        {detailDocType === 'facture' && (() => {
+                            const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
+                            const ps = detailVente.paiements ?? [];
+                            if (ps.length > 0) return (
+                                <div style={{ marginBottom: 8 }}>
+                                    <strong>Règlements :</strong>
+                                    {ps.map((p, i) => (
+                                        <div key={i} style={{ display: 'flex', justifyContent: 'space-between', marginTop: 4 }}>
+                                            <span>{modeLabels[p.mode] ?? p.mode}{p.avoirId ? ` (avoir #${p.avoirId})` : ''}</span>
+                                            <span><strong>{formatEuro(p.montant)}</strong></span>
+                                        </div>
+                                    ))}
+                                </div>
+                            );
+                            if (detailVente.modePaiement) return <p><strong>Mode de paiement :</strong> {detailVente.modePaiement}</p>;
+                            return null;
+                        })()}
 
                         <Divider />
 


### PR DESCRIPTION
## Résumé

- **Entités backend** : `AvoirEntity` (cycle de vie BROUILLON → EMIS → REMBOURSE / ANNULE), `AvoirLigneEntity` pour les lignes de l'avoir, `VentePaiementEntity` pour les paiements multiples sur une facture (modes : CHEQUE, VIREMENT, CARTE, ESPÈCES, AVOIR)
- **API REST** `/avoirs` : CRUD complet, actions métier (émettre, rembourser, annuler), envoi d'email, et génération d'avoir depuis une facture (`POST /avoirs/from-vente/{id}`)
- **Paiements multiples** : le champ `modePaiement` unique est remplacé par une liste de `VentePaiementEntity` gérée via des endpoints dédiés (`POST/DELETE /ventes/{id}/paiements`)
- **Application d'un avoir** : un avoir émis peut être utilisé comme moyen de paiement (tout ou partie) avec suivi du solde restant via `montantUtilise`
- **chantier-ui** : nouvelle page *Avoirs* (filtres, création/édition, actions statut, envoi email, application sur facture, génération depuis facture) et onglet *Paiements* dans la fiche vente
- **client-ui** : nouvelle page *Mes avoirs* (lecture seule, détail, impression) et affichage des paiements dans *Mes factures*
- **Template email** de type `AVOIR` ajouté
- **Harmonisation des en-têtes** des vues principales (comptoir, avoirs, annonces, campagnes) : barre de recherche + bouton "+" alignés sur le pattern standard ; ajout d'une recherche client-side sur les pages avoirs, annonces et campagnes

## Plan de test

- [ ] Créer un avoir en brouillon pour un client, vérifier la sauvegarde des lignes et le calcul des totaux
- [ ] Émettre l'avoir (statut → EMIS), vérifier le solde restant affiché
- [ ] Appliquer l'avoir (partiellement puis totalement) sur une facture FACTURE_PRETE, vérifier la mise à jour de \`montantUtilise\`
- [ ] Supprimer un paiement de type AVOIR et vérifier la restauration du solde
- [ ] Générer un avoir depuis une facture et vérifier que les lignes reprennent bien les forfaits, services et produits
- [ ] Rembourser puis annuler un avoir, vérifier les transitions de statut
- [ ] Vérifier la page *Mes avoirs* côté client-ui (lecture seule, détail, impression)
- [ ] Vérifier l'envoi d'email pour un avoir émis
- [ ] Vérifier la cohérence visuelle des en-têtes (barre de recherche + bouton "+") sur comptoir, avoirs, annonces et campagnes
- [ ] Tester la recherche client-side sur avoirs, annonces et campagnes