### PR TITLE
fix: correction de l'URL de retour lors de l'upload d'images

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ImageResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ImageResource.java
@@ -40,7 +40,7 @@ public class ImageResource {
             String storedName = UUID.randomUUID() + extension;
             java.nio.file.Path target = UPLOAD_DIR.resolve(storedName);
             Files.copy(file.uploadedFile(), target, StandardCopyOption.REPLACE_EXISTING);
-            urls.add("/images/" + storedName);
+            urls.add("/api/images/" + storedName);
         }
         return Response.ok(urls).build();
     }


### PR DESCRIPTION
## Résumé

- Le backend retournait des URLs `/images/{filename}` après l'upload d'une image
- Nginx ne proxifie que les requêtes sous `/api/`, donc le navigateur cherchait les images comme fichiers statiques inexistants
- Correction en retournant `/api/images/{filename}` pour que les requêtes transitent correctement par le proxy vers le backend

## Impact

Tous les modules utilisant l'upload d'images sont corrigés (catalogues bateaux, moteurs, hélices, produits, remorques, fournisseurs, clients, etc.).

> **Note** : les images déjà enregistrées en base avec l'ancienne URL `/images/...` devront être re-uploadées ou migrées manuellement.