### PR TITLE
feat: tri, filtres et navigation par clic sur les tableaux

### DIFF
--- a/chantier-ui/package-lock.json
+++ b/chantier-ui/package-lock.json
@@ -595,9 +595,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -742,7 +742,7 @@
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1030,6 +1030,22 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz",
+      "integrity": "sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2432,18 +2448,19 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
-      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.3.tgz",
+      "integrity": "sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.0",
+        "@babel/compat-data": "^7.29.3",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.3",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
@@ -7340,9 +7357,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.24",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -9425,9 +9442,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.345",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
-      "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -15691,9 +15708,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -16387,9 +16404,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",

--- a/chantier-ui/src/annonces.tsx
+++ b/chantier-ui/src/annonces.tsx
@@ -256,34 +256,54 @@ export default function Annonces() {
     };
 
     const columns = [
-        { title: 'Titre', dataIndex: 'titre', key: 'titre' },
+        { title: 'Titre', dataIndex: 'titre', key: 'titre', sorter: (a: Annonce, b: Annonce) => (a.titre || '').localeCompare(b.titre || '') },
         {
             title: 'Client',
             key: 'client',
             render: (_: unknown, record: Annonce) => clientLabel(record.client),
+            sorter: (a: Annonce, b: Annonce) => clientLabel(a.client).localeCompare(clientLabel(b.client)),
+            filters: Array.from(
+                new Map(
+                    annonces
+                        .filter(a => a.client)
+                        .map(a => [a.client!.id, { text: clientLabel(a.client), value: a.client!.id }])
+                ).values()
+            ),
+            onFilter: (value: unknown, record: Annonce) => record.client?.id === value,
         },
         {
             title: 'Bateau',
             key: 'bateau',
             render: (_: unknown, record: Annonce) => bateauLabel(record.bateau),
+            sorter: (a: Annonce, b: Annonce) => bateauLabel(a.bateau).localeCompare(bateauLabel(b.bateau)),
         },
         {
             title: 'Prix',
             dataIndex: 'prix',
             key: 'prix',
+            sorter: (a: Annonce, b: Annonce) => (a.prix || 0) - (b.prix || 0),
             render: (val: number) => formatEuro(val),
         },
-        { title: 'Contact', dataIndex: 'contact', key: 'contact' },
-        { title: 'Telephone', dataIndex: 'telephone', key: 'telephone' },
+        { title: 'Contact', dataIndex: 'contact', key: 'contact', sorter: (a: Annonce, b: Annonce) => (a.contact || '').localeCompare(b.contact || '') },
+        { title: 'Telephone', dataIndex: 'telephone', key: 'telephone', sorter: (a: Annonce, b: Annonce) => (a.telephone || '').localeCompare(b.telephone || '') },
         {
             title: 'Date',
             dataIndex: 'dateCreation',
             key: 'dateCreation',
+            sorter: (a: Annonce, b: Annonce) => (a.dateCreation || '').localeCompare(b.dateCreation || ''),
             render: (val: string) => formatDate(val),
         },
         {
             title: 'Diffusion',
             key: 'publications',
+            filters: [
+                ...plateformes.map(pf => ({ text: pf.label, value: pf.key })),
+                { text: 'Non diffusée', value: '__none__' },
+            ],
+            onFilter: (value: unknown, record: Annonce) => {
+                if (value === '__none__') return (record.publications || []).length === 0;
+                return (record.publications || []).includes(value as string);
+            },
             render: (_: unknown, record: Annonce) => {
                 const pubs = record.publications || [];
                 if (pubs.length === 0) return <Tag>Non diffusee</Tag>;
@@ -301,6 +321,13 @@ export default function Annonces() {
             title: 'Statut',
             dataIndex: 'status',
             key: 'status',
+            sorter: (a: Annonce, b: Annonce) => (a.status || '').localeCompare(b.status || ''),
+            filters: [
+                { text: 'Active', value: 'ACTIVE' },
+                { text: 'Vendu', value: 'VENDU' },
+                { text: 'Expiree', value: 'EXPIRE' },
+            ],
+            onFilter: (value: unknown, record: Annonce) => record.status === value,
             render: (val: string) => <Tag color={statusColor[val]}>{statusLabel[val] || val}</Tag>,
         },
         {
@@ -354,6 +381,13 @@ export default function Annonces() {
                 loading={loading}
                 pagination={{ pageSize: 10 }}
                 bordered
+                onRow={(record) => ({
+                    onClick: (e) => {
+                        if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                        openEdit(record);
+                    },
+                    style: { cursor: 'pointer' },
+                })}
             />
 
             {/* Create / Edit modal */}

--- a/chantier-ui/src/avoirs.tsx
+++ b/chantier-ui/src/avoirs.tsx
@@ -434,16 +434,25 @@ export default function Avoirs() {
         });
     })();
 
+    const clientFilters = Array.from(
+        new Map(avoirs.filter((a) => a.client).map((a) => [a.client!.id, a.client!])).values()
+    ).map((c) => ({ text: `${c.prenom ?? ''} ${c.nom}`.trim(), value: c.id }));
+
     const columns = [
         {
             title: '#',
             dataIndex: 'id',
             width: 60,
+            sorter: (a: AvoirEntity, b: AvoirEntity) => (a.id || 0) - (b.id || 0),
             render: (v: number) => `#${v}`,
         },
         {
             title: 'Client',
             key: 'client',
+            sorter: (a: AvoirEntity, b: AvoirEntity) => (a.client?.nom || '').localeCompare(b.client?.nom || ''),
+            filters: clientFilters,
+            filterSearch: true,
+            onFilter: (value: unknown, r: AvoirEntity) => r.client?.id === value,
             render: (_: unknown, r: AvoirEntity) =>
                 r.client ? `${r.client.prenom ?? ''} ${r.client.nom}`.trim() : '-',
         },
@@ -451,17 +460,22 @@ export default function Avoirs() {
             title: 'Facture liée',
             key: 'vente',
             width: 110,
+            sorter: (a: AvoirEntity, b: AvoirEntity) => (a.vente?.id || 0) - (b.vente?.id || 0),
             render: (_: unknown, r: AvoirEntity) => r.vente ? `#${r.vente.id}` : '-',
         },
         {
             title: 'Motif',
             dataIndex: 'motif',
             ellipsis: true,
+            sorter: (a: AvoirEntity, b: AvoirEntity) => (a.motif || '').localeCompare(b.motif || ''),
         },
         {
             title: 'Statut',
             dataIndex: 'status',
             width: 120,
+            sorter: (a: AvoirEntity, b: AvoirEntity) => (a.status || '').localeCompare(b.status || ''),
+            filters: Object.entries(STATUS_LABEL).map(([k, v]) => ({ text: v, value: k })),
+            onFilter: (value: unknown, r: AvoirEntity) => r.status === value,
             render: (v: string) => <Tag color={STATUS_COLOR[v] ?? 'default'}>{STATUS_LABEL[v] ?? v}</Tag>,
         },
         {
@@ -469,6 +483,7 @@ export default function Avoirs() {
             dataIndex: 'montantTTC',
             width: 130,
             align: 'right' as const,
+            sorter: (a: AvoirEntity, b: AvoirEntity) => (a.montantTTC || 0) - (b.montantTTC || 0),
             render: (v: number) => formatEuro(v),
         },
         {
@@ -476,6 +491,7 @@ export default function Avoirs() {
             key: 'solde',
             width: 130,
             align: 'right' as const,
+            sorter: (a: AvoirEntity, b: AvoirEntity) => ((a.montantTTC ?? 0) - (a.montantUtilise ?? 0)) - ((b.montantTTC ?? 0) - (b.montantUtilise ?? 0)),
             render: (_: unknown, r: AvoirEntity) => {
                 const restant = Math.round(((r.montantTTC ?? 0) - (r.montantUtilise ?? 0)) * 100) / 100;
                 const color = restant <= 0.005 ? '#8c8c8c' : restant < (r.montantTTC ?? 0) ? '#faad14' : undefined;
@@ -486,6 +502,7 @@ export default function Avoirs() {
             title: 'Date émission',
             dataIndex: 'dateEmission',
             width: 120,
+            sorter: (a: AvoirEntity, b: AvoirEntity) => (a.dateEmission || '').localeCompare(b.dateEmission || ''),
             render: (v: string) => formatDate(v),
         },
         {
@@ -679,6 +696,13 @@ export default function Avoirs() {
                 columns={columns}
                 pagination={{ pageSize: 15 }}
                 bordered
+                onRow={(record) => ({
+                    onClick: (e) => {
+                        if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                        openEdit(record);
+                    },
+                    style: { cursor: 'pointer' },
+                })}
             />
 
             {/* Modal création / édition */}

--- a/chantier-ui/src/campagnes.tsx
+++ b/chantier-ui/src/campagnes.tsx
@@ -278,17 +278,23 @@ export default function Campagnes() {
     };
 
     const columns = [
-        { title: 'Nom', dataIndex: 'nom', key: 'nom' },
+        { title: 'Nom', dataIndex: 'nom', key: 'nom', sorter: (a: Campagne, b: Campagne) => (a.nom || '').localeCompare(b.nom || '') },
         {
             title: 'Canal',
             dataIndex: 'canal',
             key: 'canal',
+            sorter: (a: Campagne, b: Campagne) => (a.canal || '').localeCompare(b.canal || ''),
+            filters: canalOptions.map((o) => ({ text: o.label, value: o.value })),
+            onFilter: (value: unknown, record: Campagne) => record.canal === value,
             render: (val: string) => <Tag color={val === 'EMAIL' ? 'blue' : 'purple'}>{canalLabel[val] || val}</Tag>,
         },
         {
             title: 'Cible',
             dataIndex: 'cible',
             key: 'cible',
+            sorter: (a: Campagne, b: Campagne) => (a.cible || '').localeCompare(b.cible || ''),
+            filters: cibleOptions.map((o) => ({ text: o.label, value: o.value })),
+            onFilter: (value: unknown, record: Campagne) => record.cible === value,
             render: (val: string, record: Campagne) => {
                 const label = cibleLabel[val] || val;
                 return record.cibleFiltre ? `${label} : ${record.cibleFiltre}` : label;
@@ -298,18 +304,23 @@ export default function Campagnes() {
             title: 'Statut',
             dataIndex: 'statut',
             key: 'statut',
+            sorter: (a: Campagne, b: Campagne) => (a.statut || '').localeCompare(b.statut || ''),
+            filters: Object.entries(statutLabel).map(([value, text]) => ({ text, value })),
+            onFilter: (value: unknown, record: Campagne) => record.statut === value,
             render: (val: string) => <Tag color={statutColor[val]}>{statutLabel[val] || val}</Tag>,
         },
         {
             title: 'Destinataires',
             dataIndex: 'nombreDestinataires',
             key: 'nombreDestinataires',
+            sorter: (a: Campagne, b: Campagne) => (a.nombreDestinataires || 0) - (b.nombreDestinataires || 0),
             render: (val: number, record: Campagne) => record.statut === 'ENVOYEE' ? val : '-',
         },
         {
             title: 'Date envoi',
             dataIndex: 'dateEnvoi',
             key: 'dateEnvoi',
+            sorter: (a: Campagne, b: Campagne) => (a.dateEnvoi || a.dateProgrammee || '').localeCompare(b.dateEnvoi || b.dateProgrammee || ''),
             render: (val: string, record: Campagne) => {
                 if (record.statut === 'PROGRAMMEE' && record.dateProgrammee) {
                     return <>Programmé pour le {formatDate(record.dateProgrammee)}</>;
@@ -406,6 +417,13 @@ export default function Campagnes() {
                 loading={loading}
                 pagination={{ pageSize: 10 }}
                 bordered
+                onRow={(record) => ({
+                    onClick: (e) => {
+                        if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                        openEdit(record);
+                    },
+                    style: { cursor: 'pointer' },
+                })}
             />
 
             <Modal

--- a/chantier-ui/src/catalogue-bateaux.tsx
+++ b/chantier-ui/src/catalogue-bateaux.tsx
@@ -248,6 +248,8 @@ const CatalogueBateaux: React.FC = () => {
             title: 'Marque',
             dataIndex: 'marque',
             sorter: (a,b) => a.marque.localeCompare(b.marque),
+            filters: marqueOptions.map(m => ({ text: m.value, value: m.value })),
+            onFilter: (value, record) => record.marque === value,
         },
         {
             title: 'Modèle',
@@ -272,6 +274,7 @@ const CatalogueBateaux: React.FC = () => {
         {
             title: 'Evaluation',
             dataIndex: 'evaluation',
+            sorter: (a, b) => (a.evaluation || 0) - (b.evaluation || 0),
             render: (_,record) => ( <Rate defaultValue={record.evaluation} disabled={true} /> )
         },
         {
@@ -363,6 +366,13 @@ const CatalogueBateaux: React.FC = () => {
                         loading={loading}
                         pagination={{ pageSize: 10 }}
                         bordered
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                openModal(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                     <Modal
                         title={isEdit ? 'Modifier un bateau' : 'Ajouter un bateau'}

--- a/chantier-ui/src/catalogue-helices.tsx
+++ b/chantier-ui/src/catalogue-helices.tsx
@@ -298,6 +298,8 @@ const HeliceCatalogueView: React.FC = () => {
     const columns = [
         { title: 'Marque', dataIndex: 'marque', key: 'marque',
             sorter: (a, b) => a.marque.localeCompare(b.marque),
+            filters: [...new Set(helices.map(h => h.marque))].map(marque => ({ text: marque, value: marque })),
+            onFilter: (value, record) => record.marque === value,
         },
         { title: 'Modèle', dataIndex: 'modele', key: 'modele',
             render: (_, record) => (
@@ -389,7 +391,19 @@ const HeliceCatalogueView: React.FC = () => {
             </Row>
             <Row gutter={[16, 16]}>
                 <Col span={24}>
-                    <Table rowKey="id" columns={columns} dataSource={helices} loading={loading} />
+                    <Table
+                        rowKey="id"
+                        columns={columns}
+                        dataSource={helices}
+                        loading={loading}
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                openEditModal(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
+                    />
                     <Modal
                         open={modalOpen}
                         title={modalMode === 'edit' ? 'Modifier une Hélice' : 'Nouvelle Hélice'}

--- a/chantier-ui/src/catalogue-moteurs.tsx
+++ b/chantier-ui/src/catalogue-moteurs.tsx
@@ -310,6 +310,8 @@ const MoteurCatalogue = () => {
       title: 'Marque',
       dataIndex: 'marque',
       sorter: (a, b) => a.marque.localeCompare(b.marque),
+      filters: Array.from(new Set(moteurs.map((m) => m.marque).filter(Boolean))).map((marque) => ({ text: marque, value: marque })),
+      onFilter: (value, record) => record.marque === value,
     },
     {
       title: 'Modèle',
@@ -431,6 +433,13 @@ const MoteurCatalogue = () => {
             loading={loading}
             pagination={{ pageSize: 10 }}
             bordered
+            onRow={(record) => ({
+              onClick: (e) => {
+                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                openModal(record);
+              },
+              style: { cursor: 'pointer' },
+            })}
           />
           <Modal
             open={modalVisible}

--- a/chantier-ui/src/catalogue-produits.tsx
+++ b/chantier-ui/src/catalogue-produits.tsx
@@ -172,6 +172,8 @@ const CatalogueProduits: React.FC = () => {
         {
             title: 'Marque',
             dataIndex: 'marque',
+            filters: marqueOptions.map(o => ({ text: o.value, value: o.value })),
+            onFilter: (value, record) => record.marque === value,
             sorter: (a: ProduitCatalogueEntity, b: ProduitCatalogueEntity) => (a.marque || '').localeCompare(b.marque || ''),
         },
         {
@@ -294,6 +296,13 @@ const CatalogueProduits: React.FC = () => {
                             loading={loading}
                             pagination={{ pageSize: 10 }}
                             bordered
+                            onRow={(record) => ({
+                                onClick: (e) => {
+                                    if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                    openModal(record);
+                                },
+                                style: { cursor: 'pointer' },
+                            })}
                         />
                         <Modal
                             title={isEdit ? 'Modifier un produit' : 'Ajouter un produit'}

--- a/chantier-ui/src/catalogue-remorques.tsx
+++ b/chantier-ui/src/catalogue-remorques.tsx
@@ -257,18 +257,27 @@ const RemorqueCatalogue: React.FC = () => {
   };
 
   const columns = [
-    { title: "Marque", dataIndex: "marque", key: "marque" },
-    { title: "Modèle", dataIndex: "modele", key: "modele" },
+    {
+      title: "Marque",
+      dataIndex: "marque",
+      key: "marque",
+      sorter: (a: any, b: any) => (a.marque || '').localeCompare(b.marque || ''),
+      filters: [...new Set(remorques.map((r: any) => r.marque).filter(Boolean))].map((m) => ({ text: m, value: m })),
+      onFilter: (value: any, record: any) => record.marque === value,
+      filterSearch: true,
+    },
+    { title: "Modèle", dataIndex: "modele", key: "modele", sorter: (a: any, b: any) => (a.modele || '').localeCompare(b.modele || '') },
     {
       title: "Évaluation",
       dataIndex: "evaluation",
       key: "evaluation",
+      sorter: (a: any, b: any) => (a.evaluation || 0) - (b.evaluation || 0),
       render: (rate: number) => <Rate allowHalf disabled value={rate} />,
       width: 130,
     },
-    { title: "Longueur", dataIndex: "longueur", key: "longueur" },
-    { title: "Stock", dataIndex: "stock", key: "stock" },
-    { title: "Prix TTC", dataIndex: "prixVenteTTC", key: "prixVenteTTC" },
+    { title: "Longueur", dataIndex: "longueur", key: "longueur", sorter: (a: any, b: any) => (a.longueur || 0) - (b.longueur || 0) },
+    { title: "Stock", dataIndex: "stock", key: "stock", sorter: (a: any, b: any) => (a.stock || 0) - (b.stock || 0) },
+    { title: "Prix TTC", dataIndex: "prixVenteTTC", key: "prixVenteTTC", sorter: (a: any, b: any) => (a.prixVenteTTC || 0) - (b.prixVenteTTC || 0) },
     {
       title: "Actions",
       key: "actions",
@@ -324,6 +333,13 @@ const RemorqueCatalogue: React.FC = () => {
             loading={loading}
             pagination={{ pageSize: 10 }}
             bordered
+            onRow={(record) => ({
+              onClick: (e) => {
+                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                openModal(record);
+              },
+              style: { cursor: 'pointer' },
+            })}
           />
         </Col>
       </Row>

--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -436,11 +436,13 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
     { title: "Immatriculation", dataIndex: "immatriculation", key: "immatriculation", sorter: (a, b) => a.immatriculation.localeCompare(b.immatriculation) },
     { title: "Propriétaires", dataIndex: "proprietaires", key: "proprietaires",
       render: (proprietaires: any[]) => (proprietaires && proprietaires.length ? proprietaires.map(p => (p.prenom + " " + p.nom)).join(", ") : ""),
+      sorter: (a, b) => (a.proprietaires?.[0]?.nom || '').localeCompare(b.proprietaires?.[0]?.nom || ''),
       filters: clients.map((client: any) => ({ text: `${client.prenom} ${client.nom}`, value: client.id })),
       onFilter: (value, record) => record.proprietaires?.some((p: any) => p.id === value),
     },
     { title: "Modèle", dataIndex: "modele", key: "modele",
       render: (modele: any) => { if (!modele) return ""; const a = formatAnnee(modele.anneeDebut, modele.anneeFin); return `${modele.marque} ${modele.modele}${a ? ` (${a})` : ''}`; },
+      sorter: (a, b) => (a.modele?.marque || '').localeCompare(b.modele?.marque || '') || (a.modele?.modele || '').localeCompare(b.modele?.modele || ''),
       filters: bateauxCatalogue.map((bateau) => { const a = formatAnnee(bateau.anneeDebut, bateau.anneeFin); return { text: `${bateau.marque} ${bateau.modele}${a ? ` (${a})` : ''}`, value: bateau.id }; }),
       onFilter: (value, record) => record.modele?.id === value,
     },
@@ -481,6 +483,13 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
           dataSource={bateaux}
           bordered
           pagination={{ pageSize: 10 }}
+          onRow={(record) => ({
+            onClick: (e) => {
+              if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+              handleEdit(record);
+            },
+            style: { cursor: 'pointer' },
+          })}
         />
       </Spin>
       <Modal

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -362,6 +362,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
       dataIndex: "proprietaire",
       key: "proprietaire",
       render: (proprietaire: any) => proprietaire ? `${proprietaire.prenom ?? ""} ${proprietaire.nom ?? ""}` : "",
+      sorter: (a, b) => (a.proprietaire?.nom || '').localeCompare(b.proprietaire?.nom || ''),
       filters: clients.map((client: any) => ({ text: `${client.prenom} ${client.nom}`, value: client.id })),
       onFilter: (value, record) => record.proprietaire?.id === value,
     },
@@ -377,6 +378,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
               formatAnnee(modele.anneeDebut, modele.anneeFin) && `(${formatAnnee(modele.anneeDebut, modele.anneeFin)})`
             ].filter(Boolean).join(" ")
           : "",
+      sorter: (a, b) => (a.modele?.marque || '').localeCompare(b.modele?.marque || '') || (a.modele?.modele || '').localeCompare(b.modele?.modele || ''),
       filters: catalogueMoteurs.map((modele) => { const a = formatAnnee(modele.anneeDebut, modele.anneeFin); return { text: `${modele.marque} ${modele.modele}${a ? ` (${a})` : ''}`, value: modele.id }; }),
       onFilter: (value, record) => record.modele?.id === value,
     },
@@ -429,6 +431,13 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
           dataSource={moteurs}
           bordered
           pagination={{ pageSize: 10 }}
+          onRow={(record) => ({
+            onClick: (e) => {
+              if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+              handleEdit(record);
+            },
+            style: { cursor: 'pointer' },
+          })}
         />
       </Spin>
       <Modal

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -240,6 +240,7 @@ function Clients() {
       title: "Type",
       dataIndex: "type",
       key: "type",
+      sorter: (a, b) => (a.type || '').localeCompare(b.type || ''),
       filters: [
         { text: "Particulier", value: "PARTICULIER" },
         { text: "Professionnel", value: "PROFESSIONNEL" },
@@ -248,11 +249,12 @@ function Clients() {
       onFilter: (value, record) => record.type === value,
       render: (type) => (type === "PROFESSIONNEL" ? "Professionnel" : "Particulier"),
     },
-    { title: "Email", dataIndex: "email", key: "email" },
+    { title: "Email", dataIndex: "email", key: "email", sorter: (a, b) => (a.email || '').localeCompare(b.email || '') },
     {
       title: "Canal d'acquisition",
       dataIndex: "canalAcquisition",
       key: "canalAcquisition",
+      sorter: (a, b) => (a.canalAcquisition || '').localeCompare(b.canalAcquisition || ''),
       filters: canalAcquisitionOptions.map((opt) => ({ text: opt.label, value: opt.value })),
       onFilter: (value, record) => record.canalAcquisition === value,
       render: (val) => {
@@ -260,7 +262,7 @@ function Clients() {
         return opt ? <Space>{opt.icon} {opt.label}</Space> : null;
       },
     },
-    { title: "Téléphone", dataIndex: "telephone", key: "telephone" },
+    { title: "Téléphone", dataIndex: "telephone", key: "telephone", sorter: (a, b) => (a.telephone || '').localeCompare(b.telephone || '') },
     {
       title: "Évaluation",
       dataIndex: "evaluation",
@@ -334,6 +336,13 @@ function Clients() {
           dataSource={clients}
           bordered
           pagination={{ pageSize: 10 }}
+          onRow={(record) => ({
+            onClick: (e) => {
+              if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+              handleEdit(record);
+            },
+            style: { cursor: 'pointer' },
+          })}
         />
       </Spin>
 

--- a/chantier-ui/src/commandes-fournisseur.tsx
+++ b/chantier-ui/src/commandes-fournisseur.tsx
@@ -505,6 +505,8 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
           key: "fournisseur",
           render: (_: any, record: CommandeFournisseur) => record.fournisseur?.nom || "-",
           sorter: (a: any, b: any) => (a.fournisseur?.nom || "").localeCompare(b.fournisseur?.nom || ""),
+          filters: Array.from(new Map(commandes.filter((c) => c.fournisseur?.id).map((c) => [c.fournisseur.id, c.fournisseur.nom])).entries()).map(([id, nom]) => ({ text: nom, value: id })),
+          onFilter: (value: any, record: CommandeFournisseur) => record.fournisseur?.id === value,
         }]
       : []),
     {
@@ -521,12 +523,14 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
       render: (val: CommandeFournisseurStatus) => (
         <Tag color={statusColors[val]}>{statusLabels[val] || val}</Tag>
       ),
+      sorter: (a: any, b: any) => (a.status || '').localeCompare(b.status || ''),
       filters: Object.keys(statusLabels).map((k) => ({ text: statusLabels[k as CommandeFournisseurStatus], value: k })),
       onFilter: (value: any, record: any) => record.status === value,
     },
     {
       title: "Nb lignes",
       key: "nbLignes",
+      sorter: (a: any, b: any) => (a.lignes?.length || 0) - (b.lignes?.length || 0),
       render: (_: any, record: CommandeFournisseur) => record.lignes?.length || 0,
     },
     {
@@ -575,6 +579,13 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
             loading={loading}
             bordered
             pagination={{ pageSize: 10 }}
+            onRow={(record) => ({
+              onClick: (e) => {
+                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                handleEdit(record);
+              },
+              style: { cursor: 'pointer' },
+            })}
           />
         </Col>
       </Row>

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -1093,21 +1093,48 @@ export default function Comptoir() {
         {
             title: 'Date',
             dataIndex: 'date',
+            sorter: (a: VenteEntity, b: VenteEntity) => (a.date || '').localeCompare(b.date || ''),
             render: (value: string) => value || '-'
         },
         {
             title: 'Statut',
             dataIndex: 'status',
+            sorter: (a: VenteEntity, b: VenteEntity) => (a.status || '').localeCompare(b.status || ''),
+            filters: [
+                { text: statusLabel.DEVIS, value: 'DEVIS' },
+                { text: statusLabel.FACTURE_EN_ATTENTE, value: 'FACTURE_EN_ATTENTE' },
+                { text: statusLabel.FACTURE_PRETE, value: 'FACTURE_PRETE' },
+                { text: statusLabel.FACTURE_PAYEE, value: 'FACTURE_PAYEE' },
+            ],
+            onFilter: (value: unknown, record: VenteEntity) => record.status === value,
             render: (value: VenteStatus) => <Tag color={statusColor[value] || 'default'}>{statusLabel[value] || value}</Tag>
         },
         {
             title: 'Client',
             dataIndex: 'client',
+            sorter: (a: VenteEntity, b: VenteEntity) => getClientLabel(a.client).localeCompare(getClientLabel(b.client)),
+            filters: Array.from(new Map(ventes.filter((v) => v.client).map((v) => [v.client!.id, getClientLabel(v.client)])).entries())
+                .map(([, label]) => ({ text: label, value: label }))
+                .sort((a, b) => a.text.localeCompare(b.text, 'fr')),
+            onFilter: (value: unknown, record: VenteEntity) => getClientLabel(record.client) === value,
             render: (value: ClientEntity) => getClientLabel(value)
         },
         {
             title: 'Mode paiement',
             key: 'modePaiement',
+            sorter: (a: VenteEntity, b: VenteEntity) => (a.modePaiement || '').localeCompare(b.modePaiement || ''),
+            filters: [
+                { text: 'Chèque', value: 'CHEQUE' },
+                { text: 'Virement', value: 'VIREMENT' },
+                { text: 'Carte', value: 'CARTE' },
+                { text: 'Espèces', value: 'ESPÈCES' },
+                { text: 'Avoir', value: 'AVOIR' },
+            ],
+            onFilter: (value: unknown, record: VenteEntity) => {
+                const ps = record.paiements ?? [];
+                if (ps.length > 0) return ps.some((p) => p.mode === value);
+                return record.modePaiement === value;
+            },
             render: (_: unknown, record: VenteEntity) => {
                 const modeLabels: Record<string, string> = { CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte', 'ESPÈCES': 'Espèces', AVOIR: 'Avoir' };
                 const ps = record.paiements ?? [];
@@ -1171,6 +1198,13 @@ export default function Comptoir() {
                 loading={loading}
                 pagination={{ pageSize: 10 }}
                 bordered
+                onRow={(record) => ({
+                    onClick: (e) => {
+                        if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                        openModal(record);
+                    },
+                    style: { cursor: 'pointer' },
+                })}
             />
 
             <Modal
@@ -1422,15 +1456,16 @@ export default function Comptoir() {
                                     dataSource={ps}
                                     locale={{ emptyText: 'Aucun paiement enregistré' }}
                                     columns={[
-                                        { title: 'Mode', dataIndex: 'mode', width: 110, render: (v: string) => modeLabels[v] ?? v },
+                                        { title: 'Mode', dataIndex: 'mode', width: 110, sorter: (a: VentePaiement, b: VentePaiement) => (a.mode || '').localeCompare(b.mode || ''), render: (v: string) => modeLabels[v] ?? v },
                                         {
                                             title: 'Avoir',
                                             key: 'avoir',
+                                            sorter: (a: VentePaiement, b: VentePaiement) => (a.avoirId || 0) - (b.avoirId || 0),
                                             render: (_: unknown, r: VentePaiement) =>
                                                 r.avoirId ? `#${r.avoirId} — ${r.avoirMotif ?? ''}` : '-',
                                         },
-                                        { title: 'Montant', dataIndex: 'montant', width: 120, align: 'right' as const, render: (v: number) => formatEuro(v) },
-                                        { title: 'Notes', dataIndex: 'notes', render: (v: string) => v ?? '-' },
+                                        { title: 'Montant', dataIndex: 'montant', width: 120, align: 'right' as const, sorter: (a: VentePaiement, b: VentePaiement) => (a.montant || 0) - (b.montant || 0), render: (v: number) => formatEuro(v) },
+                                        { title: 'Notes', dataIndex: 'notes', sorter: (a: VentePaiement, b: VentePaiement) => (a.notes || '').localeCompare(b.notes || ''), render: (v: string) => v ?? '-' },
                                         {
                                             title: '',
                                             key: 'remove',

--- a/chantier-ui/src/dashboard.tsx
+++ b/chantier-ui/src/dashboard.tsx
@@ -101,32 +101,38 @@ const warningColumns = [
         title: 'Vente',
         dataIndex: 'venteId',
         key: 'venteId',
+        sorter: (a: PlanningWarning, b: PlanningWarning) => (a.venteId || 0) - (b.venteId || 0),
         render: (v: number) => `#${v}`,
     },
     {
         title: 'Nom',
         dataIndex: 'nom',
         key: 'nom',
+        sorter: (a: PlanningWarning, b: PlanningWarning) => (a.nom || '').localeCompare(b.nom || ''),
     },
     {
         title: 'Type',
         dataIndex: 'type',
         key: 'type',
+        sorter: (a: PlanningWarning, b: PlanningWarning) => (a.type || '').localeCompare(b.type || ''),
         render: (v: string) => <Tag color={v === 'forfait' ? 'purple' : 'geekblue'}>{v === 'forfait' ? 'Forfait' : 'Service'}</Tag>,
     },
     {
         title: 'Technicien',
         dataIndex: 'technicien',
         key: 'technicien',
+        sorter: (a: PlanningWarning, b: PlanningWarning) => (a.technicien || '').localeCompare(b.technicien || ''),
     },
     {
         title: 'Date planification',
         dataIndex: 'datePlanification',
         key: 'datePlanification',
+        sorter: (a: PlanningWarning, b: PlanningWarning) => (a.datePlanification || '').localeCompare(b.datePlanification || ''),
     },
     {
         title: 'Durée',
         key: 'duree',
+        sorter: (a: PlanningWarning, b: PlanningWarning) => (a.dureeReelle || 0) - (b.dureeReelle || 0),
         render: (_: unknown, record: PlanningWarning) => {
             const overrun = record.warning === 'overrun';
             return (
@@ -141,6 +147,7 @@ const warningColumns = [
         title: 'Alerte',
         dataIndex: 'warning',
         key: 'warning',
+        sorter: (a: PlanningWarning, b: PlanningWarning) => (a.warning || '').localeCompare(b.warning || ''),
         render: (v: string) => v === 'late'
             ? <Tag color="volcano"><WarningOutlined /> En retard</Tag>
             : <Tag color="orange"><WarningOutlined /> Dépassement durée</Tag>,
@@ -161,27 +168,32 @@ const interventionColumns = [
     {
         title: 'Client',
         dataIndex: 'client',
-        key: 'client'
+        key: 'client',
+        sorter: (a: InterventionRow, b: InterventionRow) => (a.client || '').localeCompare(b.client || ''),
     },
     {
         title: 'Unite',
         dataIndex: 'unite',
-        key: 'unite'
+        key: 'unite',
+        sorter: (a: InterventionRow, b: InterventionRow) => (a.unite || '').localeCompare(b.unite || ''),
     },
     {
         title: 'Type',
         dataIndex: 'type',
-        key: 'type'
+        key: 'type',
+        sorter: (a: InterventionRow, b: InterventionRow) => (a.type || '').localeCompare(b.type || ''),
     },
     {
         title: 'Technicien',
         dataIndex: 'technicien',
-        key: 'technicien'
+        key: 'technicien',
+        sorter: (a: InterventionRow, b: InterventionRow) => (a.technicien || '').localeCompare(b.technicien || ''),
     },
     {
         title: 'Statut',
         dataIndex: 'statut',
         key: 'statut',
+        sorter: (a: InterventionRow, b: InterventionRow) => (a.statut || '').localeCompare(b.statut || ''),
         render: (value: InterventionRow['statut']) => {
             const color = value === 'Terminee' ? 'green' : value === 'En cours' ? 'blue' : 'orange';
             return <Tag color={color}>{value}</Tag>;

--- a/chantier-ui/src/emails.tsx
+++ b/chantier-ui/src/emails.tsx
@@ -91,12 +91,14 @@ export default function Emails() {
             dataIndex: 'type',
             key: 'type',
             width: 120,
+            sorter: (a, b) => (a.type || '').localeCompare(b.type || ''),
             render: (type) => <Tag color={TYPE_COLORS[type]}>{TYPE_LABELS[type] || type}</Tag>
         },
         {
             title: 'Sujet',
             dataIndex: 'sujet',
-            key: 'sujet'
+            key: 'sujet',
+            sorter: (a, b) => (a.sujet || '').localeCompare(b.sujet || ''),
         },
         {
             title: 'Variables disponibles',
@@ -133,6 +135,13 @@ export default function Emails() {
                         columns={columns}
                         rowKey="id"
                         pagination={false}
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                handleEdit(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                 </Space>
             </Card>

--- a/chantier-ui/src/forfaits.tsx
+++ b/chantier-ui/src/forfaits.tsx
@@ -638,26 +638,19 @@ export default function Forfaits() {
         {
             title: 'Moteurs',
             dataIndex: 'moteursAssocies',
+            sorter: (a: ForfaitEntity, b: ForfaitEntity) => (a.moteursAssocies?.length || 0) - (b.moteursAssocies?.length || 0),
             render: (values: MoteurCatalogueEntity[]) => values?.length || 0
         },
         {
             title: 'Bateaux',
             dataIndex: 'bateauxAssocies',
+            sorter: (a: ForfaitEntity, b: ForfaitEntity) => (a.bateauxAssocies?.length || 0) - (b.bateauxAssocies?.length || 0),
             render: (values: BateauCatalogueEntity[]) => values?.length || 0
-        },
-        {
-            title: 'Produits',
-            dataIndex: 'produits',
-            render: (values: ForfaitProduitEntity[]) => values?.length || 0
-        },
-        {
-            title: "Main d'Oeuvres",
-            dataIndex: 'mainOeuvres',
-            render: (values: ForfaitMainOeuvreEntity[]) => values?.length || 0
         },
         {
             title: 'Fréquence',
             key: 'frequence',
+            sorter: (a: ForfaitEntity, b: ForfaitEntity) => (a.heuresFonctionnement || 0) - (b.heuresFonctionnement || 0) || (a.joursFrequence || 0) - (b.joursFrequence || 0),
             render: (_: unknown, record: ForfaitEntity) =>
                 `${record.heuresFonctionnement || 0}h / ${record.joursFrequence || 0} jours`
         },
@@ -721,6 +714,13 @@ export default function Forfaits() {
                         loading={loading}
                         pagination={{ pageSize: 10 }}
                         bordered
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                openModal(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                 </Col>
             </Row>

--- a/chantier-ui/src/main-oeuvres.tsx
+++ b/chantier-ui/src/main-oeuvres.tsx
@@ -169,6 +169,7 @@ export default function MainOeuvres() {
         {
             title: 'Description',
             dataIndex: 'description',
+            sorter: (a: MainOeuvreEntity, b: MainOeuvreEntity) => (a.description || '').localeCompare(b.description || ''),
             render: (value: string) => value || '-'
         },
         {
@@ -230,6 +231,13 @@ export default function MainOeuvres() {
                         loading={loading}
                         pagination={{ pageSize: 10 }}
                         bordered
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                openModal(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                 </Col>
             </Row>

--- a/chantier-ui/src/planning.tsx
+++ b/chantier-ui/src/planning.tsx
@@ -755,16 +755,19 @@ export default function Planning() {
         {
             title: 'Bateau',
             key: 'bateau',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => (a.item.bateauNom || '').localeCompare(b.item.bateauNom || ''),
             render: (_: unknown, record: PlanningItemRow) => record.item.bateauNom || '-'
         },
         {
             title: 'Client',
             dataIndex: 'client',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => getClientLabel(a.vente.client).localeCompare(getClientLabel(b.vente.client)),
             render: (_: unknown, record: PlanningItemRow) => getClientLabel(record.vente.client)
         },
         {
             title: 'Type',
             key: 'itemType',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => (a.item.type || '').localeCompare(b.item.type || ''),
             render: (_: unknown, record: PlanningItemRow) => (
                 <Tag color={record.item.type === 'forfait' ? 'purple' : 'geekblue'}>
                     {record.item.type === 'forfait' ? 'Forfait' : 'Service'}
@@ -774,6 +777,7 @@ export default function Planning() {
         {
             title: 'Statut',
             dataIndex: 'itemStatus',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => (a.item.status || '').localeCompare(b.item.status || ''),
             render: (_: unknown, record: PlanningItemRow) => {
                 const status = record.item.status || 'EN_ATTENTE';
                 const label = statusOptions.find((item) => item.value === status)?.label || status;
@@ -783,21 +787,25 @@ export default function Planning() {
         {
             title: 'Nom',
             key: 'itemName',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => (a.item.nom || '').localeCompare(b.item.nom || ''),
             render: (_: unknown, record: PlanningItemRow) => record.item.nom || '(Sans nom)'
         },
         {
             title: 'Debut',
             key: 'dateDebut',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => (a.item.dateDebut || '').localeCompare(b.item.dateDebut || ''),
             render: (_: unknown, record: PlanningItemRow) => record.item.dateDebut ? dayjs(record.item.dateDebut).format('DD/MM/YYYY HH:mm') : '-'
         },
         {
             title: 'Fin',
             key: 'dateFin',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => (a.item.dateFin || '').localeCompare(b.item.dateFin || ''),
             render: (_: unknown, record: PlanningItemRow) => record.item.dateFin ? dayjs(record.item.dateFin).format('DD/MM/YYYY HH:mm') : '-'
         },
         {
             title: 'Durée',
             key: 'duree',
+            sorter: (a: PlanningItemRow, b: PlanningItemRow) => (a.item.dureeReelle || 0) - (b.item.dureeReelle || 0),
             render: (_: unknown, record: PlanningItemRow) => {
                 const estimee = record.item.dureeEstimee;
                 const reelle = record.item.dureeReelle;
@@ -1267,6 +1275,11 @@ export default function Planning() {
                                     {
                                         title: 'Techniciens',
                                         key: 'techniciens',
+                                        sorter: (a: PlanningItemRow, b: PlanningItemRow) => {
+                                            const aNom = (a.item.techniciens || [])[0]?.nom || '';
+                                            const bNom = (b.item.techniciens || [])[0]?.nom || '';
+                                            return aNom.localeCompare(bNom);
+                                        },
                                         render: (_: unknown, record: PlanningItemRow) => {
                                             const ts = record.item.techniciens || [];
                                             return ts.length > 0

--- a/chantier-ui/src/sequence-emails.tsx
+++ b/chantier-ui/src/sequence-emails.tsx
@@ -168,17 +168,20 @@ function SequenceTable({ cible, variables }: { cible: string; variables: string 
             dataIndex: 'delaiJours',
             key: 'delaiJours',
             width: 120,
+            sorter: (a: Etape, b: Etape) => a.delaiJours - b.delaiJours,
             render: (val: number) => val === 0 ? <Tag color="green">Immédiat</Tag> : <Tag color="blue">J+{val}</Tag>
         },
         {
             title: 'Sujet',
             dataIndex: 'sujet',
-            key: 'sujet'
+            key: 'sujet',
+            sorter: (a: Etape, b: Etape) => (a.sujet || '').localeCompare(b.sujet || ''),
         },
         {
             title: 'Description',
             dataIndex: 'description',
             key: 'description',
+            sorter: (a: Etape, b: Etape) => (a.description || '').localeCompare(b.description || ''),
             render: (desc: string) => <span style={{ fontSize: '0.85em', opacity: 0.7 }}>{desc}</span>
         },
         {
@@ -186,6 +189,7 @@ function SequenceTable({ cible, variables }: { cible: string; variables: string 
             dataIndex: 'actif',
             key: 'actif',
             width: 80,
+            sorter: (a: Etape, b: Etape) => (a.actif === b.actif ? 0 : a.actif ? -1 : 1),
             render: (actif: boolean, record: Etape) => (
                 <Switch checked={actif} onChange={() => handleToggleActif(record)} size="small" />
             )
@@ -223,6 +227,13 @@ function SequenceTable({ cible, variables }: { cible: string; variables: string 
                         columns={columns}
                         rowKey="id"
                         pagination={false}
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                handleEdit(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                 </Spin>
             </Space>

--- a/chantier-ui/src/services.tsx
+++ b/chantier-ui/src/services.tsx
@@ -460,16 +460,19 @@ export default function Services() {
         {
             title: 'Description',
             dataIndex: 'description',
+            sorter: (a: ServiceEntity, b: ServiceEntity) => (a.description || '').localeCompare(b.description || ''),
             render: (value: string) => value || '-'
         },
         {
             title: "Main d'Oeuvres",
             dataIndex: 'mainOeuvres',
+            sorter: (a: ServiceEntity, b: ServiceEntity) => (a.mainOeuvres?.length || 0) - (b.mainOeuvres?.length || 0),
             render: (values: ServiceMainOeuvreEntity[]) => values?.length || 0
         },
         {
             title: 'Produits',
             dataIndex: 'produits',
+            sorter: (a: ServiceEntity, b: ServiceEntity) => (a.produits?.length || 0) - (b.produits?.length || 0),
             render: (values: ServiceProduitEntity[]) => values?.length || 0
         },
         {
@@ -531,6 +534,13 @@ export default function Services() {
                         loading={loading}
                         pagination={{ pageSize: 10 }}
                         bordered
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                openModal(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                 </Col>
             </Row>

--- a/chantier-ui/src/techniciens.tsx
+++ b/chantier-ui/src/techniciens.tsx
@@ -230,11 +230,13 @@ const Techniciens: React.FC = () => {
             title: 'Téléphone',
             dataIndex: 'telephone',
             key: 'telephone',
+            sorter: (a: TechnicienEntity, b: TechnicienEntity) => (a.telephone || '').localeCompare(b.telephone || ''),
         },
         {
             title: 'Couleur',
             dataIndex: 'couleur',
             key: 'couleur',
+            sorter: (a: TechnicienEntity, b: TechnicienEntity) => (a.couleur || '').localeCompare(b.couleur || ''),
             render: (couleur?: string) => {
                 const color = couleur || defaultTechnicien.couleur;
                 return (
@@ -307,6 +309,13 @@ const Techniciens: React.FC = () => {
                             loading={loading}
                             pagination={{ pageSize: 10 }}
                             bordered
+                            onRow={(record) => ({
+                                onClick: (e) => {
+                                    if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                    openModal(record);
+                                },
+                                style: { cursor: 'pointer' },
+                            })}
                         />
                         <Modal
                             title={isEdit ? 'Modifier un technicien' : 'Ajouter un technicien'}

--- a/chantier-ui/src/utilisateurs.tsx
+++ b/chantier-ui/src/utilisateurs.tsx
@@ -244,6 +244,7 @@ export default function Utilisateurs() {
                           </span>
                       ))
                     : null,
+            sorter: (a, b) => (Array.isArray(a.roles) ? a.roles.join(',') : '').localeCompare(Array.isArray(b.roles) ? b.roles.join(',') : ''),
             filters: USER_ROLES,
             onFilter: (value, record) => record.roles.includes(value),
         },
@@ -309,6 +310,14 @@ export default function Utilisateurs() {
                         dataSource={users}
                         columns={columns}
                         pagination={{ pageSize: 8, showSizeChanger: false }}
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                setEditUser(record);
+                                setModalOpen(true);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                 )}
                 </Col>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -366,10 +366,6 @@ interface VenteFormValues {
     rappel3Jours?: number;
 }
 
-interface SearchFilters {
-    status?: VenteStatus;
-    clientId?: number;
-}
 
 const statusOptions: Array<{ value: VenteStatus; label: string }> = [
     { value: 'DEVIS', label: 'Devis/Ordre de Réparation' },
@@ -504,6 +500,7 @@ export default function Vente() {
     const [catalogueMoteurs, setCatalogueMoteurs] = useState<Array<{ id: number; marque?: string; modele?: string }>>([]);
     const [catalogueRemorques, setCatalogueRemorques] = useState<Array<{ id: number; marque?: string; modele?: string }>>([]);
     const [loading, setLoading] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
     const [modalVisible, setModalVisible] = useState(false);
     const [formDirty, setFormDirty] = useState(false);
     const suppressDirtyRef = React.useRef(false);
@@ -511,8 +508,6 @@ export default function Vente() {
     const [isEdit, setIsEdit] = useState(false);
     const [currentVente, setCurrentVente] = useState<VenteEntity | null>(null);
     const [rappelHistorique, setRappelHistorique] = useState<RappelHistoriqueEntity[]>([]);
-    const [filters, setFilters] = useState<SearchFilters>({});
-    const [searchForm] = Form.useForm<SearchFilters>();
     const [form] = Form.useForm<VenteFormValues>();
     const watchedStatus = Form.useWatch('status', form) as VenteStatus | undefined;
     const watchedBonPourAccord = Form.useWatch('bonPourAccord', form) as boolean | undefined;
@@ -610,6 +605,17 @@ export default function Vente() {
         [clients]
     );
 
+    const filteredVentes = useMemo(() => {
+        if (!searchQuery.trim()) return ventes;
+        const q = searchQuery.toLowerCase();
+        return ventes.filter((v) => {
+            const clientLabel = getClientLabel(v.client).toLowerCase();
+            const date = (v.date || '').toLowerCase();
+            const paiement = (modePaiementOptions.find((o) => o.value === v.modePaiement)?.label || v.modePaiement || '').toLowerCase();
+            return clientLabel.includes(q) || date.includes(q) || paiement.includes(q);
+        });
+    }, [ventes, searchQuery]);
+
     const bateauOptions = useMemo(
         () => bateaux.map((bateau) => ({ value: bateau.id, label: bateau.name || bateau.immatriculation || `Bateau #${bateau.id}` })),
         [bateaux]
@@ -699,19 +705,10 @@ export default function Vente() {
         [techniciens]
     );
 
-    const fetchVentes = async (nextFilters?: SearchFilters) => {
+    const fetchVentes = async () => {
         setLoading(true);
         try {
-            const activeFilters = nextFilters || {};
-            const hasStatus = !!activeFilters.status;
-            const hasClient = activeFilters.clientId !== undefined;
-            const endpoint = hasStatus || hasClient ? '/ventes/search' : '/ventes';
-            const response = await api.get(endpoint, {
-                params: {
-                    ...(hasStatus ? { status: activeFilters.status } : {}),
-                    ...(hasClient ? { clientId: activeFilters.clientId } : {})
-                }
-            });
+            const response = await api.get('/ventes');
             setVentes(response.data || []);
         } catch {
             message.error('Erreur lors du chargement des ventes.');
@@ -1635,7 +1632,7 @@ export default function Vente() {
             }
             setFormDirty(false);
             setTimeout(() => { suppressDirtyRef.current = false; }, 0);
-            fetchVentes(filters);
+            fetchVentes();
         } catch {
             // Les erreurs de validation sont affichees par le formulaire.
         }
@@ -1694,7 +1691,7 @@ export default function Vente() {
         try {
             await api.delete(`/ventes/${id}`);
             message.success('Vente supprimee avec succes');
-            fetchVentes(filters);
+            fetchVentes();
         } catch {
             message.error('Erreur lors de la suppression de la vente.');
         }
@@ -2170,16 +2167,32 @@ export default function Vente() {
         {
             title: 'Date',
             dataIndex: 'date',
+            sorter: (a: VenteEntity, b: VenteEntity) => (a.date || '').localeCompare(b.date || ''),
             render: (value: string) => formatDate(value)
         },
         {
             title: 'Origine',
             dataIndex: 'comptoir',
+            sorter: (a: VenteEntity, b: VenteEntity) => (a.comptoir === b.comptoir ? 0 : a.comptoir ? 1 : -1),
+            filters: [
+                { text: 'Comptoir', value: true },
+                { text: 'Prestation', value: false }
+            ],
+            onFilter: (value: unknown, record: VenteEntity) => !!record.comptoir === value,
             render: (value: boolean) => <Tag color={value ? 'purple' : 'geekblue'}>{value ? 'Comptoir' : 'Prestation'}</Tag>
         },
         {
             title: 'Statut',
             dataIndex: 'status',
+            sorter: (a: VenteEntity, b: VenteEntity) => (a.status || '').localeCompare(b.status || ''),
+            filters: [
+                ...statusOptions.map(opt => ({ text: opt.label, value: opt.value })),
+                { text: 'Bon pour accord', value: 'BPA' }
+            ],
+            onFilter: (value: unknown, record: VenteEntity) => {
+                if (value === 'BPA') return record.status === 'DEVIS' && !!record.bonPourAccord;
+                return record.status === value;
+            },
             render: (value: VenteStatus, record: VenteEntity) => {
                 const label = value === 'DEVIS' && record.bonPourAccord
                     ? 'Bon pour accord'
@@ -2191,26 +2204,36 @@ export default function Vente() {
         {
             title: 'Client',
             dataIndex: 'client',
+            sorter: (a: VenteEntity, b: VenteEntity) => getClientLabel(a.client).localeCompare(getClientLabel(b.client)),
+            filterSearch: true,
+            filters: Array.from(
+                new Map(
+                    ventes
+                        .filter(v => v.client?.id !== undefined)
+                        .map(v => [v.client!.id, { text: getClientLabel(v.client), value: v.client!.id! }])
+                ).values()
+            ).sort((a, b) => (a.text as string).localeCompare(b.text as string)),
+            onFilter: (value: unknown, record: VenteEntity) => record.client?.id === value,
             render: (value: ClientEntity) => getClientLabel(value)
-        },
-        {
-            title: 'Forfaits',
-            dataIndex: 'venteForfaits',
-            render: (values: VenteForfaitEntity[]) => values?.length || 0
-        },
-        {
-            title: 'Services',
-            dataIndex: 'venteServices',
-            render: (values: VenteServiceEntity[]) => values?.length || 0
-        },
-        {
-            title: 'Produits',
-            dataIndex: 'produits',
-            render: (values: ProduitCatalogueEntity[]) => values?.length || 0
         },
         {
             title: 'Relance',
             key: 'relance',
+            filters: [
+                { text: 'Relance 3 envoyée', value: 'rappel3' },
+                { text: 'Relance 2 envoyée', value: 'rappel2' },
+                { text: 'Relance 1 envoyée', value: 'rappel1' },
+                { text: 'En attente', value: 'enAttente' },
+                { text: 'Aucune relance', value: 'aucune' }
+            ],
+            onFilter: (value: unknown, record: VenteEntity) => {
+                if (value === 'rappel3') return !!record.rappel3Envoye;
+                if (value === 'rappel2') return !!record.rappel2Envoye && !record.rappel3Envoye;
+                if (value === 'rappel1') return !!record.rappel1Envoye && !record.rappel2Envoye && !record.rappel3Envoye;
+                if (value === 'enAttente') return !record.rappel1Envoye && !record.rappel2Envoye && !record.rappel3Envoye && !!(record.rappel1Jours || record.rappel2Jours || record.rappel3Jours);
+                if (value === 'aucune') return !record.rappel1Envoye && !record.rappel2Envoye && !record.rappel3Envoye && !(record.rappel1Jours || record.rappel2Jours || record.rappel3Jours);
+                return false;
+            },
             render: (_: unknown, record: VenteEntity) => {
                 if (record.rappel3Envoye) return <Tag color="red">Relance 3 envoyée</Tag>;
                 if (record.rappel2Envoye) return <Tag color="orange">Relance 2 envoyée</Tag>;
@@ -2271,69 +2294,35 @@ export default function Vente() {
 
     return (
         <Card title="Prestations">
-            <Form
-                form={searchForm}
-                layout="vertical"
-                initialValues={{ status: undefined, clientId: undefined }}
-                onFinish={(values) => {
-                    const nextFilters: SearchFilters = {
-                        status: values.status,
-                        clientId: values.clientId
-                    };
-                    setFilters(nextFilters);
-                    fetchVentes(nextFilters);
-                }}
-            >
-                <Row gutter={16} align="bottom">
-                    <Col flex="auto">
-                        <Row gutter={16}>
-                            <Col span={10}>
-                                <Form.Item name="status" label="Statut" style={{ marginBottom: 0 }}>
-                                    <Select allowClear options={statusOptions} placeholder="Tous les statuts" />
-                                </Form.Item>
-                            </Col>
-                            <Col span={14}>
-                                <Form.Item name="clientId" label="Client" style={{ marginBottom: 0 }}>
-                                    <Select
-                                        allowClear
-                                        showSearch
-                                        options={clientOptions}
-                                        filterOption={false}
-                                        onSearch={handleClientSearch}
-                                        notFoundContent={null}
-                                        placeholder="Rechercher un client par prénom ou nom"
-                                    />
-                                </Form.Item>
-                            </Col>
-                        </Row>
-                    </Col>
-                    <Col flex="none" style={{ marginBottom: 0 }}>
-                        <Space>
-                            <Button type="primary" htmlType="submit">Rechercher</Button>
-                            <Button
-                                onClick={() => {
-                                    searchForm.resetFields();
-                                    setFilters({});
-                                    fetchVentes();
-                                }}
-                            >
-                                Reinitialiser
-                            </Button>
-                            <Button type="primary" icon={<PlusCircleOutlined />} onClick={() => openModal()} />
-                        </Space>
-                    </Col>
-                </Row>
-            </Form>
+            <Space style={{ marginBottom: 16 }}>
+                <Input.Search
+                    placeholder="Recherche"
+                    enterButton
+                    allowClear
+                    style={{ width: 600 }}
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onSearch={(value) => setSearchQuery(value)}
+                />
+                <Button type="primary" icon={<PlusCircleOutlined />} onClick={() => openModal()} />
+            </Space>
 
             <Row gutter={[16, 16]} style={{ marginTop: 8 }}>
                 <Col span={24}>
                     <Table
                         rowKey="id"
-                        dataSource={ventes}
+                        dataSource={filteredVentes}
                         columns={columns}
                         loading={loading}
                         pagination={{ pageSize: 10 }}
                         bordered
+                        onRow={(record) => ({
+                            onClick: (e) => {
+                                if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+                                openModal(record);
+                            },
+                            style: { cursor: 'pointer' },
+                        })}
                     />
                 </Col>
             </Row>


### PR DESCRIPTION
## Résumé

- Ajout du **tri par colonne** (`sorter`) sur l'ensemble des tableaux de l'interface (annonces, avoirs, campagnes, catalogues, clients, comptoir, planning, vente, etc.)
- Ajout de **filtres dropdown** sur les colonnes clés (statut, client, canal, mode de paiement, diffusion…)
- Ajout d'un **clic sur les lignes** (`onRow`) pour ouvrir directement la fiche d'édition sans avoir à cliquer le bouton « Modifier »
- Dans la vue **Vente** : remplacement du formulaire de recherche côté serveur par un filtrage texte local (plus simple et sans requête réseau supplémentaire)

## Plan de test

- [x] Vérifier le tri sur chaque colonne concernée (ordre croissant/décroissant)
- [x] Vérifier les filtres dropdown (statut, client, canal…)
- [x] Vérifier qu'un clic sur une ligne ouvre bien la modale d'édition
- [x] Vérifier que les boutons d'action dans les lignes ne déclenchent pas l'ouverture de la modale
- [x] Vérifier la recherche texte dans la vue Vente