### PR TITLE
feat: inclure bateaux, moteurs, hélices et remorques du catalogue dans les ventes

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
@@ -58,6 +58,18 @@ public class VenteEntity extends PanacheEntity {
     @ManyToMany
     public List<ProduitCatalogueEntity> produits;
 
+    @ManyToMany
+    public List<BateauCatalogueEntity> bateauxCatalogue = new ArrayList<>();
+
+    @ManyToMany
+    public List<MoteurCatalogueEntity> moteursCatalogue = new ArrayList<>();
+
+    @ManyToMany
+    public List<HeliceCatalogueEntity> helicesCatalogue = new ArrayList<>();
+
+    @ManyToMany
+    public List<RemorqueCatalogueEntity> remorquesCatalogue = new ArrayList<>();
+
     @JsonbTypeAdapter(TimestampJsonbAdapter.class)
     public Timestamp date;
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -24,10 +24,14 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import net.nanthrax.moussaillon.persistence.AvoirEntity;
+import net.nanthrax.moussaillon.persistence.BateauCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.EmailTemplateEntity;
 import net.nanthrax.moussaillon.persistence.ForfaitEntity;
 import net.nanthrax.moussaillon.persistence.ForfaitProduitEntity;
+import net.nanthrax.moussaillon.persistence.HeliceCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.MoteurCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.RemorqueCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.ServiceEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
 import net.nanthrax.moussaillon.persistence.TaskEntity;
@@ -131,6 +135,82 @@ public class VenteResource {
                     double total = vs.service != null ? vs.service.prixTTC * vs.quantite : 0;
                     lignes.append(" = ").append(String.format("%.2f EUR", total));
                 }
+                lignes.append("\n");
+            }
+        }
+        if (entity.bateauxCatalogue != null && !entity.bateauxCatalogue.isEmpty()) {
+            Map<Long, int[]> count = new HashMap<>();
+            Map<Long, BateauCatalogueEntity> map = new HashMap<>();
+            for (BateauCatalogueEntity b : entity.bateauxCatalogue) {
+                if (b.id != null) {
+                    count.computeIfAbsent(b.id, k -> new int[]{0, 0});
+                    count.get(b.id)[0]++;
+                    count.get(b.id)[1] += (int) (b.prixVenteTTC * 100);
+                    map.putIfAbsent(b.id, b);
+                }
+            }
+            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
+                BateauCatalogueEntity b = map.get(entry.getKey());
+                String nom = b.marque + " " + b.modele;
+                lignes.append("- Bateau : ").append(nom).append(" x").append(entry.getValue()[0]);
+                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
+                lignes.append("\n");
+            }
+        }
+        if (entity.moteursCatalogue != null && !entity.moteursCatalogue.isEmpty()) {
+            Map<Long, int[]> count = new HashMap<>();
+            Map<Long, MoteurCatalogueEntity> map = new HashMap<>();
+            for (MoteurCatalogueEntity m : entity.moteursCatalogue) {
+                if (m.id != null) {
+                    count.computeIfAbsent(m.id, k -> new int[]{0, 0});
+                    count.get(m.id)[0]++;
+                    count.get(m.id)[1] += (int) (m.prixVenteTTC * 100);
+                    map.putIfAbsent(m.id, m);
+                }
+            }
+            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
+                MoteurCatalogueEntity m = map.get(entry.getKey());
+                String nom = m.marque + " " + m.modele;
+                lignes.append("- Moteur : ").append(nom).append(" x").append(entry.getValue()[0]);
+                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
+                lignes.append("\n");
+            }
+        }
+        if (entity.helicesCatalogue != null && !entity.helicesCatalogue.isEmpty()) {
+            Map<Long, int[]> count = new HashMap<>();
+            Map<Long, HeliceCatalogueEntity> map = new HashMap<>();
+            for (HeliceCatalogueEntity h : entity.helicesCatalogue) {
+                if (h.id != null) {
+                    count.computeIfAbsent(h.id, k -> new int[]{0, 0});
+                    count.get(h.id)[0]++;
+                    count.get(h.id)[1] += (int) (h.prixVenteTTC * 100);
+                    map.putIfAbsent(h.id, h);
+                }
+            }
+            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
+                HeliceCatalogueEntity h = map.get(entry.getKey());
+                String nom = h.marque + " " + h.modele;
+                lignes.append("- Hélice : ").append(nom).append(" x").append(entry.getValue()[0]);
+                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
+                lignes.append("\n");
+            }
+        }
+        if (entity.remorquesCatalogue != null && !entity.remorquesCatalogue.isEmpty()) {
+            Map<Long, int[]> count = new HashMap<>();
+            Map<Long, RemorqueCatalogueEntity> map = new HashMap<>();
+            for (RemorqueCatalogueEntity r : entity.remorquesCatalogue) {
+                if (r.id != null) {
+                    count.computeIfAbsent(r.id, k -> new int[]{0, 0});
+                    count.get(r.id)[0]++;
+                    count.get(r.id)[1] += (int) (r.prixVenteTTC * 100);
+                    map.putIfAbsent(r.id, r);
+                }
+            }
+            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
+                RemorqueCatalogueEntity r = map.get(entry.getKey());
+                String nom = r.marque + " " + r.modele;
+                lignes.append("- Remorque : ").append(nom).append(" x").append(entry.getValue()[0]);
+                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
                 lignes.append("\n");
             }
         }
@@ -456,6 +536,30 @@ public class VenteResource {
             }
         }
 
