### PR TITLE
ci(dependabot): grouper les mises à jour React

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,18 +17,39 @@ updates:
     directory: "/chantier-ui"
     schedule:
       interval: "weekly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   # npm - client-ui
   - package-ecosystem: "npm"
     directory: "/client-ui"
     schedule:
       interval: "weekly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   # npm - technicien-ui
   - package-ecosystem: "npm"
     directory: "/technicien-ui"
     schedule:
       interval: "weekly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   # Docker - backend
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Résumé
- Ajoute un groupe `react` à chaque configuration npm de Dependabot (`chantier-ui`, `client-ui`, `technicien-ui`)
- Regroupe `react`, `react-dom`, `@types/react` et `@types/react-dom` dans un seul PR par UI
- Évite les échecs CI dus à des versions `react` / `react-dom` désynchronisées (cf. PR #318 où `react-dom` 19.2.7 a été bumpé seul alors que `react` était toujours en 19.2.6)

## Test plan
- [ ] Vérifier que les prochains PRs Dependabot pour React arrivent groupés
- [ ] PR #318 et le PR `react` correspondant pourront être fermés/refaits une fois ce changement mergé