### PR TITLE
feat: ajouter une note libre sur le comptoir et les prestations

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
@@ -141,4 +141,7 @@ public class VenteEntity extends PanacheEntity {
     public boolean rappel2Envoye;
     public boolean rappel3Envoye;
 
+    @jakarta.persistence.Column(columnDefinition = "TEXT")
+    public String note;
+
 }

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -201,6 +201,7 @@ interface VenteEntity {
     prixVenteTTC?: number;
     modePaiement?: ModePaiement;
     paiements?: VentePaiement[];
+    note?: string;
 }
 
 interface VenteFormValues {
@@ -223,6 +224,7 @@ interface VenteFormValues {
     montantTTC: number;
     prixVenteTTC: number;
     modePaiement?: ModePaiement;
+    note?: string;
 }
 
 const modePaiementOptions: Array<{ value: ModePaiement; label: string }> = [
@@ -716,7 +718,8 @@ export default function Comptoir() {
                 montantTVA: vente.montantTVA || 0,
                 montantTTC: vente.montantTTC || 0,
                 prixVenteTTC: vente.prixVenteTTC || 0,
-                modePaiement: vente.modePaiement
+                modePaiement: vente.modePaiement,
+                note: vente.note
             });
         } else {
             setIsEdit(false);
@@ -828,7 +831,8 @@ export default function Comptoir() {
         montantTVA: values.montantTVA || 0,
         montantTTC: values.montantTTC || 0,
         prixVenteTTC: values.prixVenteTTC || 0,
-        modePaiement: values.modePaiement
+        modePaiement: values.modePaiement,
+        note: values.note
     });
 
     const handleSave = async () => {
@@ -1022,6 +1026,7 @@ export default function Comptoir() {
                             ${produitRows || '<tr><td colspan="4">Aucun produit</td></tr>'}
                         </tbody>
                     </table>
+                    ${vente.note ? `<div style="margin-top:16px;"><strong>Note:</strong><div style="white-space:pre-wrap;margin-top:4px;">${escapeHtml(vente.note)}</div></div>` : ''}
                 </body>
                 </html>
             `
@@ -1077,6 +1082,7 @@ export default function Comptoir() {
                             return `<div class="line"><span>${escapeHtml(label)}${escapeHtml(avoir)}</span><span>${escapeHtml(formatEuro(p.montant))}</span></div>`;
                         }).join('')
                         : `<div class="line"><span>Paiement</span><span>${escapeHtml(vente.modePaiement || '-')}</span></div>`}
+                    ${vente.note ? `<div class="separator"></div><div style="white-space:pre-wrap;"><strong>Note:</strong><br/>${escapeHtml(vente.note)}</div>` : ''}
                     <div class="center" style="margin-top:12px;">Merci de votre visite</div>
                 </body>
                 </html>
@@ -1578,6 +1584,14 @@ export default function Comptoir() {
                         <Col span={6}>
                             <Form.Item name="prixVenteTTC" label="Prix vente TTC">
                                 <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+
+                    <Row gutter={16}>
+                        <Col span={24}>
+                            <Form.Item name="note" label="Note">
+                                <Input.TextArea rows={3} allowClear placeholder="Note libre (visible sur le devis et la facture)" />
                             </Form.Item>
                         </Col>
                     </Row>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -360,6 +360,7 @@ interface VenteEntity {
     rappel1Envoye?: boolean;
     rappel2Envoye?: boolean;
     rappel3Envoye?: boolean;
+    note?: string;
 }
 
 interface RappelHistoriqueEntity {
@@ -419,6 +420,7 @@ interface VenteFormValues {
     conditionsPaiement?: string;
     penalitesRetard?: string;
     indemniteForfaitaire?: number;
+    note?: string;
 }
 
 
@@ -1483,6 +1485,7 @@ export default function Vente() {
             conditionsPaiement: vente.conditionsPaiement,
             penalitesRetard: vente.penalitesRetard,
             indemniteForfaitaire: vente.indemniteForfaitaire ?? 40,
+            note: vente.note,
         });
     };
 
@@ -1765,7 +1768,8 @@ export default function Vente() {
             documents: values.documents || [],
             rappel1Jours: values.rappel1Jours,
             rappel2Jours: values.rappel2Jours,
-            rappel3Jours: values.rappel3Jours
+            rappel3Jours: values.rappel3Jours,
+            note: values.note
         };
     };
 
@@ -2132,6 +2136,9 @@ export default function Vente() {
         const signatureHtml = docType !== 'facture' && vente.signatureBonPourAccord
             ? `<div class="section"><h3>Signature client</h3><img src="${vente.signatureBonPourAccord}" style="max-width:300px;border:1px solid #d9d9d9;border-radius:4px;" /></div>` : '';
 
+        const noteHtml = vente.note
+            ? `<div class="section"><h3>Note</h3><div class="row" style="white-space:pre-wrap;">${escapeHtml(vente.note)}</div></div>` : '';
+
         return `<html>
             <head>
                 <title>${escapeHtml(title)}</title>
@@ -2160,6 +2167,7 @@ export default function Vente() {
                     ${tableHtml}
                 </div>
                 ${totalsHtml}
+                ${noteHtml}
                 ${conditionsLegalesHtml}
                 ${signatureHtml}
             </body>
@@ -3254,6 +3262,14 @@ export default function Vente() {
                         <Col span={6}>
                             <Form.Item name="indemniteForfaitaire" label="Indemnité forfaitaire (€)">
                                 <InputNumber addonAfter="EUR" min={0} step={1} style={{ width: '100%' }} />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+
+                    <Row gutter={16}>
+                        <Col span={24}>
+                            <Form.Item name="note" label="Note">
+                                <Input.TextArea rows={3} allowClear placeholder="Note libre (visible sur le devis et la facture)" />
                             </Form.Item>
                         </Col>
                     </Row>


### PR DESCRIPTION
## Résumé
- Ajout d'un champ `note` (texte libre) sur l'entité `Vente` côté backend
- Nouvelle zone de saisie « Note » dans les formulaires du comptoir et des prestations
- Affichage de la note sur l'impression du devis, de l'ordre de réparation, de la facture et du ticket de caisse

## Détails

### Backend
- `VenteEntity.java` : nouveau champ `note` (`@Column(columnDefinition = "TEXT")`) pour stocker du texte long

### Comptoir (`chantier-ui/src/comptoir.tsx`)
- Interfaces `VenteEntity` et `VenteFormValues` étendues avec `note?: string`
- `toPayload()` et la pré-remplissage du formulaire propagent la note
- Nouvelle `Form.Item` Textarea (3 lignes) sous le bloc remise / prix
- `handlePrintInvoice` : note rendue sous le tableau produits
- `handlePrintReceipt` : note rendue sur le ticket de caisse

### Prestations (`chantier-ui/src/vente.tsx`)
- Interfaces `VenteEntity` et `VenteFormValues` étendues avec `note?: string`
- `populateForm()` et `toPayload()` propagent la note
- Nouvelle `Form.Item` Textarea après les indemnités forfaitaires
- `buildDocumentHtml` : nouveau bloc `noteHtml` rendu après les totaux, présent sur devis, ordre de réparation et facture

## Plan de test
- [x] Saisir une note sur une vente comptoir puis l'enregistrer ; rouvrir et vérifier la persistance
- [x] Imprimer la facture comptoir : la note apparaît sous le tableau
- [x] Imprimer le ticket de caisse : la note apparaît avant « Merci de votre visite »
- [x] Saisir une note sur une prestation puis l'enregistrer ; rouvrir et vérifier la persistance
- [x] Imprimer le devis / l'ordre de réparation : la note apparaît après les totaux
- [x] Imprimer la facture prestation : la note apparaît après les totaux, avant les conditions légales