+        // Update bateauxCatalogue
+        entity.bateauxCatalogue.clear();
+        if (vente.bateauxCatalogue != null) {
+            entity.bateauxCatalogue.addAll(vente.bateauxCatalogue);
+        }
+
+        // Update moteursCatalogue
+        entity.moteursCatalogue.clear();
+        if (vente.moteursCatalogue != null) {
+            entity.moteursCatalogue.addAll(vente.moteursCatalogue);
+        }
+
+        // Update helicesCatalogue
+        entity.helicesCatalogue.clear();
+        if (vente.helicesCatalogue != null) {
+            entity.helicesCatalogue.addAll(vente.helicesCatalogue);
+        }
+
+        // Update remorquesCatalogue
+        entity.remorquesCatalogue.clear();
+        if (vente.remorquesCatalogue != null) {
+            entity.remorquesCatalogue.addAll(vente.remorquesCatalogue);
+        }
+
         // Send incident notification email for any INCIDENT items
         if (entity.client != null && entity.client.email != null && !entity.client.email.isBlank()) {
             for (VenteForfaitEntity vf : entity.venteForfaits) {
@@ -706,6 +810,30 @@ public class VenteResource {
                 ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(produit.id);
                 if (p != null) {
                     p.stock = Math.max(0, p.stock - 1);
+                }
+            }
+        }
+        if (vente.bateauxCatalogue != null) {
+            for (BateauCatalogueEntity bateau : vente.bateauxCatalogue) {
+                BateauCatalogueEntity b = BateauCatalogueEntity.findById(bateau.id);
+                if (b != null) {
+                    b.stock = Math.max(0, b.stock - 1);
+                }
+            }
+        }
+        if (vente.moteursCatalogue != null) {
+            for (MoteurCatalogueEntity moteur : vente.moteursCatalogue) {
+                MoteurCatalogueEntity m = MoteurCatalogueEntity.findById(moteur.id);
+                if (m != null) {
+                    m.stock = Math.max(0, m.stock - 1);
+                }
+            }
+        }
+        if (vente.remorquesCatalogue != null) {
+            for (RemorqueCatalogueEntity remorque : vente.remorquesCatalogue) {
+                RemorqueCatalogueEntity r = RemorqueCatalogueEntity.findById(remorque.id);
+                if (r != null) {
+                    r.stock = Math.max(0, r.stock - 1);
                 }
             }
         }

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -84,6 +84,34 @@ interface ProduitCatalogueEntity {
     prixVenteTTC?: number;
 }
 
+interface CatalogueBateauEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
+interface CatalogueMoteurEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
+interface CatalogueHeliceEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
+interface CatalogueRemorqueEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
 
 const defaultNewProduit = {
     nom: '',
@@ -153,6 +181,10 @@ interface VenteEntity {
     remorque?: RemorqueClientEntity;
     forfaits?: ForfaitEntity[];
     produits?: ProduitCatalogueEntity[];
+    bateauxCatalogue?: CatalogueBateauEntity[];
+    moteursCatalogue?: CatalogueMoteurEntity[];
+    helicesCatalogue?: CatalogueHeliceEntity[];
+    remorquesCatalogue?: CatalogueRemorqueEntity[];
     services?: ServiceEntity[];
     taches?: TaskEntity[];
     date?: string;
@@ -180,7 +212,7 @@ interface VenteFormValues {
     moteurId?: number;
     remorqueId?: number;
     forfaits: Array<{ forfaitId?: number; quantite: number }>;
-    produits: Array<{ produitId?: number; quantite?: number }>;
+    produits: Array<{ produitRef?: string; quantite?: number }>;
     services: Array<{ serviceId?: number; quantite: number }>;
     date?: string;
     montantHT: number;
@@ -283,6 +315,10 @@ export default function Comptoir() {
     const [remorques, setRemorques] = useState<RemorqueClientEntity[]>([]);
     const [forfaits, setForfaits] = useState<ForfaitEntity[]>([]);
     const [produits, setProduits] = useState<ProduitCatalogueEntity[]>([]);
+    const [catalogueBateaux, setCatalogueBateaux] = useState<CatalogueBateauEntity[]>([]);
+    const [catalogueMoteurs, setCatalogueMoteurs] = useState<CatalogueMoteurEntity[]>([]);
+    const [catalogueHelices, setCatalogueHelices] = useState<CatalogueHeliceEntity[]>([]);
+    const [catalogueRemorques, setCatalogueRemorques] = useState<CatalogueRemorqueEntity[]>([]);
     const [services, setServices] = useState<ServiceEntity[]>([]);
     const [loading, setLoading] = useState(false);
     const [modalVisible, setModalVisible] = useState(false);
@@ -328,13 +364,24 @@ export default function Comptoir() {
         setClientSearchTimeout(timeout);
     };
 
-    const handleProduitSearch = (value: string) => {
+    const handleCatalogueSearch = (value: string) => {
         if (produitSearchTimeout) clearTimeout(produitSearchTimeout);
         if (!value || value.trim() === '') return;
+        const q = encodeURIComponent(value);
         const timeout = setTimeout(async () => {
             try {
-                const res = await api.get(`/catalogue/produits/search?q=${encodeURIComponent(value)}`);
-                setProduits((prev) => mergeById(prev, res.data || []));
+                const [produitsRes, bateauxRes, moteursRes, helicesRes, remorquesRes] = await Promise.allSettled([
+                    api.get(`/catalogue/produits/search?q=${q}`),
+                    api.get(`/catalogue/bateaux/search?q=${q}`),
+                    api.get(`/catalogue/moteurs/search?q=${q}`),
+                    api.get(`/catalogue/helices/search?q=${q}`),
+                    api.get(`/catalogue/remorques/search?q=${q}`),
+                ]);
+                if (produitsRes.status === 'fulfilled') setProduits((prev) => mergeById(prev, produitsRes.value.data || []));
+                if (bateauxRes.status === 'fulfilled') setCatalogueBateaux((prev) => mergeById(prev, bateauxRes.value.data || []));
+                if (moteursRes.status === 'fulfilled') setCatalogueMoteurs((prev) => mergeById(prev, moteursRes.value.data || []));
+                if (helicesRes.status === 'fulfilled') setCatalogueHelices((prev) => mergeById(prev, helicesRes.value.data || []));
+                if (remorquesRes.status === 'fulfilled') setCatalogueRemorques((prev) => mergeById(prev, remorquesRes.value.data || []));
             } catch {
                 // ignore
             }
@@ -371,10 +418,56 @@ export default function Comptoir() {
             })),
         [forfaits]
     );
-    const produitOptions = useMemo(
-        () => produits.map((produit) => ({ value: produit.id, label: `${produit.nom}${produit.marque ? ` (${produit.marque})` : ''}` })),
-        [produits]
-    );
+    const catalogueOptions = useMemo(() => [
+        {
+            label: 'Produits',
+            options: produits.map((p) => ({
+                value: `produit:${p.id}`,
+                label: `${p.nom}${p.marque ? ` (${p.marque})` : ''}`,
+            })),
+        },
+        {
+            label: 'Bateaux',
+            options: catalogueBateaux.map((b) => ({
+                value: `bateau:${b.id}`,
+                label: `${b.marque} ${b.modele}`,
+            })),
+        },
+        {
+            label: 'Moteurs',
+            options: catalogueMoteurs.map((m) => ({
+                value: `moteur:${m.id}`,
+                label: `${m.marque} ${m.modele}`,
+            })),
+        },
+        {
+            label: 'Hélices',
+            options: catalogueHelices.map((h) => ({
+                value: `helice:${h.id}`,
+                label: `${h.marque} ${h.modele}`,
+            })),
+        },
+        {
+            label: 'Remorques',
+            options: catalogueRemorques.map((r) => ({
+                value: `remorque:${r.id}`,
+                label: `${r.marque} ${r.modele}`,
+            })),
+        },
+    ], [produits, catalogueBateaux, catalogueMoteurs, catalogueHelices, catalogueRemorques]);
+
+    const getCatalogueItemPrice = (ref?: string): number => {
+        if (!ref) return 0;
+        const [type, idStr] = ref.split(':');
+        const id = parseInt(idStr, 10);
+        if (isNaN(id)) return 0;
+        if (type === 'produit') return produits.find((p) => p.id === id)?.prixVenteTTC || 0;
+        if (type === 'bateau') return catalogueBateaux.find((b) => b.id === id)?.prixVenteTTC || 0;
+        if (type === 'moteur') return catalogueMoteurs.find((m) => m.id === id)?.prixVenteTTC || 0;
+        if (type === 'helice') return catalogueHelices.find((h) => h.id === id)?.prixVenteTTC || 0;
+        if (type === 'remorque') return catalogueRemorques.find((r) => r.id === id)?.prixVenteTTC || 0;
+        return 0;
+    };
     const serviceOptions = useMemo(
         () => services.map((service) => ({ value: service.id, label: service.nom })),
         [services]
@@ -524,7 +617,7 @@ export default function Comptoir() {
             if (newProduitTargetLine !== null && created.id) {
                 const currentLines = form.getFieldValue('produits') || [];
                 const updated = [...currentLines];
-                updated[newProduitTargetLine] = { ...updated[newProduitTargetLine], produitId: created.id };
+                updated[newProduitTargetLine] = { ...updated[newProduitTargetLine], produitRef: `produit:${created.id}` };
                 form.setFieldValue('produits', updated);
                 recalculateFromLines('auto');
             }
@@ -562,17 +655,28 @@ export default function Comptoir() {
                 setClients((prev) => mergeById(prev, [vente.client as ClientEntity]));
             }
             const venteProduits = (vente.produits || []).filter((p): p is ProduitCatalogueEntity => !!p?.id);
-            if (venteProduits.length > 0) {
-                setProduits((prev) => mergeById(prev, venteProduits));
-            }
-            const produitLinesMap = (vente.produits || []).reduce((acc, item) => {
-                if (!item?.id) {
-                    return acc;
-                }
-                acc.set(item.id, (acc.get(item.id) || 0) + 1);
-                return acc;
-            }, new Map<number, number>());
-            const produitLines = Array.from(produitLinesMap.entries()).map(([produitId, quantite]) => ({ produitId, quantite }));
+            if (venteProduits.length > 0) setProduits((prev) => mergeById(prev, venteProduits));
+            const venteBateaux = (vente.bateauxCatalogue || []).filter((b): b is CatalogueBateauEntity => !!b?.id);
+            if (venteBateaux.length > 0) setCatalogueBateaux((prev) => mergeById(prev, venteBateaux));
+            const venteMoteurs = (vente.moteursCatalogue || []).filter((m): m is CatalogueMoteurEntity => !!m?.id);
+            if (venteMoteurs.length > 0) setCatalogueMoteurs((prev) => mergeById(prev, venteMoteurs));
+            const venteHelices = (vente.helicesCatalogue || []).filter((h): h is CatalogueHeliceEntity => !!h?.id);
+            if (venteHelices.length > 0) setCatalogueHelices((prev) => mergeById(prev, venteHelices));
+            const venteRemorques = (vente.remorquesCatalogue || []).filter((r): r is CatalogueRemorqueEntity => !!r?.id);
+            if (venteRemorques.length > 0) setCatalogueRemorques((prev) => mergeById(prev, venteRemorques));
+
+            const buildRefLines = <T extends { id: number }>(items: T[], prefix: string): Array<{ produitRef: string; quantite: number }> => {
+                const map = new Map<number, number>();
+                items.forEach((item) => { if (item?.id) map.set(item.id, (map.get(item.id) || 0) + 1); });
+                return Array.from(map.entries()).map(([id, quantite]) => ({ produitRef: `${prefix}:${id}`, quantite }));
+            };
+            const produitLines = [
+                ...buildRefLines(vente.produits || [], 'produit'),
+                ...buildRefLines(vente.bateauxCatalogue || [], 'bateau'),
+                ...buildRefLines(vente.moteursCatalogue || [], 'moteur'),
+                ...buildRefLines(vente.helicesCatalogue || [], 'helice'),
+                ...buildRefLines(vente.remorquesCatalogue || [], 'remorque'),
+            ];
             form.setFieldsValue({
                 status: vente.status || 'DEVIS',
                 bonPourAccord: vente.bonPourAccord || false,
@@ -657,11 +761,40 @@ export default function Comptoir() {
                 return item ? expandByQuantity([item], line.quantite) : [];
             }) as ForfaitEntity[],
         produits: (values.produits || [])
-            .filter((line) => line.produitId)
+            .filter((line) => line.produitRef?.startsWith('produit:'))
             .flatMap((line) => {
-                const item = produits.find((produit) => produit.id === line.produitId);
+                const id = parseInt((line.produitRef || '').split(':')[1], 10);
+                const item = produits.find((p) => p.id === id);
                 return item ? expandByQuantity([item], line.quantite || 1) : [];
             }) as ProduitCatalogueEntity[],
+        bateauxCatalogue: (values.produits || [])
+            .filter((line) => line.produitRef?.startsWith('bateau:'))
+            .flatMap((line) => {
+                const id = parseInt((line.produitRef || '').split(':')[1], 10);
+                const item = catalogueBateaux.find((b) => b.id === id);
+                return item ? expandByQuantity([item], line.quantite || 1) : [];
+            }) as CatalogueBateauEntity[],
+        moteursCatalogue: (values.produits || [])
+            .filter((line) => line.produitRef?.startsWith('moteur:'))
+            .flatMap((line) => {
+                const id = parseInt((line.produitRef || '').split(':')[1], 10);
+                const item = catalogueMoteurs.find((m) => m.id === id);
+                return item ? expandByQuantity([item], line.quantite || 1) : [];
+            }) as CatalogueMoteurEntity[],
+        helicesCatalogue: (values.produits || [])
+            .filter((line) => line.produitRef?.startsWith('helice:'))
+            .flatMap((line) => {
+                const id = parseInt((line.produitRef || '').split(':')[1], 10);
+                const item = catalogueHelices.find((h) => h.id === id);
+                return item ? expandByQuantity([item], line.quantite || 1) : [];
+            }) as CatalogueHeliceEntity[],
+        remorquesCatalogue: (values.produits || [])
+            .filter((line) => line.produitRef?.startsWith('remorque:'))
+            .flatMap((line) => {
+                const id = parseInt((line.produitRef || '').split(':')[1], 10);
+                const item = catalogueRemorques.find((r) => r.id === id);
+                return item ? expandByQuantity([item], line.quantite || 1) : [];
+            }) as CatalogueRemorqueEntity[],
         services: (values.services || [])
             .filter((line) => line.serviceId)
             .flatMap((line) => {
@@ -749,15 +882,22 @@ export default function Comptoir() {
     };
 
     const getProduitLines = (vente: VenteEntity) => {
-        const quantites = (vente.produits || []).reduce((acc, produit) => {
-            const key = `${produit.id}`;
-            const current = acc.get(key) || { ...produit, quantite: 0 };
-            current.quantite += 1;
-            acc.set(key, current);
-            return acc;
-        }, new Map<string, (ProduitCatalogueEntity & { quantite: number })>());
-
-        return Array.from(quantites.values());
+        type LineItem = { id: number; nom: string; marque?: string; prixVenteTTC?: number; quantite: number };
+        const lines = new Map<string, LineItem>();
+        const addItems = (items: Array<{ id: number; prixVenteTTC?: number } & Record<string, unknown>>, getNom: (item: unknown) => string, prefix: string) => {
+            (items || []).forEach((item) => {
+                const key = `${prefix}:${item.id}`;
+                const current = lines.get(key) || { id: item.id, nom: getNom(item), marque: (item as { marque?: string }).marque, prixVenteTTC: item.prixVenteTTC, quantite: 0 };
+                current.quantite += 1;
+                lines.set(key, current);
+            });
+        };
+        addItems(vente.produits || [], (p) => (p as ProduitCatalogueEntity).nom, 'produit');
+        addItems(vente.bateauxCatalogue || [], (b) => `${(b as CatalogueBateauEntity).marque} ${(b as CatalogueBateauEntity).modele}`, 'bateau');
+        addItems(vente.moteursCatalogue || [], (m) => `${(m as CatalogueMoteurEntity).marque} ${(m as CatalogueMoteurEntity).modele}`, 'moteur');
+        addItems(vente.helicesCatalogue || [], (h) => `${(h as CatalogueHeliceEntity).marque} ${(h as CatalogueHeliceEntity).modele}`, 'helice');
+        addItems(vente.remorquesCatalogue || [], (r) => `${(r as CatalogueRemorqueEntity).marque} ${(r as CatalogueRemorqueEntity).modele}`, 'remorque');
+        return Array.from(lines.values());
     };
 
     const openPrintDocument = (_title: string, contentHtml: string, _width: number = 900) => {
@@ -810,14 +950,14 @@ export default function Comptoir() {
     const handlePrintInvoice = (vente: VenteEntity) => {
         const title = `Facture #${vente.id || '-'}`;
         const produitRows = getProduitLines(vente)
-            .map((produit) => {
-                const pu = produit.prixVenteTTC || 0;
-                const total = pu * produit.quantite;
+            .map((item) => {
+                const pu = item.prixVenteTTC || 0;
+                const total = pu * item.quantite;
                 return `
                 <tr>
-                    <td>${escapeHtml(`${produit.nom}${produit.marque ? ` (${produit.marque})` : ''}`)}</td>
+                    <td>${escapeHtml(item.nom)}</td>
                     <td style="text-align:right;">${escapeHtml(formatEuro(pu))}</td>
-                    <td style="text-align:right;">${produit.quantite}</td>
+                    <td style="text-align:right;">${item.quantite}</td>
                     <td style="text-align:right;">${escapeHtml(formatEuro(total))}</td>
                 </tr>`;
             })
@@ -871,13 +1011,13 @@ export default function Comptoir() {
     const handlePrintReceipt = (vente: VenteEntity) => {
         const title = `Ticket #${vente.id || '-'}`;
         const produitRows = getProduitLines(vente)
-            .map((produit) => {
-                const pu = produit.prixVenteTTC || 0;
-                const total = pu * produit.quantite;
+            .map((item) => {
+                const pu = item.prixVenteTTC || 0;
+                const total = pu * item.quantite;
                 return `
                 <div class="line">
-                    <span>${escapeHtml(`${produit.nom}${produit.marque ? ` (${produit.marque})` : ''}`)}</span>
-                    <span>x${produit.quantite}</span>
+                    <span>${escapeHtml(item.nom)}</span>
+                    <span>x${item.quantite}</span>
                 </div>
                 <div class="line sub">
                     <span>${escapeHtml(formatEuro(pu))} /u</span>
@@ -955,8 +1095,8 @@ export default function Comptoir() {
             const prixUnitaire = forfaits.find((item) => item.id === line.forfaitId)?.prixTTC || 0;
             return sum + (prixUnitaire * Math.max(1, Math.floor(line.quantite || 1)));
         }, 0);
-        const produitsTTC = produitLines.reduce((sum: number, line: { produitId?: number; quantite?: number }) => {
-            const prixUnitaire = produits.find((item) => item.id === line.produitId)?.prixVenteTTC || 0;
+        const produitsTTC = produitLines.reduce((sum: number, line: { produitRef?: string; quantite?: number }) => {
+            const prixUnitaire = getCatalogueItemPrice(line.produitRef);
             return sum + (prixUnitaire * Math.max(1, Math.floor(line.quantite || 1)));
         }, 0);
         const servicesTTC = serviceLines.reduce((sum: number, line: { serviceId?: number; quantite?: number }) => {
@@ -994,7 +1134,7 @@ export default function Comptoir() {
                 return;
             }
             const lastProduitLine = currentProduitLines[currentProduitLines.length - 1];
-            const isLastLineComplete = !!lastProduitLine?.produitId && (lastProduitLine?.quantite || 0) > 0;
+            const isLastLineComplete = !!lastProduitLine?.produitRef && (lastProduitLine?.quantite || 0) > 0;
             if (isLastLineComplete) {
                 form.setFieldValue('produits', [...currentProduitLines, {}]);
                 return;
@@ -1294,23 +1434,23 @@ export default function Comptoir() {
                                     {fields.map((field) => (
                                         <Form.Item key={field.key} shouldUpdate noStyle>
                                             {() => {
-                                                const produitId = form.getFieldValue(['produits', field.name, 'produitId']);
-                                                const prixUnitaire = produits.find((p) => p.id === produitId)?.prixVenteTTC;
+                                                const produitRef = form.getFieldValue(['produits', field.name, 'produitRef']);
+                                                const prixUnitaire = getCatalogueItemPrice(produitRef) || undefined;
                                                 const quantite = form.getFieldValue(['produits', field.name, 'quantite']);
                                                 const totalLigne = (prixUnitaire && quantite) ? Math.round(prixUnitaire * quantite * 100) / 100 : undefined;
-                                                const isEmptyLine = !produitId;
+                                                const isEmptyLine = !produitRef;
                                                 return (
                                                 <Space align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
                                                     <Form.Item
                                                         {...field}
-                                                        name={[field.name, 'produitId']}
+                                                        name={[field.name, 'produitRef']}
                                                         rules={[
                                                             {
                                                                 validator: async (_, value) => {
                                                                     const line = form.getFieldValue(['produits', field.name]);
                                                                     const quantite = Number(line?.quantite || 0);
                                                                     if (!value && quantite > 0) {
-                                                                        throw new Error('Produit requis');
+                                                                        throw new Error('Article requis');
                                                                     }
                                                                 }
                                                             }
@@ -1320,11 +1460,11 @@ export default function Comptoir() {
                                                         <Select
                                                             allowClear
                                                             showSearch
-                                                            options={produitOptions}
+                                                            options={catalogueOptions}
                                                             filterOption={false}
-                                                            onSearch={handleProduitSearch}
+                                                            onSearch={handleCatalogueSearch}
                                                             notFoundContent={null}
-                                                            placeholder="Rechercher un produit par nom, marque, catégorie ou réf."
+                                                            placeholder="Rechercher produit, bateau, moteur, hélice ou remorque"
                                                         />
                                                     </Form.Item>
                                                     <Form.Item style={{ width: 150 }}>
@@ -1343,7 +1483,7 @@ export default function Comptoir() {
                                                             {
                                                                 validator: async (_, value) => {
                                                                     const line = form.getFieldValue(['produits', field.name]);
-                                                                    if (!line?.produitId && (value === undefined || value === null)) {
+                                                                    if (!line?.produitRef && (value === undefined || value === null)) {
                                                                         return;
                                                                     }
                                                                     if (!value || value <= 0) {

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -180,6 +180,34 @@ interface ProduitCatalogueEntity {
     prixVenteTTC?: number;
 }
 
+interface CatalogueBateauEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
+interface CatalogueMoteurEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
+interface CatalogueHeliceEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
+interface CatalogueRemorqueEntity {
+    id: number;
+    modele: string;
+    marque: string;
+    prixVenteTTC?: number;
+}
+
 
 const defaultNewProduit = {
     nom: '',
@@ -287,6 +315,10 @@ interface VenteEntity {
     venteForfaits?: VenteForfaitEntity[];
     venteServices?: VenteServiceEntity[];
     produits?: ProduitCatalogueEntity[];
+    bateauxCatalogue?: CatalogueBateauEntity[];
+    moteursCatalogue?: CatalogueMoteurEntity[];
+    helicesCatalogue?: CatalogueHeliceEntity[];
+    remorquesCatalogue?: CatalogueRemorqueEntity[];
     date?: string;
     dateDevis?: string;
     dateBonPourAccord?: string;
@@ -320,7 +352,7 @@ interface RappelHistoriqueEntity {
     dateEnvoi?: string;
 }
 
-type LigneType = 'forfait' | 'service' | 'produit';
+type LigneType = 'forfait' | 'service' | 'produit' | 'bateau' | 'moteur' | 'helice' | 'remorque';
 
 interface LigneUnifiee {
     type?: LigneType;
@@ -496,9 +528,10 @@ export default function Vente() {
     const [services, setServices] = useState<ServiceEntity[]>([]);
     const [mainOeuvres, setMainOeuvres] = useState<MainOeuvreEntity[]>([]);
     const [techniciens, setTechniciens] = useState<TechnicienEntity[]>([]);
-    const [catalogueBateaux, setCatalogueBateaux] = useState<Array<{ id: number; marque?: string; modele?: string }>>([]);
-    const [catalogueMoteurs, setCatalogueMoteurs] = useState<Array<{ id: number; marque?: string; modele?: string }>>([]);
-    const [catalogueRemorques, setCatalogueRemorques] = useState<Array<{ id: number; marque?: string; modele?: string }>>([]);
+    const [catalogueBateaux, setCatalogueBateaux] = useState<CatalogueBateauEntity[]>([]);
+    const [catalogueMoteurs, setCatalogueMoteurs] = useState<CatalogueMoteurEntity[]>([]);
+    const [catalogueHelices, setCatalogueHelices] = useState<CatalogueHeliceEntity[]>([]);
+    const [catalogueRemorques, setCatalogueRemorques] = useState<CatalogueRemorqueEntity[]>([]);
     const [loading, setLoading] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const [modalVisible, setModalVisible] = useState(false);
@@ -569,10 +602,21 @@ export default function Vente() {
     const handleProduitSearch = (value: string) => {
         if (produitSearchTimeout) clearTimeout(produitSearchTimeout);
         if (!value || value.trim() === '') return;
+        const q = encodeURIComponent(value);
         const timeout = setTimeout(async () => {
             try {
-                const res = await api.get(`/catalogue/produits/search?q=${encodeURIComponent(value)}`);
-                setProduits((prev) => mergeById(prev, res.data || []));
+                const [produitsRes, bateauxRes, moteursRes, helicesRes, remorquesRes] = await Promise.allSettled([
+                    api.get(`/catalogue/produits/search?q=${q}`),
+                    api.get(`/catalogue/bateaux/search?q=${q}`),
+                    api.get(`/catalogue/moteurs/search?q=${q}`),
+                    api.get(`/catalogue/helices/search?q=${q}`),
+                    api.get(`/catalogue/remorques/search?q=${q}`),
+                ]);
+                if (produitsRes.status === 'fulfilled') setProduits((prev) => mergeById(prev, produitsRes.value.data || []));
+                if (bateauxRes.status === 'fulfilled') setCatalogueBateaux((prev) => mergeById(prev, bateauxRes.value.data || []));
+                if (moteursRes.status === 'fulfilled') setCatalogueMoteurs((prev) => mergeById(prev, moteursRes.value.data || []));
+                if (helicesRes.status === 'fulfilled') setCatalogueHelices((prev) => mergeById(prev, helicesRes.value.data || []));
+                if (remorquesRes.status === 'fulfilled') setCatalogueRemorques((prev) => mergeById(prev, remorquesRes.value.data || []));
             } catch {
                 // ignore
             }
@@ -669,8 +713,40 @@ export default function Vente() {
                     searchText: `${p.nom} ${p.marque || ''}`.toLowerCase(),
                 })),
             },
+            {
+                label: 'Bateaux',
+                options: catalogueBateaux.map((b) => ({
+                    value: `bateau:${b.id}`,
+                    label: `${b.marque} ${b.modele}`,
+                    searchText: `${b.marque} ${b.modele}`.toLowerCase(),
+                })),
+            },
+            {
+                label: 'Moteurs',
+                options: catalogueMoteurs.map((m) => ({
+                    value: `moteur:${m.id}`,
+                    label: `${m.marque} ${m.modele}`,
+                    searchText: `${m.marque} ${m.modele}`.toLowerCase(),
+                })),
+            },
+            {
+                label: 'Hélices',
+                options: catalogueHelices.map((h) => ({
+                    value: `helice:${h.id}`,
+                    label: `${h.marque} ${h.modele}`,
+                    searchText: `${h.marque} ${h.modele}`.toLowerCase(),
+                })),
+            },
+            {
+                label: 'Remorques',
+                options: catalogueRemorques.map((r) => ({
+                    value: `remorque:${r.id}`,
+                    label: `${r.marque} ${r.modele}`,
+                    searchText: `${r.marque} ${r.modele}`.toLowerCase(),
+                })),
+            },
         ],
-        [forfaits, produits]
+        [forfaits, produits, catalogueBateaux, catalogueMoteurs, catalogueHelices, catalogueRemorques]
     );
 
     const parseLigneValue = (compositeValue?: string): { type: LigneType; id: number } | null => {
@@ -729,6 +805,7 @@ export default function Vente() {
                 techniciensRes,
                 catBateauxRes,
                 catMoteursRes,
+                catHelicesRes,
                 catRemorquesRes
             ] = await Promise.all([
                 api.get('/bateaux'),
@@ -740,6 +817,7 @@ export default function Vente() {
                 api.get('/techniciens'),
                 api.get('/catalogue/bateaux'),
                 api.get('/catalogue/moteurs'),
+                api.get('/catalogue/helices'),
                 api.get('/catalogue/remorques')
             ]);
             setBateaux(bateauxRes.data || []);
@@ -751,6 +829,7 @@ export default function Vente() {
             setTechniciens(techniciensRes.data || []);
             setCatalogueBateaux(catBateauxRes.data || []);
             setCatalogueMoteurs(catMoteursRes.data || []);
+            setCatalogueHelices(catHelicesRes.data || []);
             setCatalogueRemorques(catRemorquesRes.data || []);
         } catch {
             message.error('Erreur lors du chargement des listes de reference.');
@@ -1274,8 +1353,14 @@ export default function Vente() {
         const keys: string[] = [];
         (vente?.venteForfaits || []).forEach(vf => { if (vf.forfait?.id) keys.push(`forfait:${vf.forfait.id}`); });
         (vente?.venteServices || []).forEach(vs => { if (vs.service?.id) keys.push(`service:${vs.service.id}`); });
-        const produitIds = new Set((vente?.produits || []).map(p => p?.id).filter(Boolean));
-        produitIds.forEach(id => keys.push(`produit:${id}`));
+        const addIds = (items: Array<{ id?: number }>, prefix: string) => {
+            new Set(items.map(i => i?.id).filter(Boolean) as number[]).forEach(id => keys.push(`${prefix}:${id}`));
+        };
+        addIds(vente?.produits || [], 'produit');
+        addIds(vente?.bateauxCatalogue || [], 'bateau');
+        addIds(vente?.moteursCatalogue || [], 'moteur');
+        addIds(vente?.helicesCatalogue || [], 'helice');
+        addIds(vente?.remorquesCatalogue || [], 'remorque');
         savedLinesRef.current = keys.sort();
     };
 
@@ -1284,9 +1369,15 @@ export default function Vente() {
             setClients((prev) => mergeById(prev, [vente.client as ClientEntity]));
         }
         const venteProduits = (vente.produits || []).filter((p): p is ProduitCatalogueEntity => !!p?.id);
-        if (venteProduits.length > 0) {
-            setProduits((prev) => mergeById(prev, venteProduits));
-        }
+        if (venteProduits.length > 0) setProduits((prev) => mergeById(prev, venteProduits));
+        const venteBateaux = (vente.bateauxCatalogue || []).filter((b): b is CatalogueBateauEntity => !!b?.id);
+        if (venteBateaux.length > 0) setCatalogueBateaux((prev) => mergeById(prev, venteBateaux));
+        const venteMoteurs = (vente.moteursCatalogue || []).filter((m): m is CatalogueMoteurEntity => !!m?.id);
+        if (venteMoteurs.length > 0) setCatalogueMoteurs((prev) => mergeById(prev, venteMoteurs));
+        const venteHelices = (vente.helicesCatalogue || []).filter((h): h is CatalogueHeliceEntity => !!h?.id);
+        if (venteHelices.length > 0) setCatalogueHelices((prev) => mergeById(prev, venteHelices));
+        const venteRemorques = (vente.remorquesCatalogue || []).filter((r): r is CatalogueRemorqueEntity => !!r?.id);
+        if (venteRemorques.length > 0) setCatalogueRemorques((prev) => mergeById(prev, venteRemorques));
         const lignes: LigneUnifiee[] = [];
         (vente.venteForfaits || []).forEach(vf => {
             lignes.push({
@@ -1326,14 +1417,16 @@ export default function Vente() {
                 documents: vs.documents || [],
             });
         });
-        const produitLinesMap = (vente.produits || []).reduce((acc, item) => {
-            if (!item?.id) return acc;
-            acc.set(item.id, (acc.get(item.id) || 0) + 1);
-            return acc;
-        }, new Map<number, number>());
-        Array.from(produitLinesMap.entries()).forEach(([produitId, quantite]) => {
-            lignes.push({ type: 'produit', itemId: produitId, quantite });
-        });
+        const buildLignesFromItems = (items: Array<{ id: number }>, type: LigneType) => {
+            const map = new Map<number, number>();
+            items.forEach((item) => { if (item?.id) map.set(item.id, (map.get(item.id) || 0) + 1); });
+            map.forEach((quantite, itemId) => lignes.push({ type, itemId, quantite }));
+        };
+        buildLignesFromItems(vente.produits || [], 'produit');
+        buildLignesFromItems(vente.bateauxCatalogue || [], 'bateau');
+        buildLignesFromItems(vente.moteursCatalogue || [], 'moteur');
+        buildLignesFromItems(vente.helicesCatalogue || [], 'helice');
+        buildLignesFromItems(vente.remorquesCatalogue || [], 'remorque');
         form.resetFields();
         form.setFieldsValue({
             status: vente.status || 'DEVIS',
@@ -1377,10 +1470,22 @@ export default function Vente() {
             } else if (line.type === 'produit') {
                 const p = produits.find((item) => item.id === line.itemId);
                 if (p) lines.push({ type: 'Produit', nom: p.nom, quantite, prixTTC: (p.prixVenteTTC || 0) * quantite });
+            } else if (line.type === 'bateau') {
+                const b = catalogueBateaux.find((item) => item.id === line.itemId);
+                if (b) lines.push({ type: 'Bateau', nom: `${b.marque} ${b.modele}`, quantite, prixTTC: (b.prixVenteTTC || 0) * quantite });
+            } else if (line.type === 'moteur') {
+                const m = catalogueMoteurs.find((item) => item.id === line.itemId);
+                if (m) lines.push({ type: 'Moteur', nom: `${m.marque} ${m.modele}`, quantite, prixTTC: (m.prixVenteTTC || 0) * quantite });
+            } else if (line.type === 'helice') {
+                const h = catalogueHelices.find((item) => item.id === line.itemId);
+                if (h) lines.push({ type: 'Hélice', nom: `${h.marque} ${h.modele}`, quantite, prixTTC: (h.prixVenteTTC || 0) * quantite });
+            } else if (line.type === 'remorque') {
+                const r = catalogueRemorques.find((item) => item.id === line.itemId);
+                if (r) lines.push({ type: 'Remorque', nom: `${r.marque} ${r.modele}`, quantite, prixTTC: (r.prixVenteTTC || 0) * quantite });
             }
         });
         return lines;
-    }, [form, forfaits, services, produits]);
+    }, [form, forfaits, services, produits, catalogueBateaux, catalogueMoteurs, catalogueHelices, catalogueRemorques]);
 
     const initSignatureCanvas = useCallback(() => {
         setTimeout(() => {
@@ -1527,6 +1632,10 @@ export default function Vente() {
         const forfaitLines = allLignes.filter((l) => l.type === 'forfait');
         const serviceLines = allLignes.filter((l) => l.type === 'service');
         const produitLines = allLignes.filter((l) => l.type === 'produit');
+        const bateauLines = allLignes.filter((l) => l.type === 'bateau');
+        const moteurLines = allLignes.filter((l) => l.type === 'moteur');
+        const heliceLines = allLignes.filter((l) => l.type === 'helice');
+        const remorqueLines = allLignes.filter((l) => l.type === 'remorque');
 
         return {
             status: values.status,
@@ -1589,6 +1698,26 @@ export default function Vente() {
                 const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
                 return item ? Array.from({ length: safeQuantity }, () => item) : [];
             }) as ProduitCatalogueEntity[],
+            bateauxCatalogue: bateauLines.flatMap((line) => {
+                const item = catalogueBateaux.find((b) => b.id === line.itemId);
+                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
+                return item ? Array.from({ length: safeQuantity }, () => item) : [];
+            }) as CatalogueBateauEntity[],
+            moteursCatalogue: moteurLines.flatMap((line) => {
+                const item = catalogueMoteurs.find((m) => m.id === line.itemId);
+                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
+                return item ? Array.from({ length: safeQuantity }, () => item) : [];
+            }) as CatalogueMoteurEntity[],
+            helicesCatalogue: heliceLines.flatMap((line) => {
+                const item = catalogueHelices.find((h) => h.id === line.itemId);
+                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
+                return item ? Array.from({ length: safeQuantity }, () => item) : [];
+            }) as CatalogueHeliceEntity[],
+            remorquesCatalogue: remorqueLines.flatMap((line) => {
+                const item = catalogueRemorques.find((r) => r.id === line.itemId);
+                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
+                return item ? Array.from({ length: safeQuantity }, () => item) : [];
+            }) as CatalogueRemorqueEntity[],
             date: toBackendDateValue(values.date),
             montantHT: values.montantHT || 0,
             remise: values.remise || 0,
@@ -1865,7 +1994,23 @@ export default function Vente() {
             type: 'Service', label: vs.service?.nom || '', quantite: vs.quantite || 1,
             totalPrixTTC: (vs.service?.prixTTC || 0) * (vs.quantite || 1)
         }));
-        return [...forfaitLines, ...produitLines, ...serviceLines];
+        const buildCatalogueLines = (items: Array<{ id: number; marque: string; modele: string; prixVenteTTC?: number }>, typeLabel: string) =>
+            Array.from(
+                (items || []).reduce((acc, item) => {
+                    const label = `${item.marque} ${item.modele}`;
+                    const key = `id-${item.id}`;
+                    const current = acc.get(key) || { type: typeLabel, label, quantite: 0, totalPrixTTC: 0 };
+                    current.quantite += 1;
+                    current.totalPrixTTC += item.prixVenteTTC || 0;
+                    acc.set(key, current);
+                    return acc;
+                }, new Map<string, { type: string; label: string; quantite: number; totalPrixTTC: number }>()).values()
+            );
+        const bateauLines = buildCatalogueLines(vente.bateauxCatalogue || [], 'Bateau');
+        const moteurCatLines = buildCatalogueLines(vente.moteursCatalogue || [], 'Moteur');
+        const heliceLines = buildCatalogueLines(vente.helicesCatalogue || [], 'Hélice');
+        const remorqueCatLines = buildCatalogueLines(vente.remorquesCatalogue || [], 'Remorque');
+        return [...forfaitLines, ...produitLines, ...bateauLines, ...moteurCatLines, ...heliceLines, ...remorqueCatLines, ...serviceLines];
     };
 
     const getDocumentType = (vente: VenteEntity): 'devis' | 'ordre_reparation' | 'facture' => {
@@ -2038,6 +2183,14 @@ export default function Vente() {
                 totalTTC += (allServices.find((s) => s.id === line.itemId)?.prixTTC || 0) * quantite;
             } else if (line.type === 'produit') {
                 totalTTC += (allProduits.find((p) => p.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+            } else if (line.type === 'bateau') {
+                totalTTC += (catalogueBateaux.find((b) => b.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+            } else if (line.type === 'moteur') {
+                totalTTC += (catalogueMoteurs.find((m) => m.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+            } else if (line.type === 'helice') {
+                totalTTC += (catalogueHelices.find((h) => h.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+            } else if (line.type === 'remorque') {
+                totalTTC += (catalogueRemorques.find((r) => r.id === line.itemId)?.prixVenteTTC || 0) * quantite;
             }
         });
 
@@ -2522,6 +2675,10 @@ export default function Vente() {
                                                         if (lineType === 'forfait') return forfaits.find((f) => f.id === itemId)?.prixTTC;
                                                         if (lineType === 'service') return services.find((s) => s.id === itemId)?.prixTTC;
                                                         if (lineType === 'produit') return produits.find((p) => p.id === itemId)?.prixVenteTTC;
+                                                        if (lineType === 'bateau') return catalogueBateaux.find((b) => b.id === itemId)?.prixVenteTTC;
+                                                        if (lineType === 'moteur') return catalogueMoteurs.find((m) => m.id === itemId)?.prixVenteTTC;
+                                                        if (lineType === 'helice') return catalogueHelices.find((h) => h.id === itemId)?.prixVenteTTC;
+                                                        if (lineType === 'remorque') return catalogueRemorques.find((r) => r.id === itemId)?.prixVenteTTC;
                                                         return undefined;
                                                     };
 
@@ -2550,7 +2707,7 @@ export default function Vente() {
                                                                     showSearch
                                                                     value={toLigneCompositeValue(lineType, itemId)}
                                                                     options={ligneUnifieeOptions}
-                                                                    placeholder="Forfait ou Produit"
+                                                                    placeholder="Forfait, produit, bateau, moteur..."
                                                                     onSearch={handleProduitSearch}
                                                                     filterOption={(input, option) =>
                                                                         ((option as { searchText?: string } | undefined)?.searchText || '').includes(input.toLowerCase())
@@ -2579,8 +2736,8 @@ export default function Vente() {
                                                             )}
                                                         </Form.Item>
                                                         {lineType && (
-                                                            <Tag color={lineType === 'forfait' ? 'blue' : lineType === 'service' ? 'green' : 'orange'} style={{ marginRight: 0 }}>
-                                                                {lineType === 'forfait' ? 'F' : lineType === 'service' ? 'S' : 'P'}
+                                                            <Tag color={lineType === 'forfait' ? 'blue' : lineType === 'service' ? 'green' : lineType === 'produit' ? 'orange' : 'purple'} style={{ marginRight: 0 }}>
+                                                                {lineType === 'forfait' ? 'F' : lineType === 'service' ? 'S' : lineType === 'produit' ? 'P' : lineType === 'bateau' ? 'B' : lineType === 'moteur' ? 'M' : lineType === 'helice' ? 'H' : 'R'}
                                                             </Tag>
                                                         )}
                                                         <Form.Item


### PR DESCRIPTION
## Résumé

- Ajoute la sélection de **bateaux, moteurs, hélices et remorques** du catalogue en plus des produits dans les formulaires de vente (comptoir et atelier)
- Les montants sont calculés automatiquement à partir du `prixVenteTTC` de chaque article
- Les stocks sont décrémentés et les emails de facture incluent les nouveaux types d'articles

## Détails techniques

**Backend**
- `VenteEntity` : 4 nouvelles relations `@ManyToMany` (`bateauxCatalogue`, `moteursCatalogue`, `helicesCatalogue`, `remorquesCatalogue`)
- `VenteResource` : CRUD, `decrementStock` et `envoyerFactureEmail` mis à jour pour les nouveaux types

**Frontend — `comptoir.tsx`**
- Sélecteur unifié groupé par type (Produits / Bateaux / Moteurs / Hélices / Remorques)
- Valeur composite `type:id` (ex. `bateau:42`) dans le formulaire
- Recherche en parallèle sur les 5 endpoints catalogue
- Payload splitté par type vers les bons champs backend

**Frontend — `vente.tsx`**
- `LigneType` étendu : `bateau | moteur | helice | remorque`
- Nouveaux groupes dans `ligneUnifieeOptions`
- Recherche, recalcul, BPA, document HTML et snapshot couvrent les 5 types

## Plan de test

- [x] Créer une vente comptoir avec un bateau, un moteur et une hélice du catalogue et vérifier les montants
- [x] Éditer une vente existante avec des produits : les articles s'affichent correctement
- [x] Créer une vente atelier avec des lignes de type bateau/moteur/remorque et vérifier le PDF/devis
- [x] Vérifier que le stock est décrémenté sur les bateaux/moteurs/remorques lors du passage en EN_COURS
- [x] Vérifier l'email de facture avec des articles des 4 nouveaux types