### PR TITLE
fix: afficher l'ensemble du catalogue dans le comptoir et les prestations

### DIFF
--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -424,6 +424,7 @@ export default function Comptoir() {
             options: produits.map((p) => ({
                 value: `produit:${p.id}`,
                 label: `${p.nom}${p.marque ? ` (${p.marque})` : ''}`,
+                searchText: `${p.nom} ${p.marque || ''} ${p.ref || ''} ${(p.refs || []).join(' ')}`.toLowerCase(),
             })),
         },
         {
@@ -431,6 +432,7 @@ export default function Comptoir() {
             options: catalogueBateaux.map((b) => ({
                 value: `bateau:${b.id}`,
                 label: `${b.marque} ${b.modele}`,
+                searchText: `${b.marque} ${b.modele}`.toLowerCase(),
             })),
         },
         {
@@ -438,6 +440,7 @@ export default function Comptoir() {
             options: catalogueMoteurs.map((m) => ({
                 value: `moteur:${m.id}`,
                 label: `${m.marque} ${m.modele}`,
+                searchText: `${m.marque} ${m.modele}`.toLowerCase(),
             })),
         },
         {
@@ -445,6 +448,7 @@ export default function Comptoir() {
             options: catalogueHelices.map((h) => ({
                 value: `helice:${h.id}`,
                 label: `${h.marque} ${h.modele}`,
+                searchText: `${h.marque} ${h.modele}`.toLowerCase(),
             })),
         },
         {
@@ -452,6 +456,7 @@ export default function Comptoir() {
             options: catalogueRemorques.map((r) => ({
                 value: `remorque:${r.id}`,
                 label: `${r.marque} ${r.modele}`,
+                searchText: `${r.marque} ${r.modele}`.toLowerCase(),
             })),
         },
     ], [produits, catalogueBateaux, catalogueMoteurs, catalogueHelices, catalogueRemorques]);
@@ -505,19 +510,34 @@ export default function Comptoir() {
                 moteursRes,
                 remorquesRes,
                 forfaitsRes,
-                servicesRes
+                servicesRes,
+                catProduitsRes,
+                catBateauxRes,
+                catMoteursRes,
+                catHelicesRes,
+                catRemorquesRes
             ] = await Promise.all([
                 api.get('/bateaux'),
                 api.get('/moteurs'),
                 api.get('/remorques'),
                 api.get('/forfaits'),
-                api.get('/services')
+                api.get('/services'),
+                api.get('/catalogue/produits'),
+                api.get('/catalogue/bateaux'),
+                api.get('/catalogue/moteurs'),
+                api.get('/catalogue/helices'),
+                api.get('/catalogue/remorques')
             ]);
             setBateaux(bateauxRes.data || []);
             setMoteurs(moteursRes.data || []);
             setRemorques(remorquesRes.data || []);
             setForfaits(forfaitsRes.data || []);
             setServices(servicesRes.data || []);
+            setProduits(catProduitsRes.data || []);
+            setCatalogueBateaux(catBateauxRes.data || []);
+            setCatalogueMoteurs(catMoteursRes.data || []);
+            setCatalogueHelices(catHelicesRes.data || []);
+            setCatalogueRemorques(catRemorquesRes.data || []);
         } catch {
             message.error('Erreur lors du chargement des listes de reference.');
         }
@@ -1461,7 +1481,9 @@ export default function Comptoir() {
                                                             allowClear
                                                             showSearch
                                                             options={catalogueOptions}
-                                                            filterOption={false}
+                                                            filterOption={(input, option) =>
+                                                                ((option as { searchText?: string } | undefined)?.searchText || '').includes(input.toLowerCase())
+                                                            }
                                                             onSearch={handleCatalogueSearch}
                                                             notFoundContent={null}
                                                             placeholder="Rechercher produit, bateau, moteur, hélice ou remorque"

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -827,6 +827,7 @@ export default function Vente() {
                 servicesRes,
                 mainOeuvresRes,
                 techniciensRes,
+                catProduitsRes,
                 catBateauxRes,
                 catMoteursRes,
                 catHelicesRes,
@@ -839,6 +840,7 @@ export default function Vente() {
                 api.get('/services'),
                 api.get('/main-oeuvres'),
                 api.get('/techniciens'),
+                api.get('/catalogue/produits'),
                 api.get('/catalogue/bateaux'),
                 api.get('/catalogue/moteurs'),
                 api.get('/catalogue/helices'),
@@ -851,6 +853,7 @@ export default function Vente() {
             setServices(servicesRes.data || []);
             setMainOeuvres(mainOeuvresRes.data || []);
             setTechniciens(techniciensRes.data || []);
+            setProduits(catProduitsRes.data || []);
             setCatalogueBateaux(catBateauxRes.data || []);
             setCatalogueMoteurs(catMoteursRes.data || []);
             setCatalogueHelices(catHelicesRes.data || []);
@@ -3491,7 +3494,7 @@ export default function Vente() {
                                                                         allowClear
                                                                         placeholder="Rechercher un produit par nom, marque, catégorie ou réf."
                                                                         options={produitOptionsForService}
-                                                                        filterOption={false}
+                                                                        filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
                                                                         onSearch={handleProduitSearch}
                                                                         notFoundContent={null}
                                                                     />
@@ -3632,7 +3635,7 @@ export default function Vente() {
                                                                             allowClear
                                                                             showSearch
                                                                             options={produitOptions}
-                                                                            filterOption={false}
+                                                                            filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
                                                                             onSearch={handleProduitSearch}
                                                                             notFoundContent={null}
                                                                             placeholder="Rechercher un produit par nom, marque, catégorie ou réf."


### PR DESCRIPTION
## Résumé

Dans les écrans **Comptoir** et **Prestations** de `chantier-ui`, la liste déroulante des produits/bateaux/moteurs/hélices/remorques était vide à l'ouverture : le catalogue n'était récupéré qu'après saisie dans le champ de recherche.

- `comptoir.tsx` : `fetchOptions` charge désormais l'intégralité des catalogues (`/catalogue/produits`, `/catalogue/bateaux`, `/catalogue/moteurs`, `/catalogue/helices`, `/catalogue/remorques`) au montage.
- `comptoir.tsx` : le `<Select>` du catalogue passe d'un filtre 100 % serveur (`filterOption={false}`) à un filtre client basé sur un champ `searchText` (nom, marque, références), tout en conservant `onSearch` pour fusionner d'éventuels nouveaux résultats serveur.
- `vente.tsx` (prestations) : `fetchOptions` charge également `/catalogue/produits` (les autres catalogues étaient déjà préchargés).
- `vente.tsx` : les deux `<Select>` produits des sous-modales « Créer un service » et « Créer un forfait » utilisent maintenant un filtre client cohérent avec le reste du formulaire.

## Plan de test

- [x] Ouvrir l'écran **Comptoir** → cliquer sur « Ajouter » → vérifier que la liste « Produits / Bateaux / Moteurs / Hélices / Remorques » affiche tous les éléments du catalogue sans saisie préalable.
- [x] Saisir un terme (nom, marque, référence) → vérifier que la liste se filtre correctement côté client.
- [x] Ouvrir l'écran **Prestations** → ouvrir une vente → vérifier que la sélection unifiée « Forfait, produit, bateau, moteur… » liste l'ensemble des éléments.
- [x] Dans la sous-modale « Créer un service » et « Créer un forfait », vérifier que le sélecteur de produits associés affiche le catalogue complet et permet la recherche.