### PR TITLE
feat: remise par ligne sur comptoir et prestations

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteBateauCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteBateauCatalogueEntity.java
@@ -1,0 +1,23 @@
+package net.nanthrax.moussaillon.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class VenteBateauCatalogueEntity extends PanacheEntity {
+
+    @ManyToOne
+    public BateauCatalogueEntity bateau;
+
+    @Column(columnDefinition = "integer default 0")
+    public int quantite;
+
+    @Column(columnDefinition = "double default 0")
+    public double remise;
+
+    @Column(columnDefinition = "double default 0")
+    public double remisePourcentage;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteEntity.java
@@ -55,6 +55,28 @@ public class VenteEntity extends PanacheEntity {
     @JoinColumn(name = "vente_id")
     public List<VenteServiceEntity> venteServices = new ArrayList<>();
 
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = jakarta.persistence.FetchType.EAGER)
+    @JoinColumn(name = "vente_id")
+    public List<VenteProduitEntity> venteProduits = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = jakarta.persistence.FetchType.EAGER)
+    @JoinColumn(name = "vente_id")
+    public List<VenteBateauCatalogueEntity> venteBateauxCatalogue = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = jakarta.persistence.FetchType.EAGER)
+    @JoinColumn(name = "vente_id")
+    public List<VenteMoteurCatalogueEntity> venteMoteursCatalogue = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = jakarta.persistence.FetchType.EAGER)
+    @JoinColumn(name = "vente_id")
+    public List<VenteHeliceCatalogueEntity> venteHelicesCatalogue = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = jakarta.persistence.FetchType.EAGER)
+    @JoinColumn(name = "vente_id")
+    public List<VenteRemorqueCatalogueEntity> venteRemorquesCatalogue = new ArrayList<>();
+
+    // Legacy @ManyToMany lists kept temporarily for data migration on startup.
+    // New code should use the venteXxxCatalogue lists above (with quantite and remise per line).
     @ManyToMany
     public List<ProduitCatalogueEntity> produits;
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteForfaitEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteForfaitEntity.java
@@ -23,6 +23,12 @@ public class VenteForfaitEntity extends PanacheEntity {
 
     public int quantite;
 
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double remise;
+
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double remisePourcentage;
+
     @ManyToMany(fetch = FetchType.EAGER)
     public List<TechnicienEntity> techniciens = new ArrayList<>();
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteHeliceCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteHeliceCatalogueEntity.java
@@ -1,0 +1,23 @@
+package net.nanthrax.moussaillon.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class VenteHeliceCatalogueEntity extends PanacheEntity {
+
+    @ManyToOne
+    public HeliceCatalogueEntity helice;
+
+    @Column(columnDefinition = "integer default 0")
+    public int quantite;
+
+    @Column(columnDefinition = "double default 0")
+    public double remise;
+
+    @Column(columnDefinition = "double default 0")
+    public double remisePourcentage;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteMoteurCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteMoteurCatalogueEntity.java
@@ -1,0 +1,23 @@
+package net.nanthrax.moussaillon.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class VenteMoteurCatalogueEntity extends PanacheEntity {
+
+    @ManyToOne
+    public MoteurCatalogueEntity moteur;
+
+    @Column(columnDefinition = "integer default 0")
+    public int quantite;
+
+    @Column(columnDefinition = "double default 0")
+    public double remise;
+
+    @Column(columnDefinition = "double default 0")
+    public double remisePourcentage;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteProduitEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteProduitEntity.java
@@ -1,0 +1,23 @@
+package net.nanthrax.moussaillon.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class VenteProduitEntity extends PanacheEntity {
+
+    @ManyToOne
+    public ProduitCatalogueEntity produit;
+
+    @Column(columnDefinition = "integer default 0")
+    public int quantite;
+
+    @Column(columnDefinition = "double default 0")
+    public double remise;
+
+    @Column(columnDefinition = "double default 0")
+    public double remisePourcentage;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteRemorqueCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteRemorqueCatalogueEntity.java
@@ -1,0 +1,23 @@
+package net.nanthrax.moussaillon.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class VenteRemorqueCatalogueEntity extends PanacheEntity {
+
+    @ManyToOne
+    public RemorqueCatalogueEntity remorque;
+
+    @Column(columnDefinition = "integer default 0")
+    public int quantite;
+
+    @Column(columnDefinition = "double default 0")
+    public double remise;
+
+    @Column(columnDefinition = "double default 0")
+    public double remisePourcentage;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteServiceEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/VenteServiceEntity.java
@@ -23,6 +23,12 @@ public class VenteServiceEntity extends PanacheEntity {
 
     public int quantite;
 
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double remise;
+
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double remisePourcentage;
+
     @ManyToMany(fetch = FetchType.EAGER)
     public List<TechnicienEntity> techniciens = new ArrayList<>();
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/AvoirResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/AvoirResource.java
@@ -24,10 +24,10 @@ import net.nanthrax.moussaillon.persistence.AvoirEntity;
 import net.nanthrax.moussaillon.persistence.AvoirLigneEntity;
 import net.nanthrax.moussaillon.persistence.ClientEntity;
 import net.nanthrax.moussaillon.persistence.EmailTemplateEntity;
-import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
 import net.nanthrax.moussaillon.persistence.VenteEntity;
 import net.nanthrax.moussaillon.persistence.VenteForfaitEntity;
+import net.nanthrax.moussaillon.persistence.VenteProduitEntity;
 import net.nanthrax.moussaillon.persistence.VenteServiceEntity;
 
 @Path("/avoirs")
@@ -148,8 +148,11 @@ public class AvoirResource {
                 ligne.quantite = Math.max(1, vf.quantite);
                 ligne.prixUnitaireHT = vf.forfait.prixHT;
                 ligne.tva = vf.forfait.tva > 0 ? vf.forfait.tva : tvaTaux;
-                ligne.montantTVA = round2(ligne.prixUnitaireHT * ligne.quantite * (ligne.tva / 100.0));
-                ligne.totalTTC = round2(vf.forfait.prixTTC * ligne.quantite);
+                double brutTTC = vf.forfait.prixTTC * ligne.quantite;
+                double netTTC = Math.max(0, brutTTC - vf.remise);
+                double ratio = brutTTC > 0 ? netTTC / brutTTC : 1.0;
+                ligne.montantTVA = round2(ligne.prixUnitaireHT * ligne.quantite * (ligne.tva / 100.0) * ratio);
+                ligne.totalTTC = round2(netTTC);
                 avoir.lignes.add(ligne);
             }
         }
@@ -163,35 +166,31 @@ public class AvoirResource {
                 ligne.quantite = Math.max(1, vs.quantite);
                 ligne.prixUnitaireHT = vs.service.prixHT;
                 ligne.tva = vs.service.tva > 0 ? vs.service.tva : tvaTaux;
-                ligne.montantTVA = round2(ligne.prixUnitaireHT * ligne.quantite * (ligne.tva / 100.0));
-                ligne.totalTTC = round2(vs.service.prixTTC * ligne.quantite);
+                double brutTTC = vs.service.prixTTC * ligne.quantite;
+                double netTTC = Math.max(0, brutTTC - vs.remise);
+                double ratio = brutTTC > 0 ? netTTC / brutTTC : 1.0;
+                ligne.montantTVA = round2(ligne.prixUnitaireHT * ligne.quantite * (ligne.tva / 100.0) * ratio);
+                ligne.totalTTC = round2(netTTC);
                 avoir.lignes.add(ligne);
             }
         }
 
-        // Lignes depuis les produits (regroupés par id)
-        if (vente.produits != null && !vente.produits.isEmpty()) {
-            java.util.Map<Long, int[]> counts = new java.util.LinkedHashMap<>();
-            java.util.Map<Long, ProduitCatalogueEntity> byId = new java.util.LinkedHashMap<>();
-            for (ProduitCatalogueEntity p : vente.produits) {
-                if (p == null || p.id == null) continue;
-                counts.computeIfAbsent(p.id, k -> new int[]{0});
-                counts.get(p.id)[0]++;
-                byId.putIfAbsent(p.id, p);
-            }
-            for (java.util.Map.Entry<Long, int[]> entry : counts.entrySet()) {
-                ProduitCatalogueEntity p = byId.get(entry.getKey());
-                if (p == null) continue;
-                int qty = entry.getValue()[0];
+        // Lignes depuis les produits
+        if (vente.venteProduits != null) {
+            for (VenteProduitEntity vp : vente.venteProduits) {
+                if (vp.produit == null) continue;
                 AvoirLigneEntity ligne = new AvoirLigneEntity();
-                String nom = p.nom != null ? p.nom : "Produit";
-                if (p.marque != null && !p.marque.isBlank()) nom += " (" + p.marque + ")";
+                String nom = vp.produit.nom != null ? vp.produit.nom : "Produit";
+                if (vp.produit.marque != null && !vp.produit.marque.isBlank()) nom += " (" + vp.produit.marque + ")";
                 ligne.designation = nom;
-                ligne.quantite = qty;
-                ligne.prixUnitaireHT = p.prixVenteHT;
-                ligne.tva = p.tva > 0 ? p.tva : tvaTaux;
-                ligne.montantTVA = round2(ligne.prixUnitaireHT * qty * (ligne.tva / 100.0));
-                ligne.totalTTC = round2(p.prixVenteTTC * qty);
+                ligne.quantite = Math.max(1, vp.quantite);
+                ligne.prixUnitaireHT = vp.produit.prixVenteHT;
+                ligne.tva = vp.produit.tva > 0 ? vp.produit.tva : tvaTaux;
+                double brutTTC = vp.produit.prixVenteTTC * ligne.quantite;
+                double netTTC = Math.max(0, brutTTC - vp.remise);
+                double ratio = brutTTC > 0 ? netTTC / brutTTC : 1.0;
+                ligne.montantTVA = round2(ligne.prixUnitaireHT * ligne.quantite * (ligne.tva / 100.0) * ratio);
+                ligne.totalTTC = round2(netTTC);
                 avoir.lignes.add(ligne);
             }
         }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
@@ -194,7 +194,7 @@ public class ClientPortalResource {
             entity.signatureBonPourAccord = body.get("signature");
         }
         // Force initialization of lazy collections before serialization
-        if (entity.produits != null) entity.produits.size();
+        if (entity.venteProduits != null) entity.venteProduits.size();
         return entity;
     }
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/FacturXService.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/FacturXService.java
@@ -6,9 +6,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -24,14 +22,14 @@ import org.mustangproject.Product;
 import org.mustangproject.TradeParty;
 import org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA3;
 
-import net.nanthrax.moussaillon.persistence.BateauCatalogueEntity;
-import net.nanthrax.moussaillon.persistence.HeliceCatalogueEntity;
-import net.nanthrax.moussaillon.persistence.MoteurCatalogueEntity;
-import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
-import net.nanthrax.moussaillon.persistence.RemorqueCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
+import net.nanthrax.moussaillon.persistence.VenteBateauCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.VenteEntity;
 import net.nanthrax.moussaillon.persistence.VenteForfaitEntity;
+import net.nanthrax.moussaillon.persistence.VenteHeliceCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.VenteMoteurCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.VenteProduitEntity;
+import net.nanthrax.moussaillon.persistence.VenteRemorqueCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.VenteServiceEntity;
 
 @ApplicationScoped
@@ -126,15 +124,20 @@ public class FacturXService {
                 List<LignePdf> lignes = extraireLignes(vente);
                 if (lignes.isEmpty()) {
                     lignes.add(new LignePdf("Prestations diverses", 1,
-                        vente.montantHT, vente.prixVenteTTC, vente.tva > 0 ? vente.tva : TVA_DEFAUT));
+                        vente.montantHT, vente.prixVenteTTC, vente.tva > 0 ? vente.tva : TVA_DEFAUT, 0));
                 }
                 for (LignePdf ligne : lignes) {
                     if (y < 130) break;
-                    y = drawText(cs, fontNormal, 9, ligne.designation, colDes, y);
+                    String designation = ligne.designation;
+                    if (ligne.remise > 0) {
+                        designation += String.format(" (remise %.2f €)", ligne.remise);
+                    }
+                    y = drawText(cs, fontNormal, 9, designation, colDes, y);
                     float rowY = y + 9;
+                    double totalTTC = Math.max(0, ligne.prixTTC * ligne.quantite - ligne.remise);
                     drawTextAt(cs, fontNormal, 9, String.valueOf(ligne.quantite),                           colQte,  rowY);
                     drawTextAt(cs, fontNormal, 9, String.format("%.2f €", ligne.prixHT),               colPuHT, rowY);
-                    drawTextAt(cs, fontNormal, 9, String.format("%.2f €", ligne.prixTTC * ligne.quantite), colTtc, rowY);
+                    drawTextAt(cs, fontNormal, 9, String.format("%.2f €", totalTTC),                   colTtc, rowY);
                     y -= 3;
                 }
 
@@ -222,14 +225,20 @@ public class FacturXService {
         List<LignePdf> lignes = extraireLignes(vente);
         if (lignes.isEmpty()) {
             lignes.add(new LignePdf("Prestations diverses", 1,
-                vente.montantHT, vente.prixVenteTTC, vente.tva > 0 ? vente.tva : TVA_DEFAUT));
+                vente.montantHT, vente.prixVenteTTC, vente.tva > 0 ? vente.tva : TVA_DEFAUT, 0));
         }
         for (LignePdf ligne : lignes) {
             Product produit = new Product(ligne.designation, "", "C62",
                 BigDecimal.valueOf(ligne.tva).setScale(2, RoundingMode.HALF_UP));
+            // Apply line-level remise by reducing the effective unit HT price.
+            double brutTTC = ligne.prixTTC * ligne.quantite;
+            double ratio = (brutTTC > 0 && ligne.remise > 0)
+                ? Math.max(0, brutTTC - ligne.remise) / brutTTC
+                : 1.0;
+            double effectivePrixHT = ligne.prixHT * ratio;
             Item item = new Item(produit,
                 BigDecimal.valueOf(ligne.quantite),
-                BigDecimal.valueOf(ligne.prixHT).setScale(4, RoundingMode.HALF_UP));
+                BigDecimal.valueOf(effectivePrixHT).setScale(4, RoundingMode.HALF_UP));
             invoice.addItem(item);
         }
 
@@ -246,7 +255,7 @@ public class FacturXService {
                 double tva = vf.forfait.tva > 0 ? vf.forfait.tva : tvaGlobale;
                 double prixHT = vf.forfait.prixHT > 0 ? vf.forfait.prixHT
                     : vf.forfait.prixTTC / (1 + tva / 100);
-                lignes.add(new LignePdf(safe(vf.forfait.nom, "Forfait"), vf.quantite, prixHT, vf.forfait.prixTTC, tva));
+                lignes.add(new LignePdf(safe(vf.forfait.nom, "Forfait"), vf.quantite, prixHT, vf.forfait.prixTTC, tva, vf.remise));
             }
         }
 
@@ -256,87 +265,52 @@ public class FacturXService {
                 double tva = vs.service.tva > 0 ? vs.service.tva : tvaGlobale;
                 double prixHT = vs.service.prixHT > 0 ? vs.service.prixHT
                     : vs.service.prixTTC / (1 + tva / 100);
-                lignes.add(new LignePdf(safe(vs.service.nom, "Service"), vs.quantite, prixHT, vs.service.prixTTC, tva));
+                lignes.add(new LignePdf(safe(vs.service.nom, "Service"), vs.quantite, prixHT, vs.service.prixTTC, tva, vs.remise));
             }
         }
 
-        if (vente.produits != null && !vente.produits.isEmpty()) {
-            Map<Long, int[]> counts = new HashMap<>();
-            Map<Long, ProduitCatalogueEntity> map = new HashMap<>();
-            for (ProduitCatalogueEntity p : vente.produits) {
-                if (p.id == null) continue;
-                counts.merge(p.id, new int[]{1}, (a, b) -> new int[]{a[0] + 1});
-                map.putIfAbsent(p.id, p);
-            }
-            for (Map.Entry<Long, int[]> e : counts.entrySet()) {
-                ProduitCatalogueEntity p = map.get(e.getKey());
-                double tva = p.tva > 0 ? p.tva : tvaGlobale;
-                double prixHT = p.prixVenteTTC / (1 + tva / 100);
-                lignes.add(new LignePdf(safe(p.nom, "Produit"), e.getValue()[0], prixHT, p.prixVenteTTC, tva));
+        if (vente.venteProduits != null) {
+            for (VenteProduitEntity vp : vente.venteProduits) {
+                if (vp.produit == null) continue;
+                double tva = vp.produit.tva > 0 ? vp.produit.tva : tvaGlobale;
+                double prixHT = vp.produit.prixVenteTTC / (1 + tva / 100);
+                lignes.add(new LignePdf(safe(vp.produit.nom, "Produit"), vp.quantite, prixHT, vp.produit.prixVenteTTC, tva, vp.remise));
             }
         }
 
-        if (vente.bateauxCatalogue != null && !vente.bateauxCatalogue.isEmpty()) {
-            Map<Long, int[]> counts = new HashMap<>();
-            Map<Long, BateauCatalogueEntity> map = new HashMap<>();
-            for (BateauCatalogueEntity b : vente.bateauxCatalogue) {
-                if (b.id == null) continue;
-                counts.merge(b.id, new int[]{1}, (a, c) -> new int[]{a[0] + 1});
-                map.putIfAbsent(b.id, b);
-            }
-            for (Map.Entry<Long, int[]> e : counts.entrySet()) {
-                BateauCatalogueEntity b = map.get(e.getKey());
-                double tva = b.tva > 0 ? b.tva : tvaGlobale;
-                double prixHT = b.prixVenteTTC / (1 + tva / 100);
-                lignes.add(new LignePdf(safe(b.marque, "") + " " + safe(b.modele, "Bateau"), e.getValue()[0], prixHT, b.prixVenteTTC, tva));
+        if (vente.venteBateauxCatalogue != null) {
+            for (VenteBateauCatalogueEntity vb : vente.venteBateauxCatalogue) {
+                if (vb.bateau == null) continue;
+                double tva = vb.bateau.tva > 0 ? vb.bateau.tva : tvaGlobale;
+                double prixHT = vb.bateau.prixVenteTTC / (1 + tva / 100);
+                lignes.add(new LignePdf(safe(vb.bateau.marque, "") + " " + safe(vb.bateau.modele, "Bateau"), vb.quantite, prixHT, vb.bateau.prixVenteTTC, tva, vb.remise));
             }
         }
 
-        if (vente.moteursCatalogue != null && !vente.moteursCatalogue.isEmpty()) {
-            Map<Long, int[]> counts = new HashMap<>();
-            Map<Long, MoteurCatalogueEntity> map = new HashMap<>();
-            for (MoteurCatalogueEntity m : vente.moteursCatalogue) {
-                if (m.id == null) continue;
-                counts.merge(m.id, new int[]{1}, (a, c) -> new int[]{a[0] + 1});
-                map.putIfAbsent(m.id, m);
-            }
-            for (Map.Entry<Long, int[]> e : counts.entrySet()) {
-                MoteurCatalogueEntity m = map.get(e.getKey());
-                double tva = m.tva > 0 ? m.tva : tvaGlobale;
-                double prixHT = m.prixVenteTTC / (1 + tva / 100);
-                lignes.add(new LignePdf(safe(m.marque, "") + " " + safe(m.modele, "Moteur"), e.getValue()[0], prixHT, m.prixVenteTTC, tva));
+        if (vente.venteMoteursCatalogue != null) {
+            for (VenteMoteurCatalogueEntity vm : vente.venteMoteursCatalogue) {
+                if (vm.moteur == null) continue;
+                double tva = vm.moteur.tva > 0 ? vm.moteur.tva : tvaGlobale;
+                double prixHT = vm.moteur.prixVenteTTC / (1 + tva / 100);
+                lignes.add(new LignePdf(safe(vm.moteur.marque, "") + " " + safe(vm.moteur.modele, "Moteur"), vm.quantite, prixHT, vm.moteur.prixVenteTTC, tva, vm.remise));
             }
         }
 
-        if (vente.helicesCatalogue != null && !vente.helicesCatalogue.isEmpty()) {
-            Map<Long, int[]> counts = new HashMap<>();
-            Map<Long, HeliceCatalogueEntity> map = new HashMap<>();
-            for (HeliceCatalogueEntity h : vente.helicesCatalogue) {
-                if (h.id == null) continue;
-                counts.merge(h.id, new int[]{1}, (a, c) -> new int[]{a[0] + 1});
-                map.putIfAbsent(h.id, h);
-            }
-            for (Map.Entry<Long, int[]> e : counts.entrySet()) {
-                HeliceCatalogueEntity h = map.get(e.getKey());
-                double tva = h.tva > 0 ? h.tva : tvaGlobale;
-                double prixHT = h.prixVenteTTC / (1 + tva / 100);
-                lignes.add(new LignePdf(safe(h.marque, "") + " " + safe(h.modele, "Hélice"), e.getValue()[0], prixHT, h.prixVenteTTC, tva));
+        if (vente.venteHelicesCatalogue != null) {
+            for (VenteHeliceCatalogueEntity vh : vente.venteHelicesCatalogue) {
+                if (vh.helice == null) continue;
+                double tva = vh.helice.tva > 0 ? vh.helice.tva : tvaGlobale;
+                double prixHT = vh.helice.prixVenteTTC / (1 + tva / 100);
+                lignes.add(new LignePdf(safe(vh.helice.marque, "") + " " + safe(vh.helice.modele, "Hélice"), vh.quantite, prixHT, vh.helice.prixVenteTTC, tva, vh.remise));
             }
         }
 
-        if (vente.remorquesCatalogue != null && !vente.remorquesCatalogue.isEmpty()) {
-            Map<Long, int[]> counts = new HashMap<>();
-            Map<Long, RemorqueCatalogueEntity> map = new HashMap<>();
-            for (RemorqueCatalogueEntity r : vente.remorquesCatalogue) {
-                if (r.id == null) continue;
-                counts.merge(r.id, new int[]{1}, (a, c) -> new int[]{a[0] + 1});
-                map.putIfAbsent(r.id, r);
-            }
-            for (Map.Entry<Long, int[]> e : counts.entrySet()) {
-                RemorqueCatalogueEntity r = map.get(e.getKey());
-                double tva = r.tva > 0 ? r.tva : tvaGlobale;
-                double prixHT = r.prixVenteTTC / (1 + tva / 100);
-                lignes.add(new LignePdf(safe(r.marque, "") + " " + safe(r.modele, "Remorque"), e.getValue()[0], prixHT, r.prixVenteTTC, tva));
+        if (vente.venteRemorquesCatalogue != null) {
+            for (VenteRemorqueCatalogueEntity vr : vente.venteRemorquesCatalogue) {
+                if (vr.remorque == null) continue;
+                double tva = vr.remorque.tva > 0 ? vr.remorque.tva : tvaGlobale;
+                double prixHT = vr.remorque.prixVenteTTC / (1 + tva / 100);
+                lignes.add(new LignePdf(safe(vr.remorque.marque, "") + " " + safe(vr.remorque.modele, "Remorque"), vr.quantite, prixHT, vr.remorque.prixVenteTTC, tva, vr.remise));
             }
         }
 
@@ -410,13 +384,15 @@ public class FacturXService {
         final double prixHT;
         final double prixTTC;
         final double tva;
+        final double remise;
 
-        LignePdf(String designation, int quantite, double prixHT, double prixTTC, double tva) {
+        LignePdf(String designation, int quantite, double prixHT, double prixTTC, double tva, double remise) {
             this.designation = designation;
             this.quantite    = quantite;
             this.prixHT      = prixHT;
             this.prixTTC     = prixTTC;
             this.tva         = tva;
+            this.remise      = remise;
         }
     }
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
@@ -526,11 +526,12 @@ public class TechnicienPortalResource {
     }
 
     private void decrementStock(VenteEntity vente) {
-        if (vente.produits != null) {
-            for (ProduitCatalogueEntity produit : vente.produits) {
-                ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(produit.id);
+        if (vente.venteProduits != null) {
+            for (net.nanthrax.moussaillon.persistence.VenteProduitEntity vp : vente.venteProduits) {
+                if (vp.produit == null || vp.produit.id == null) continue;
+                ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(vp.produit.id);
                 if (p != null) {
-                    p.stock = Math.max(0, p.stock - 1);
+                    p.stock = Math.max(0, p.stock - Math.max(1, vp.quantite));
                 }
             }
         }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteLignesMigrator.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteLignesMigrator.java
@@ -1,0 +1,118 @@
+package net.nanthrax.moussaillon.services;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.transaction.Transactional;
+import net.nanthrax.moussaillon.persistence.BateauCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.HeliceCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.MoteurCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.RemorqueCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.VenteBateauCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.VenteEntity;
+import net.nanthrax.moussaillon.persistence.VenteHeliceCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.VenteMoteurCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.VenteProduitEntity;
+import net.nanthrax.moussaillon.persistence.VenteRemorqueCatalogueEntity;
+
+/**
+ * Migrates the historical @ManyToMany lists on VenteEntity (produits, bateauxCatalogue,
+ * moteursCatalogue, helicesCatalogue, remorquesCatalogue) — where quantity was encoded by
+ * duplicating entries — into the new dedicated line entities that carry quantite + remise.
+ *
+ * Runs once on startup, idempotent: only migrates ventes that still have legacy entries and
+ * empty new lists.
+ */
+@ApplicationScoped
+public class VenteLignesMigrator {
+
+    @Transactional
+    void onStart(@Observes StartupEvent event) {
+        List<VenteEntity> ventes = VenteEntity.listAll();
+        for (VenteEntity vente : ventes) {
+            migrateVente(vente);
+        }
+    }
+
+    private void migrateVente(VenteEntity vente) {
+        if (vente.produits != null && !vente.produits.isEmpty() && vente.venteProduits.isEmpty()) {
+            Map<Long, Integer> counts = countById(vente.produits, p -> p.id);
+            for (Map.Entry<Long, Integer> entry : counts.entrySet()) {
+                ProduitCatalogueEntity ref = ProduitCatalogueEntity.findById(entry.getKey());
+                if (ref == null) continue;
+                VenteProduitEntity line = new VenteProduitEntity();
+                line.produit = ref;
+                line.quantite = entry.getValue();
+                vente.venteProduits.add(line);
+            }
+            vente.produits.clear();
+        }
+
+        if (vente.bateauxCatalogue != null && !vente.bateauxCatalogue.isEmpty() && vente.venteBateauxCatalogue.isEmpty()) {
+            Map<Long, Integer> counts = countById(vente.bateauxCatalogue, b -> b.id);
+            for (Map.Entry<Long, Integer> entry : counts.entrySet()) {
+                BateauCatalogueEntity ref = BateauCatalogueEntity.findById(entry.getKey());
+                if (ref == null) continue;
+                VenteBateauCatalogueEntity line = new VenteBateauCatalogueEntity();
+                line.bateau = ref;
+                line.quantite = entry.getValue();
+                vente.venteBateauxCatalogue.add(line);
+            }
+            vente.bateauxCatalogue.clear();
+        }
+
+        if (vente.moteursCatalogue != null && !vente.moteursCatalogue.isEmpty() && vente.venteMoteursCatalogue.isEmpty()) {
+            Map<Long, Integer> counts = countById(vente.moteursCatalogue, m -> m.id);
+            for (Map.Entry<Long, Integer> entry : counts.entrySet()) {
+                MoteurCatalogueEntity ref = MoteurCatalogueEntity.findById(entry.getKey());
+                if (ref == null) continue;
+                VenteMoteurCatalogueEntity line = new VenteMoteurCatalogueEntity();
+                line.moteur = ref;
+                line.quantite = entry.getValue();
+                vente.venteMoteursCatalogue.add(line);
+            }
+            vente.moteursCatalogue.clear();
+        }
+
+        if (vente.helicesCatalogue != null && !vente.helicesCatalogue.isEmpty() && vente.venteHelicesCatalogue.isEmpty()) {
+            Map<Long, Integer> counts = countById(vente.helicesCatalogue, h -> h.id);
+            for (Map.Entry<Long, Integer> entry : counts.entrySet()) {
+                HeliceCatalogueEntity ref = HeliceCatalogueEntity.findById(entry.getKey());
+                if (ref == null) continue;
+                VenteHeliceCatalogueEntity line = new VenteHeliceCatalogueEntity();
+                line.helice = ref;
+                line.quantite = entry.getValue();
+                vente.venteHelicesCatalogue.add(line);
+            }
+            vente.helicesCatalogue.clear();
+        }
+
+        if (vente.remorquesCatalogue != null && !vente.remorquesCatalogue.isEmpty() && vente.venteRemorquesCatalogue.isEmpty()) {
+            Map<Long, Integer> counts = countById(vente.remorquesCatalogue, r -> r.id);
+            for (Map.Entry<Long, Integer> entry : counts.entrySet()) {
+                RemorqueCatalogueEntity ref = RemorqueCatalogueEntity.findById(entry.getKey());
+                if (ref == null) continue;
+                VenteRemorqueCatalogueEntity line = new VenteRemorqueCatalogueEntity();
+                line.remorque = ref;
+                line.quantite = entry.getValue();
+                vente.venteRemorquesCatalogue.add(line);
+            }
+            vente.remorquesCatalogue.clear();
+        }
+    }
+
+    private <T> Map<Long, Integer> countById(List<T> items, java.util.function.Function<T, Long> idGetter) {
+        Map<Long, Integer> counts = new LinkedHashMap<>();
+        for (T item : items) {
+            Long id = idGetter.apply(item);
+            if (id == null) continue;
+            counts.merge(id, 1, Integer::sum);
+        }
+        return counts;
+    }
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -2,9 +2,7 @@ package net.nanthrax.moussaillon.services;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.Mailer;
@@ -35,9 +33,14 @@ import net.nanthrax.moussaillon.persistence.RemorqueCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.ServiceEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
 import net.nanthrax.moussaillon.persistence.TaskEntity;
+import net.nanthrax.moussaillon.persistence.VenteBateauCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.VenteEntity;
 import net.nanthrax.moussaillon.persistence.VenteForfaitEntity;
+import net.nanthrax.moussaillon.persistence.VenteHeliceCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.VenteMoteurCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.VentePaiementEntity;
+import net.nanthrax.moussaillon.persistence.VenteProduitEntity;
+import net.nanthrax.moussaillon.persistence.VenteRemorqueCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.VenteServiceEntity;
 
 @Path("/ventes")
@@ -134,31 +137,28 @@ public class VenteResource {
                 String nom = vf.forfait != null ? vf.forfait.nom : "Forfait";
                 lignes.append("- Forfait : ").append(nom).append(" x").append(vf.quantite);
                 if (showPrices) {
-                    double total = vf.forfait != null ? vf.forfait.prixTTC * vf.quantite : 0;
+                    double base = vf.forfait != null ? vf.forfait.prixTTC * vf.quantite : 0;
+                    double total = Math.max(0, base - vf.remise);
                     lignes.append(" = ").append(String.format("%.2f EUR", total));
+                    if (vf.remise > 0) {
+                        lignes.append(" (remise ").append(String.format("%.2f EUR", vf.remise)).append(")");
+                    }
                 }
                 lignes.append("\n");
             }
         }
-        if (entity.produits != null) {
-            Map<Long, int[]> produitCount = new HashMap<>();
-            Map<Long, ProduitCatalogueEntity> produitMap = new HashMap<>();
-            for (ProduitCatalogueEntity p : entity.produits) {
-                if (p.id != null) {
-                    produitCount.computeIfAbsent(p.id, k -> new int[]{0, 0});
-                    produitCount.get(p.id)[0]++;
-                    produitCount.get(p.id)[1] += (int) (p.prixVenteTTC * 100);
-                    produitMap.putIfAbsent(p.id, p);
-                }
-            }
-            for (Map.Entry<Long, int[]> entry : produitCount.entrySet()) {
-                ProduitCatalogueEntity p = produitMap.get(entry.getKey());
-                String nom = p.nom + (p.marque != null ? " (" + p.marque + ")" : "");
-                int qty = entry.getValue()[0];
-                lignes.append("- Produit : ").append(nom).append(" x").append(qty);
+        if (entity.venteProduits != null) {
+            for (VenteProduitEntity vp : entity.venteProduits) {
+                if (vp.produit == null) continue;
+                String nom = vp.produit.nom + (vp.produit.marque != null ? " (" + vp.produit.marque + ")" : "");
+                lignes.append("- Produit : ").append(nom).append(" x").append(vp.quantite);
                 if (showPrices) {
-                    double total = entry.getValue()[1] / 100.0;
+                    double base = vp.produit.prixVenteTTC * vp.quantite;
+                    double total = Math.max(0, base - vp.remise);
                     lignes.append(" = ").append(String.format("%.2f EUR", total));
+                    if (vp.remise > 0) {
+                        lignes.append(" (remise ").append(String.format("%.2f EUR", vp.remise)).append(")");
+                    }
                 }
                 lignes.append("\n");
             }
@@ -168,85 +168,77 @@ public class VenteResource {
                 String nom = vs.service != null ? vs.service.nom : "Service";
                 lignes.append("- Service : ").append(nom).append(" x").append(vs.quantite);
                 if (showPrices) {
-                    double total = vs.service != null ? vs.service.prixTTC * vs.quantite : 0;
+                    double base = vs.service != null ? vs.service.prixTTC * vs.quantite : 0;
+                    double total = Math.max(0, base - vs.remise);
                     lignes.append(" = ").append(String.format("%.2f EUR", total));
+                    if (vs.remise > 0) {
+                        lignes.append(" (remise ").append(String.format("%.2f EUR", vs.remise)).append(")");
+                    }
                 }
                 lignes.append("\n");
             }
         }
-        if (entity.bateauxCatalogue != null && !entity.bateauxCatalogue.isEmpty()) {
-            Map<Long, int[]> count = new HashMap<>();
-            Map<Long, BateauCatalogueEntity> map = new HashMap<>();
-            for (BateauCatalogueEntity b : entity.bateauxCatalogue) {
-                if (b.id != null) {
-                    count.computeIfAbsent(b.id, k -> new int[]{0, 0});
-                    count.get(b.id)[0]++;
-                    count.get(b.id)[1] += (int) (b.prixVenteTTC * 100);
-                    map.putIfAbsent(b.id, b);
+        if (entity.venteBateauxCatalogue != null) {
+            for (VenteBateauCatalogueEntity vb : entity.venteBateauxCatalogue) {
+                if (vb.bateau == null) continue;
+                String nom = vb.bateau.marque + " " + vb.bateau.modele;
+                lignes.append("- Bateau : ").append(nom).append(" x").append(vb.quantite);
+                if (showPrices) {
+                    double base = vb.bateau.prixVenteTTC * vb.quantite;
+                    double total = Math.max(0, base - vb.remise);
+                    lignes.append(" = ").append(String.format("%.2f EUR", total));
+                    if (vb.remise > 0) {
+                        lignes.append(" (remise ").append(String.format("%.2f EUR", vb.remise)).append(")");
+                    }
                 }
-            }
-            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
-                BateauCatalogueEntity b = map.get(entry.getKey());
-                String nom = b.marque + " " + b.modele;
-                lignes.append("- Bateau : ").append(nom).append(" x").append(entry.getValue()[0]);
-                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
                 lignes.append("\n");
             }
         }
-        if (entity.moteursCatalogue != null && !entity.moteursCatalogue.isEmpty()) {
-            Map<Long, int[]> count = new HashMap<>();
-            Map<Long, MoteurCatalogueEntity> map = new HashMap<>();
-            for (MoteurCatalogueEntity m : entity.moteursCatalogue) {
-                if (m.id != null) {
-                    count.computeIfAbsent(m.id, k -> new int[]{0, 0});
-                    count.get(m.id)[0]++;
-                    count.get(m.id)[1] += (int) (m.prixVenteTTC * 100);
-                    map.putIfAbsent(m.id, m);
+        if (entity.venteMoteursCatalogue != null) {
+            for (VenteMoteurCatalogueEntity vm : entity.venteMoteursCatalogue) {
+                if (vm.moteur == null) continue;
+                String nom = vm.moteur.marque + " " + vm.moteur.modele;
+                lignes.append("- Moteur : ").append(nom).append(" x").append(vm.quantite);
+                if (showPrices) {
+                    double base = vm.moteur.prixVenteTTC * vm.quantite;
+                    double total = Math.max(0, base - vm.remise);
+                    lignes.append(" = ").append(String.format("%.2f EUR", total));
+                    if (vm.remise > 0) {
+                        lignes.append(" (remise ").append(String.format("%.2f EUR", vm.remise)).append(")");
+                    }
                 }
-            }
-            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
-                MoteurCatalogueEntity m = map.get(entry.getKey());
-                String nom = m.marque + " " + m.modele;
-                lignes.append("- Moteur : ").append(nom).append(" x").append(entry.getValue()[0]);
-                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
                 lignes.append("\n");
             }
         }
-        if (entity.helicesCatalogue != null && !entity.helicesCatalogue.isEmpty()) {
-            Map<Long, int[]> count = new HashMap<>();
-            Map<Long, HeliceCatalogueEntity> map = new HashMap<>();
-            for (HeliceCatalogueEntity h : entity.helicesCatalogue) {
-                if (h.id != null) {
-                    count.computeIfAbsent(h.id, k -> new int[]{0, 0});
-                    count.get(h.id)[0]++;
-                    count.get(h.id)[1] += (int) (h.prixVenteTTC * 100);
-                    map.putIfAbsent(h.id, h);
+        if (entity.venteHelicesCatalogue != null) {
+            for (VenteHeliceCatalogueEntity vh : entity.venteHelicesCatalogue) {
+                if (vh.helice == null) continue;
+                String nom = vh.helice.marque + " " + vh.helice.modele;
+                lignes.append("- Hélice : ").append(nom).append(" x").append(vh.quantite);
+                if (showPrices) {
+                    double base = vh.helice.prixVenteTTC * vh.quantite;
+                    double total = Math.max(0, base - vh.remise);
+                    lignes.append(" = ").append(String.format("%.2f EUR", total));
+                    if (vh.remise > 0) {
+                        lignes.append(" (remise ").append(String.format("%.2f EUR", vh.remise)).append(")");
+                    }
                 }
-            }
-            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
-                HeliceCatalogueEntity h = map.get(entry.getKey());
-                String nom = h.marque + " " + h.modele;
-                lignes.append("- Hélice : ").append(nom).append(" x").append(entry.getValue()[0]);
-                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
                 lignes.append("\n");
             }
         }
-        if (entity.remorquesCatalogue != null && !entity.remorquesCatalogue.isEmpty()) {
-            Map<Long, int[]> count = new HashMap<>();
-            Map<Long, RemorqueCatalogueEntity> map = new HashMap<>();
-            for (RemorqueCatalogueEntity r : entity.remorquesCatalogue) {
-                if (r.id != null) {
-                    count.computeIfAbsent(r.id, k -> new int[]{0, 0});
-                    count.get(r.id)[0]++;
-                    count.get(r.id)[1] += (int) (r.prixVenteTTC * 100);
-                    map.putIfAbsent(r.id, r);
+        if (entity.venteRemorquesCatalogue != null) {
+            for (VenteRemorqueCatalogueEntity vr : entity.venteRemorquesCatalogue) {
+                if (vr.remorque == null) continue;
+                String nom = vr.remorque.marque + " " + vr.remorque.modele;
+                lignes.append("- Remorque : ").append(nom).append(" x").append(vr.quantite);
+                if (showPrices) {
+                    double base = vr.remorque.prixVenteTTC * vr.quantite;
+                    double total = Math.max(0, base - vr.remise);
+                    lignes.append(" = ").append(String.format("%.2f EUR", total));
+                    if (vr.remise > 0) {
+                        lignes.append(" (remise ").append(String.format("%.2f EUR", vr.remise)).append(")");
+                    }
                 }
-            }
-            for (Map.Entry<Long, int[]> entry : count.entrySet()) {
-                RemorqueCatalogueEntity r = map.get(entry.getKey());
-                String nom = r.marque + " " + r.modele;
-                lignes.append("- Remorque : ").append(nom).append(" x").append(entry.getValue()[0]);
-                if (showPrices) lignes.append(" = ").append(String.format("%.2f EUR", entry.getValue()[1] / 100.0));
                 lignes.append("\n");
             }
         }
@@ -475,6 +467,8 @@ public class VenteResource {
                 VenteForfaitEntity cloned = new VenteForfaitEntity();
                 cloned.forfait = incoming.forfait;
                 cloned.quantite = incoming.quantite;
+                cloned.remise = incoming.remise;
+                cloned.remisePourcentage = incoming.remisePourcentage;
                 if (incoming.techniciens != null) {
                     cloned.techniciens.addAll(incoming.techniciens);
                 }
@@ -521,6 +515,8 @@ public class VenteResource {
                 VenteServiceEntity cloned = new VenteServiceEntity();
                 cloned.service = incoming.service;
                 cloned.quantite = incoming.quantite;
+                cloned.remise = incoming.remise;
+                cloned.remisePourcentage = incoming.remisePourcentage;
                 if (incoming.techniciens != null) {
                     cloned.techniciens.addAll(incoming.techniciens);
                 }
@@ -560,41 +556,78 @@ public class VenteResource {
             }
         }
 
-        // Update produits
+        // Update venteProduits (new line entity with quantite + remise per line)
+        entity.venteProduits.clear();
+        if (vente.venteProduits != null) {
+            for (VenteProduitEntity incoming : vente.venteProduits) {
+                VenteProduitEntity cloned = new VenteProduitEntity();
+                cloned.produit = incoming.produit;
+                cloned.quantite = incoming.quantite;
+                cloned.remise = incoming.remise;
+                cloned.remisePourcentage = incoming.remisePourcentage;
+                entity.venteProduits.add(cloned);
+            }
+        }
+        // Clear legacy @ManyToMany list (data is now stored in venteProduits)
         if (entity.produits != null) {
             entity.produits.clear();
         }
-        if (vente.produits != null) {
-            if (entity.produits == null) {
-                entity.produits = vente.produits;
-            } else {
-                entity.produits.addAll(vente.produits);
+
+        // Update venteBateauxCatalogue
+        entity.venteBateauxCatalogue.clear();
+        if (vente.venteBateauxCatalogue != null) {
+            for (VenteBateauCatalogueEntity incoming : vente.venteBateauxCatalogue) {
+                VenteBateauCatalogueEntity cloned = new VenteBateauCatalogueEntity();
+                cloned.bateau = incoming.bateau;
+                cloned.quantite = incoming.quantite;
+                cloned.remise = incoming.remise;
+                cloned.remisePourcentage = incoming.remisePourcentage;
+                entity.venteBateauxCatalogue.add(cloned);
             }
         }
-
-        // Update bateauxCatalogue
         entity.bateauxCatalogue.clear();
-        if (vente.bateauxCatalogue != null) {
-            entity.bateauxCatalogue.addAll(vente.bateauxCatalogue);
-        }
 
-        // Update moteursCatalogue
+        // Update venteMoteursCatalogue
+        entity.venteMoteursCatalogue.clear();
+        if (vente.venteMoteursCatalogue != null) {
+            for (VenteMoteurCatalogueEntity incoming : vente.venteMoteursCatalogue) {
+                VenteMoteurCatalogueEntity cloned = new VenteMoteurCatalogueEntity();
+                cloned.moteur = incoming.moteur;
+                cloned.quantite = incoming.quantite;
+                cloned.remise = incoming.remise;
+                cloned.remisePourcentage = incoming.remisePourcentage;
+                entity.venteMoteursCatalogue.add(cloned);
+            }
+        }
         entity.moteursCatalogue.clear();
-        if (vente.moteursCatalogue != null) {
-            entity.moteursCatalogue.addAll(vente.moteursCatalogue);
-        }
 
-        // Update helicesCatalogue
+        // Update venteHelicesCatalogue
+        entity.venteHelicesCatalogue.clear();
+        if (vente.venteHelicesCatalogue != null) {
+            for (VenteHeliceCatalogueEntity incoming : vente.venteHelicesCatalogue) {
+                VenteHeliceCatalogueEntity cloned = new VenteHeliceCatalogueEntity();
+                cloned.helice = incoming.helice;
+                cloned.quantite = incoming.quantite;
+                cloned.remise = incoming.remise;
+                cloned.remisePourcentage = incoming.remisePourcentage;
+                entity.venteHelicesCatalogue.add(cloned);
+            }
+        }
         entity.helicesCatalogue.clear();
-        if (vente.helicesCatalogue != null) {
-            entity.helicesCatalogue.addAll(vente.helicesCatalogue);
-        }
 
-        // Update remorquesCatalogue
-        entity.remorquesCatalogue.clear();
-        if (vente.remorquesCatalogue != null) {
-            entity.remorquesCatalogue.addAll(vente.remorquesCatalogue);
+        // Update venteRemorquesCatalogue
+        entity.venteRemorquesCatalogue.clear();
+        if (vente.venteRemorquesCatalogue != null) {
+            for (VenteRemorqueCatalogueEntity incoming : vente.venteRemorquesCatalogue) {
+                VenteRemorqueCatalogueEntity cloned = new VenteRemorqueCatalogueEntity();
+                cloned.remorque = incoming.remorque;
+                cloned.quantite = incoming.quantite;
+                cloned.remise = incoming.remise;
+                cloned.remisePourcentage = incoming.remisePourcentage;
+                entity.venteRemorquesCatalogue.add(cloned);
+            }
         }
+        entity.remorquesCatalogue.clear();
 
         // Send incident notification email for any INCIDENT items
         if (entity.client != null && entity.client.email != null && !entity.client.email.isBlank()) {
@@ -850,35 +883,39 @@ public class VenteResource {
     }
 
     private void decrementStock(VenteEntity vente) {
-        if (vente.produits != null) {
-            for (ProduitCatalogueEntity produit : vente.produits) {
-                ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(produit.id);
+        if (vente.venteProduits != null) {
+            for (VenteProduitEntity vp : vente.venteProduits) {
+                if (vp.produit == null || vp.produit.id == null) continue;
+                ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(vp.produit.id);
                 if (p != null) {
-                    p.stock = Math.max(0, p.stock - 1);
+                    p.stock = Math.max(0, p.stock - Math.max(1, vp.quantite));
                 }
             }
         }
-        if (vente.bateauxCatalogue != null) {
-            for (BateauCatalogueEntity bateau : vente.bateauxCatalogue) {
-                BateauCatalogueEntity b = BateauCatalogueEntity.findById(bateau.id);
+        if (vente.venteBateauxCatalogue != null) {
+            for (VenteBateauCatalogueEntity vb : vente.venteBateauxCatalogue) {
+                if (vb.bateau == null || vb.bateau.id == null) continue;
+                BateauCatalogueEntity b = BateauCatalogueEntity.findById(vb.bateau.id);
                 if (b != null) {
-                    b.stock = Math.max(0, b.stock - 1);
+                    b.stock = Math.max(0, b.stock - Math.max(1, vb.quantite));
                 }
             }
         }
-        if (vente.moteursCatalogue != null) {
-            for (MoteurCatalogueEntity moteur : vente.moteursCatalogue) {
-                MoteurCatalogueEntity m = MoteurCatalogueEntity.findById(moteur.id);
+        if (vente.venteMoteursCatalogue != null) {
+            for (VenteMoteurCatalogueEntity vm : vente.venteMoteursCatalogue) {
+                if (vm.moteur == null || vm.moteur.id == null) continue;
+                MoteurCatalogueEntity m = MoteurCatalogueEntity.findById(vm.moteur.id);
                 if (m != null) {
-                    m.stock = Math.max(0, m.stock - 1);
+                    m.stock = Math.max(0, m.stock - Math.max(1, vm.quantite));
                 }
             }
         }
-        if (vente.remorquesCatalogue != null) {
-            for (RemorqueCatalogueEntity remorque : vente.remorquesCatalogue) {
-                RemorqueCatalogueEntity r = RemorqueCatalogueEntity.findById(remorque.id);
+        if (vente.venteRemorquesCatalogue != null) {
+            for (VenteRemorqueCatalogueEntity vr : vente.venteRemorquesCatalogue) {
+                if (vr.remorque == null || vr.remorque.id == null) continue;
+                RemorqueCatalogueEntity r = RemorqueCatalogueEntity.findById(vr.remorque.id);
                 if (r != null) {
-                    r.stock = Math.max(0, r.stock - 1);
+                    r.stock = Math.max(0, r.stock - Math.max(1, vr.quantite));
                 }
             }
         }

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -169,6 +169,46 @@ interface AvoirDisponible {
     montantUtilise: number;
 }
 
+interface VenteProduitLigne {
+    id?: number;
+    produit?: ProduitCatalogueEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteBateauCatalogueLigne {
+    id?: number;
+    bateau?: CatalogueBateauEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteMoteurCatalogueLigne {
+    id?: number;
+    moteur?: CatalogueMoteurEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteHeliceCatalogueLigne {
+    id?: number;
+    helice?: CatalogueHeliceEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteRemorqueCatalogueLigne {
+    id?: number;
+    remorque?: CatalogueRemorqueEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
 interface VenteEntity {
     id?: number;
     status: VenteStatus;
@@ -180,11 +220,11 @@ interface VenteEntity {
     moteur?: MoteurClientEntity;
     remorque?: RemorqueClientEntity;
     forfaits?: ForfaitEntity[];
-    produits?: ProduitCatalogueEntity[];
-    bateauxCatalogue?: CatalogueBateauEntity[];
-    moteursCatalogue?: CatalogueMoteurEntity[];
-    helicesCatalogue?: CatalogueHeliceEntity[];
-    remorquesCatalogue?: CatalogueRemorqueEntity[];
+    venteProduits?: VenteProduitLigne[];
+    venteBateauxCatalogue?: VenteBateauCatalogueLigne[];
+    venteMoteursCatalogue?: VenteMoteurCatalogueLigne[];
+    venteHelicesCatalogue?: VenteHeliceCatalogueLigne[];
+    venteRemorquesCatalogue?: VenteRemorqueCatalogueLigne[];
     services?: ServiceEntity[];
     taches?: TaskEntity[];
     date?: string;
@@ -211,9 +251,9 @@ interface VenteFormValues {
     bateauId?: number;
     moteurId?: number;
     remorqueId?: number;
-    forfaits: Array<{ forfaitId?: number; quantite: number }>;
-    produits: Array<{ produitRef?: string; quantite?: number }>;
-    services: Array<{ serviceId?: number; quantite: number }>;
+    forfaits: Array<{ forfaitId?: number; quantite: number; remise?: number; remisePourcentage?: number }>;
+    produits: Array<{ produitRef?: string; quantite?: number; remise?: number; remisePourcentage?: number }>;
+    services: Array<{ serviceId?: number; quantite: number; remise?: number; remisePourcentage?: number }>;
     date?: string;
     montantHT: number;
     remise: number;
@@ -674,28 +714,43 @@ export default function Comptoir() {
             if (vente.client?.id) {
                 setClients((prev) => mergeById(prev, [vente.client as ClientEntity]));
             }
-            const venteProduits = (vente.produits || []).filter((p): p is ProduitCatalogueEntity => !!p?.id);
-            if (venteProduits.length > 0) setProduits((prev) => mergeById(prev, venteProduits));
-            const venteBateaux = (vente.bateauxCatalogue || []).filter((b): b is CatalogueBateauEntity => !!b?.id);
-            if (venteBateaux.length > 0) setCatalogueBateaux((prev) => mergeById(prev, venteBateaux));
-            const venteMoteurs = (vente.moteursCatalogue || []).filter((m): m is CatalogueMoteurEntity => !!m?.id);
-            if (venteMoteurs.length > 0) setCatalogueMoteurs((prev) => mergeById(prev, venteMoteurs));
-            const venteHelices = (vente.helicesCatalogue || []).filter((h): h is CatalogueHeliceEntity => !!h?.id);
-            if (venteHelices.length > 0) setCatalogueHelices((prev) => mergeById(prev, venteHelices));
-            const venteRemorques = (vente.remorquesCatalogue || []).filter((r): r is CatalogueRemorqueEntity => !!r?.id);
-            if (venteRemorques.length > 0) setCatalogueRemorques((prev) => mergeById(prev, venteRemorques));
+            const produitsCatalogue = (vente.venteProduits || [])
+                .map((l) => l.produit)
+                .filter((p): p is ProduitCatalogueEntity => !!p?.id);
+            if (produitsCatalogue.length > 0) setProduits((prev) => mergeById(prev, produitsCatalogue));
+            const bateauxCat = (vente.venteBateauxCatalogue || [])
+                .map((l) => l.bateau)
+                .filter((b): b is CatalogueBateauEntity => !!b?.id);
+            if (bateauxCat.length > 0) setCatalogueBateaux((prev) => mergeById(prev, bateauxCat));
+            const moteursCat = (vente.venteMoteursCatalogue || [])
+                .map((l) => l.moteur)
+                .filter((m): m is CatalogueMoteurEntity => !!m?.id);
+            if (moteursCat.length > 0) setCatalogueMoteurs((prev) => mergeById(prev, moteursCat));
+            const helicesCat = (vente.venteHelicesCatalogue || [])
+                .map((l) => l.helice)
+                .filter((h): h is CatalogueHeliceEntity => !!h?.id);
+            if (helicesCat.length > 0) setCatalogueHelices((prev) => mergeById(prev, helicesCat));
+            const remorquesCat = (vente.venteRemorquesCatalogue || [])
+                .map((l) => l.remorque)
+                .filter((r): r is CatalogueRemorqueEntity => !!r?.id);
+            if (remorquesCat.length > 0) setCatalogueRemorques((prev) => mergeById(prev, remorquesCat));
 
-            const buildRefLines = <T extends { id: number }>(items: T[], prefix: string): Array<{ produitRef: string; quantite: number }> => {
-                const map = new Map<number, number>();
-                items.forEach((item) => { if (item?.id) map.set(item.id, (map.get(item.id) || 0) + 1); });
-                return Array.from(map.entries()).map(([id, quantite]) => ({ produitRef: `${prefix}:${id}`, quantite }));
-            };
             const produitLines = [
-                ...buildRefLines(vente.produits || [], 'produit'),
-                ...buildRefLines(vente.bateauxCatalogue || [], 'bateau'),
-                ...buildRefLines(vente.moteursCatalogue || [], 'moteur'),
-                ...buildRefLines(vente.helicesCatalogue || [], 'helice'),
-                ...buildRefLines(vente.remorquesCatalogue || [], 'remorque'),
+                ...(vente.venteProduits || [])
+                    .filter((l) => l.produit?.id)
+                    .map((l) => ({ produitRef: `produit:${l.produit!.id}`, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 })),
+                ...(vente.venteBateauxCatalogue || [])
+                    .filter((l) => l.bateau?.id)
+                    .map((l) => ({ produitRef: `bateau:${l.bateau!.id}`, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 })),
+                ...(vente.venteMoteursCatalogue || [])
+                    .filter((l) => l.moteur?.id)
+                    .map((l) => ({ produitRef: `moteur:${l.moteur!.id}`, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 })),
+                ...(vente.venteHelicesCatalogue || [])
+                    .filter((l) => l.helice?.id)
+                    .map((l) => ({ produitRef: `helice:${l.helice!.id}`, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 })),
+                ...(vente.venteRemorquesCatalogue || [])
+                    .filter((l) => l.remorque?.id)
+                    .map((l) => ({ produitRef: `remorque:${l.remorque!.id}`, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 })),
             ];
             form.setFieldsValue({
                 status: vente.status || 'DEVIS',
@@ -762,9 +817,6 @@ export default function Comptoir() {
         }
     };
 
-    const expandByQuantity = <T,>(items: T[], quantite: number): T[] =>
-        Array.from({ length: Math.max(1, Math.floor(quantite || 1)) }, () => items).flat();
-
     const toPayload = (values: VenteFormValues): VenteEntity => ({
         status: values.status,
         bonPourAccord: values.bonPourAccord,
@@ -778,48 +830,73 @@ export default function Comptoir() {
             .filter((line) => line.forfaitId)
             .flatMap((line) => {
                 const item = forfaits.find((forfait) => forfait.id === line.forfaitId);
-                return item ? expandByQuantity([item], line.quantite) : [];
+                return item ? [item] : [];
             }) as ForfaitEntity[],
-        produits: (values.produits || [])
+        venteProduits: (values.produits || [])
             .filter((line) => line.produitRef?.startsWith('produit:'))
-            .flatMap((line) => {
+            .flatMap<VenteProduitLigne>((line) => {
                 const id = parseInt((line.produitRef || '').split(':')[1], 10);
-                const item = produits.find((p) => p.id === id);
-                return item ? expandByQuantity([item], line.quantite || 1) : [];
-            }) as ProduitCatalogueEntity[],
-        bateauxCatalogue: (values.produits || [])
+                const produit = produits.find((p) => p.id === id);
+                return produit ? [{
+                    produit,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+        venteBateauxCatalogue: (values.produits || [])
             .filter((line) => line.produitRef?.startsWith('bateau:'))
-            .flatMap((line) => {
+            .flatMap<VenteBateauCatalogueLigne>((line) => {
                 const id = parseInt((line.produitRef || '').split(':')[1], 10);
-                const item = catalogueBateaux.find((b) => b.id === id);
-                return item ? expandByQuantity([item], line.quantite || 1) : [];
-            }) as CatalogueBateauEntity[],
-        moteursCatalogue: (values.produits || [])
+                const bateau = catalogueBateaux.find((b) => b.id === id);
+                return bateau ? [{
+                    bateau,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+        venteMoteursCatalogue: (values.produits || [])
             .filter((line) => line.produitRef?.startsWith('moteur:'))
-            .flatMap((line) => {
+            .flatMap<VenteMoteurCatalogueLigne>((line) => {
                 const id = parseInt((line.produitRef || '').split(':')[1], 10);
-                const item = catalogueMoteurs.find((m) => m.id === id);
-                return item ? expandByQuantity([item], line.quantite || 1) : [];
-            }) as CatalogueMoteurEntity[],
-        helicesCatalogue: (values.produits || [])
+                const moteur = catalogueMoteurs.find((m) => m.id === id);
+                return moteur ? [{
+                    moteur,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+        venteHelicesCatalogue: (values.produits || [])
             .filter((line) => line.produitRef?.startsWith('helice:'))
-            .flatMap((line) => {
+            .flatMap<VenteHeliceCatalogueLigne>((line) => {
                 const id = parseInt((line.produitRef || '').split(':')[1], 10);
-                const item = catalogueHelices.find((h) => h.id === id);
-                return item ? expandByQuantity([item], line.quantite || 1) : [];
-            }) as CatalogueHeliceEntity[],
-        remorquesCatalogue: (values.produits || [])
+                const helice = catalogueHelices.find((h) => h.id === id);
+                return helice ? [{
+                    helice,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+        venteRemorquesCatalogue: (values.produits || [])
             .filter((line) => line.produitRef?.startsWith('remorque:'))
-            .flatMap((line) => {
+            .flatMap<VenteRemorqueCatalogueLigne>((line) => {
                 const id = parseInt((line.produitRef || '').split(':')[1], 10);
-                const item = catalogueRemorques.find((r) => r.id === id);
-                return item ? expandByQuantity([item], line.quantite || 1) : [];
-            }) as CatalogueRemorqueEntity[],
+                const remorque = catalogueRemorques.find((r) => r.id === id);
+                return remorque ? [{
+                    remorque,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
         services: (values.services || [])
             .filter((line) => line.serviceId)
             .flatMap((line) => {
                 const item = services.find((service) => service.id === line.serviceId);
-                return item ? expandByQuantity([item], line.quantite) : [];
+                return item ? [item] : [];
             }) as ServiceEntity[],
         date: toBackendDateValue(values.date),
         montantHT: values.montantHT || 0,
@@ -902,22 +979,29 @@ export default function Comptoir() {
     };
 
     const getProduitLines = (vente: VenteEntity) => {
-        type LineItem = { id: number; nom: string; marque?: string; prixVenteTTC?: number; quantite: number };
-        const lines = new Map<string, LineItem>();
-        const addItems = (items: Array<{ id: number; prixVenteTTC?: number } & Record<string, unknown>>, getNom: (item: unknown) => string, prefix: string) => {
-            (items || []).forEach((item) => {
-                const key = `${prefix}:${item.id}`;
-                const current = lines.get(key) || { id: item.id, nom: getNom(item), marque: (item as { marque?: string }).marque, prixVenteTTC: item.prixVenteTTC, quantite: 0 };
-                current.quantite += 1;
-                lines.set(key, current);
-            });
-        };
-        addItems(vente.produits || [], (p) => (p as ProduitCatalogueEntity).nom, 'produit');
-        addItems(vente.bateauxCatalogue || [], (b) => `${(b as CatalogueBateauEntity).marque} ${(b as CatalogueBateauEntity).modele}`, 'bateau');
-        addItems(vente.moteursCatalogue || [], (m) => `${(m as CatalogueMoteurEntity).marque} ${(m as CatalogueMoteurEntity).modele}`, 'moteur');
-        addItems(vente.helicesCatalogue || [], (h) => `${(h as CatalogueHeliceEntity).marque} ${(h as CatalogueHeliceEntity).modele}`, 'helice');
-        addItems(vente.remorquesCatalogue || [], (r) => `${(r as CatalogueRemorqueEntity).marque} ${(r as CatalogueRemorqueEntity).modele}`, 'remorque');
-        return Array.from(lines.values());
+        type LineItem = { id: number; nom: string; marque?: string; prixVenteTTC?: number; quantite: number; remise: number };
+        const lines: LineItem[] = [];
+        (vente.venteProduits || []).forEach((l) => {
+            if (!l.produit?.id) return;
+            lines.push({ id: l.produit.id, nom: l.produit.nom, marque: l.produit.marque, prixVenteTTC: l.produit.prixVenteTTC, quantite: l.quantite || 1, remise: l.remise || 0 });
+        });
+        (vente.venteBateauxCatalogue || []).forEach((l) => {
+            if (!l.bateau?.id) return;
+            lines.push({ id: l.bateau.id, nom: `${l.bateau.marque} ${l.bateau.modele}`, marque: l.bateau.marque, prixVenteTTC: l.bateau.prixVenteTTC, quantite: l.quantite || 1, remise: l.remise || 0 });
+        });
+        (vente.venteMoteursCatalogue || []).forEach((l) => {
+            if (!l.moteur?.id) return;
+            lines.push({ id: l.moteur.id, nom: `${l.moteur.marque} ${l.moteur.modele}`, marque: l.moteur.marque, prixVenteTTC: l.moteur.prixVenteTTC, quantite: l.quantite || 1, remise: l.remise || 0 });
+        });
+        (vente.venteHelicesCatalogue || []).forEach((l) => {
+            if (!l.helice?.id) return;
+            lines.push({ id: l.helice.id, nom: `${l.helice.marque} ${l.helice.modele}`, marque: l.helice.marque, prixVenteTTC: l.helice.prixVenteTTC, quantite: l.quantite || 1, remise: l.remise || 0 });
+        });
+        (vente.venteRemorquesCatalogue || []).forEach((l) => {
+            if (!l.remorque?.id) return;
+            lines.push({ id: l.remorque.id, nom: `${l.remorque.marque} ${l.remorque.modele}`, marque: l.remorque.marque, prixVenteTTC: l.remorque.prixVenteTTC, quantite: l.quantite || 1, remise: l.remise || 0 });
+        });
+        return lines;
     };
 
     const openPrintDocument = (_title: string, contentHtml: string, _width: number = 900) => {
@@ -972,12 +1056,14 @@ export default function Comptoir() {
         const produitRows = getProduitLines(vente)
             .map((item) => {
                 const pu = item.prixVenteTTC || 0;
-                const total = pu * item.quantite;
+                const brut = pu * item.quantite;
+                const total = Math.max(0, brut - item.remise);
                 return `
                 <tr>
                     <td>${escapeHtml(item.nom)}</td>
                     <td style="text-align:right;">${escapeHtml(formatEuro(pu))}</td>
                     <td style="text-align:right;">${item.quantite}</td>
+                    <td style="text-align:right;">${escapeHtml(formatEuro(item.remise))}</td>
                     <td style="text-align:right;">${escapeHtml(formatEuro(total))}</td>
                 </tr>`;
             })
@@ -1015,11 +1101,12 @@ export default function Comptoir() {
                                 <th>Produit</th>
                                 <th style="text-align:right;">P.U. TTC</th>
                                 <th style="text-align:right;">Qté</th>
+                                <th style="text-align:right;">Remise</th>
                                 <th style="text-align:right;">Total TTC</th>
                             </tr>
                         </thead>
                         <tbody>
-                            ${produitRows || '<tr><td colspan="4">Aucun produit</td></tr>'}
+                            ${produitRows || '<tr><td colspan="5">Aucun produit</td></tr>'}
                         </tbody>
                     </table>
                 </body>
@@ -1033,7 +1120,11 @@ export default function Comptoir() {
         const produitRows = getProduitLines(vente)
             .map((item) => {
                 const pu = item.prixVenteTTC || 0;
-                const total = pu * item.quantite;
+                const brut = pu * item.quantite;
+                const total = Math.max(0, brut - item.remise);
+                const remiseLine = item.remise > 0
+                    ? `<div class="line sub"><span>Remise</span><span>-${escapeHtml(formatEuro(item.remise))}</span></div>`
+                    : '';
                 return `
                 <div class="line">
                     <span>${escapeHtml(item.nom)}</span>
@@ -1042,7 +1133,7 @@ export default function Comptoir() {
                 <div class="line sub">
                     <span>${escapeHtml(formatEuro(pu))} /u</span>
                     <span>${escapeHtml(formatEuro(total))}</span>
-                </div>`;
+                </div>${remiseLine}`;
             })
             .join('');
 
@@ -1111,17 +1202,21 @@ export default function Comptoir() {
         let remisePourcentage = form.getFieldValue('remisePourcentage') || 0;
         const tva = form.getFieldValue('tva') || 0;
 
-        const forfaitsTTC = forfaitLines.reduce((sum: number, line: { forfaitId?: number; quantite?: number }) => {
+        const sumLine = (prixUnitaire: number, quantite: number, remiseLigne: number) => {
+            const brut = prixUnitaire * Math.max(1, Math.floor(quantite || 1));
+            return Math.max(0, brut - (remiseLigne || 0));
+        };
+        const forfaitsTTC = forfaitLines.reduce((sum: number, line: { forfaitId?: number; quantite?: number; remise?: number }) => {
             const prixUnitaire = forfaits.find((item) => item.id === line.forfaitId)?.prixTTC || 0;
-            return sum + (prixUnitaire * Math.max(1, Math.floor(line.quantite || 1)));
+            return sum + sumLine(prixUnitaire, line.quantite || 1, line.remise || 0);
         }, 0);
-        const produitsTTC = produitLines.reduce((sum: number, line: { produitRef?: string; quantite?: number }) => {
+        const produitsTTC = produitLines.reduce((sum: number, line: { produitRef?: string; quantite?: number; remise?: number }) => {
             const prixUnitaire = getCatalogueItemPrice(line.produitRef);
-            return sum + (prixUnitaire * Math.max(1, Math.floor(line.quantite || 1)));
+            return sum + sumLine(prixUnitaire, line.quantite || 1, line.remise || 0);
         }, 0);
-        const servicesTTC = serviceLines.reduce((sum: number, line: { serviceId?: number; quantite?: number }) => {
+        const servicesTTC = serviceLines.reduce((sum: number, line: { serviceId?: number; quantite?: number; remise?: number }) => {
             const prixUnitaire = services.find((item) => item.id === line.serviceId)?.prixTTC || 0;
-            return sum + (prixUnitaire * Math.max(1, Math.floor(line.quantite || 1)));
+            return sum + sumLine(prixUnitaire, line.quantite || 1, line.remise || 0);
         }, 0);
 
         const montantTTC = Math.round(((forfaitsTTC + produitsTTC + servicesTTC) + Number.EPSILON) * 100) / 100;
@@ -1146,8 +1241,36 @@ export default function Comptoir() {
         form.setFieldValue('prixVenteTTC', prixVenteTTC);
     };
 
+    const syncLineRemise = (changedProduitLines: Array<Partial<{ produitRef: string; quantite: number; remise: number; remisePourcentage: number }> | undefined>) => {
+        const currentLines = form.getFieldValue('produits') || [];
+        changedProduitLines.forEach((changed, index) => {
+            if (!changed) return;
+            const line = currentLines[index];
+            if (!line) return;
+            const prixUnitaire = getCatalogueItemPrice(line.produitRef);
+            const quantite = Math.max(1, Math.floor(line.quantite || 1));
+            const brut = Math.round(prixUnitaire * quantite * 100) / 100;
+            if (changed.remisePourcentage !== undefined) {
+                const remise = Math.round(((brut * (changed.remisePourcentage || 0)) / 100 + Number.EPSILON) * 100) / 100;
+                form.setFieldValue(['produits', index, 'remise'], remise);
+            } else if (changed.remise !== undefined) {
+                const remisePourcentage = brut > 0
+                    ? Math.round((((changed.remise || 0) / brut) * 100 + Number.EPSILON) * 100) / 100
+                    : 0;
+                form.setFieldValue(['produits', index, 'remisePourcentage'], remisePourcentage);
+            }
+        });
+    };
+
     const onValuesChange = (changedValues: Partial<VenteFormValues>, allValues: VenteFormValues) => {
         if (changedValues.produits !== undefined) {
+            // Sync line-level remise EUR <-> % when changed
+            const lineRemiseChanged = (changedValues.produits as Array<Partial<{ remise: number; remisePourcentage: number }> | undefined>)
+                .some((p) => p && (p.remise !== undefined || p.remisePourcentage !== undefined));
+            if (lineRemiseChanged) {
+                syncLineRemise(changedValues.produits as Array<Partial<{ produitRef: string; quantite: number; remise: number; remisePourcentage: number }> | undefined>);
+            }
+
             const currentProduitLines = allValues.produits || [];
             if (currentProduitLines.length === 0) {
                 form.setFieldValue('produits', [{}]);
@@ -1457,7 +1580,11 @@ export default function Comptoir() {
                                                 const produitRef = form.getFieldValue(['produits', field.name, 'produitRef']);
                                                 const prixUnitaire = getCatalogueItemPrice(produitRef) || undefined;
                                                 const quantite = form.getFieldValue(['produits', field.name, 'quantite']);
-                                                const totalLigne = (prixUnitaire && quantite) ? Math.round(prixUnitaire * quantite * 100) / 100 : undefined;
+                                                const remiseLigne = form.getFieldValue(['produits', field.name, 'remise']) || 0;
+                                                const brutLigne = (prixUnitaire && quantite) ? Math.round(prixUnitaire * quantite * 100) / 100 : undefined;
+                                                const totalLigne = brutLigne !== undefined
+                                                    ? Math.max(0, Math.round((brutLigne - remiseLigne) * 100) / 100)
+                                                    : undefined;
                                                 const isEmptyLine = !produitRef;
                                                 return (
                                                 <Space align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
@@ -1475,7 +1602,7 @@ export default function Comptoir() {
                                                                 }
                                                             }
                                                         ]}
-                                                        style={{ width: 420 }}
+                                                        style={{ width: 320 }}
                                                     >
                                                         <Select
                                                             allowClear
@@ -1489,7 +1616,7 @@ export default function Comptoir() {
                                                             placeholder="Rechercher produit, bateau, moteur, hélice ou remorque"
                                                         />
                                                     </Form.Item>
-                                                    <Form.Item style={{ width: 150 }}>
+                                                    <Form.Item style={{ width: 110 }}>
                                                         <InputNumber
                                                             addonAfter="EUR"
                                                             value={prixUnitaire ?? undefined}
@@ -1514,11 +1641,25 @@ export default function Comptoir() {
                                                                 }
                                                             }
                                                         ]}
-                                                        style={{ width: 150 }}
+                                                        style={{ width: 90 }}
                                                     >
                                                         <InputNumber min={1} step={1} style={{ width: '100%' }} placeholder="Qte" />
                                                     </Form.Item>
-                                                    <Form.Item style={{ width: 150 }}>
+                                                    <Form.Item
+                                                        {...field}
+                                                        name={[field.name, 'remisePourcentage']}
+                                                        style={{ width: 110 }}
+                                                    >
+                                                        <InputNumber addonAfter="%" min={0} max={100} step={0.01} style={{ width: '100%' }} placeholder="Remise" />
+                                                    </Form.Item>
+                                                    <Form.Item
+                                                        {...field}
+                                                        name={[field.name, 'remise']}
+                                                        style={{ width: 130 }}
+                                                    >
+                                                        <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} placeholder="Remise" />
+                                                    </Form.Item>
+                                                    <Form.Item style={{ width: 130 }}>
                                                         <InputNumber
                                                             addonAfter="EUR"
                                                             value={totalLigne}

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -82,6 +82,8 @@ interface VenteForfaitEntity {
     id?: number;
     forfait?: ForfaitEntity;
     quantite?: number;
+    remise?: number;
+    remisePourcentage?: number;
     techniciens?: TechnicienEntity[];
     datePlanification?: string;
     dateDebut?: string;
@@ -101,6 +103,8 @@ interface VenteServiceEntity {
     id?: number;
     service?: ServiceEntity;
     quantite?: number;
+    remise?: number;
+    remisePourcentage?: number;
     techniciens?: TechnicienEntity[];
     datePlanification?: string;
     dateDebut?: string;
@@ -315,6 +319,46 @@ interface SocieteData {
     bancaire?: string;
 }
 
+interface VenteProduitLigne {
+    id?: number;
+    produit?: ProduitCatalogueEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteBateauCatalogueLigne {
+    id?: number;
+    bateau?: CatalogueBateauEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteMoteurCatalogueLigne {
+    id?: number;
+    moteur?: CatalogueMoteurEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteHeliceCatalogueLigne {
+    id?: number;
+    helice?: CatalogueHeliceEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
+interface VenteRemorqueCatalogueLigne {
+    id?: number;
+    remorque?: CatalogueRemorqueEntity;
+    quantite: number;
+    remise?: number;
+    remisePourcentage?: number;
+}
+
 interface VenteEntity {
     id?: number;
     status: VenteStatus;
@@ -328,11 +372,11 @@ interface VenteEntity {
     remorque?: RemorqueClientEntity;
     venteForfaits?: VenteForfaitEntity[];
     venteServices?: VenteServiceEntity[];
-    produits?: ProduitCatalogueEntity[];
-    bateauxCatalogue?: CatalogueBateauEntity[];
-    moteursCatalogue?: CatalogueMoteurEntity[];
-    helicesCatalogue?: CatalogueHeliceEntity[];
-    remorquesCatalogue?: CatalogueRemorqueEntity[];
+    venteProduits?: VenteProduitLigne[];
+    venteBateauxCatalogue?: VenteBateauCatalogueLigne[];
+    venteMoteursCatalogue?: VenteMoteurCatalogueLigne[];
+    venteHelicesCatalogue?: VenteHeliceCatalogueLigne[];
+    venteRemorquesCatalogue?: VenteRemorqueCatalogueLigne[];
     date?: string;
     dateDevis?: string;
     dateBonPourAccord?: string;
@@ -377,6 +421,8 @@ interface LigneUnifiee {
     type?: LigneType;
     itemId?: number;
     quantite?: number;
+    remise?: number;
+    remisePourcentage?: number;
     technicienIds?: number[];
     status?: PlanningStatus;
     datePlanification?: string;
@@ -1380,14 +1426,11 @@ export default function Vente() {
         const keys: string[] = [];
         (vente?.venteForfaits || []).forEach(vf => { if (vf.forfait?.id) keys.push(`forfait:${vf.forfait.id}`); });
         (vente?.venteServices || []).forEach(vs => { if (vs.service?.id) keys.push(`service:${vs.service.id}`); });
-        const addIds = (items: Array<{ id?: number }>, prefix: string) => {
-            new Set(items.map(i => i?.id).filter(Boolean) as number[]).forEach(id => keys.push(`${prefix}:${id}`));
-        };
-        addIds(vente?.produits || [], 'produit');
-        addIds(vente?.bateauxCatalogue || [], 'bateau');
-        addIds(vente?.moteursCatalogue || [], 'moteur');
-        addIds(vente?.helicesCatalogue || [], 'helice');
-        addIds(vente?.remorquesCatalogue || [], 'remorque');
+        (vente?.venteProduits || []).forEach(vp => { if (vp.produit?.id) keys.push(`produit:${vp.produit.id}`); });
+        (vente?.venteBateauxCatalogue || []).forEach(vb => { if (vb.bateau?.id) keys.push(`bateau:${vb.bateau.id}`); });
+        (vente?.venteMoteursCatalogue || []).forEach(vm => { if (vm.moteur?.id) keys.push(`moteur:${vm.moteur.id}`); });
+        (vente?.venteHelicesCatalogue || []).forEach(vh => { if (vh.helice?.id) keys.push(`helice:${vh.helice.id}`); });
+        (vente?.venteRemorquesCatalogue || []).forEach(vr => { if (vr.remorque?.id) keys.push(`remorque:${vr.remorque.id}`); });
         savedLinesRef.current = keys.sort();
     };
 
@@ -1395,22 +1438,24 @@ export default function Vente() {
         if (vente.client?.id) {
             setClients((prev) => mergeById(prev, [vente.client as ClientEntity]));
         }
-        const venteProduits = (vente.produits || []).filter((p): p is ProduitCatalogueEntity => !!p?.id);
-        if (venteProduits.length > 0) setProduits((prev) => mergeById(prev, venteProduits));
-        const venteBateaux = (vente.bateauxCatalogue || []).filter((b): b is CatalogueBateauEntity => !!b?.id);
-        if (venteBateaux.length > 0) setCatalogueBateaux((prev) => mergeById(prev, venteBateaux));
-        const venteMoteurs = (vente.moteursCatalogue || []).filter((m): m is CatalogueMoteurEntity => !!m?.id);
-        if (venteMoteurs.length > 0) setCatalogueMoteurs((prev) => mergeById(prev, venteMoteurs));
-        const venteHelices = (vente.helicesCatalogue || []).filter((h): h is CatalogueHeliceEntity => !!h?.id);
-        if (venteHelices.length > 0) setCatalogueHelices((prev) => mergeById(prev, venteHelices));
-        const venteRemorques = (vente.remorquesCatalogue || []).filter((r): r is CatalogueRemorqueEntity => !!r?.id);
-        if (venteRemorques.length > 0) setCatalogueRemorques((prev) => mergeById(prev, venteRemorques));
+        const produitsCat = (vente.venteProduits || []).map((l) => l.produit).filter((p): p is ProduitCatalogueEntity => !!p?.id);
+        if (produitsCat.length > 0) setProduits((prev) => mergeById(prev, produitsCat));
+        const bateauxCat = (vente.venteBateauxCatalogue || []).map((l) => l.bateau).filter((b): b is CatalogueBateauEntity => !!b?.id);
+        if (bateauxCat.length > 0) setCatalogueBateaux((prev) => mergeById(prev, bateauxCat));
+        const moteursCat = (vente.venteMoteursCatalogue || []).map((l) => l.moteur).filter((m): m is CatalogueMoteurEntity => !!m?.id);
+        if (moteursCat.length > 0) setCatalogueMoteurs((prev) => mergeById(prev, moteursCat));
+        const helicesCat = (vente.venteHelicesCatalogue || []).map((l) => l.helice).filter((h): h is CatalogueHeliceEntity => !!h?.id);
+        if (helicesCat.length > 0) setCatalogueHelices((prev) => mergeById(prev, helicesCat));
+        const remorquesCat = (vente.venteRemorquesCatalogue || []).map((l) => l.remorque).filter((r): r is CatalogueRemorqueEntity => !!r?.id);
+        if (remorquesCat.length > 0) setCatalogueRemorques((prev) => mergeById(prev, remorquesCat));
         const lignes: LigneUnifiee[] = [];
         (vente.venteForfaits || []).forEach(vf => {
             lignes.push({
                 type: 'forfait',
                 itemId: vf.forfait?.id,
                 quantite: vf.quantite || 1,
+                remise: vf.remise || 0,
+                remisePourcentage: vf.remisePourcentage || 0,
                 technicienIds: (vf.techniciens || []).map(t => t.id),
                 status: vf.status || 'EN_ATTENTE',
                 datePlanification: vf.datePlanification,
@@ -1430,6 +1475,8 @@ export default function Vente() {
                 type: 'service',
                 itemId: vs.service?.id,
                 quantite: vs.quantite || 1,
+                remise: vs.remise || 0,
+                remisePourcentage: vs.remisePourcentage || 0,
                 technicienIds: (vs.techniciens || []).map(t => t.id),
                 status: vs.status || 'EN_ATTENTE',
                 datePlanification: vs.datePlanification,
@@ -1444,16 +1491,21 @@ export default function Vente() {
                 documents: vs.documents || [],
             });
         });
-        const buildLignesFromItems = (items: Array<{ id: number }>, type: LigneType) => {
-            const map = new Map<number, number>();
-            items.forEach((item) => { if (item?.id) map.set(item.id, (map.get(item.id) || 0) + 1); });
-            map.forEach((quantite, itemId) => lignes.push({ type, itemId, quantite }));
-        };
-        buildLignesFromItems(vente.produits || [], 'produit');
-        buildLignesFromItems(vente.bateauxCatalogue || [], 'bateau');
-        buildLignesFromItems(vente.moteursCatalogue || [], 'moteur');
-        buildLignesFromItems(vente.helicesCatalogue || [], 'helice');
-        buildLignesFromItems(vente.remorquesCatalogue || [], 'remorque');
+        (vente.venteProduits || []).forEach((l) => {
+            if (l.produit?.id) lignes.push({ type: 'produit', itemId: l.produit.id, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 });
+        });
+        (vente.venteBateauxCatalogue || []).forEach((l) => {
+            if (l.bateau?.id) lignes.push({ type: 'bateau', itemId: l.bateau.id, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 });
+        });
+        (vente.venteMoteursCatalogue || []).forEach((l) => {
+            if (l.moteur?.id) lignes.push({ type: 'moteur', itemId: l.moteur.id, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 });
+        });
+        (vente.venteHelicesCatalogue || []).forEach((l) => {
+            if (l.helice?.id) lignes.push({ type: 'helice', itemId: l.helice.id, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 });
+        });
+        (vente.venteRemorquesCatalogue || []).forEach((l) => {
+            if (l.remorque?.id) lignes.push({ type: 'remorque', itemId: l.remorque.id, quantite: l.quantite || 1, remise: l.remise || 0, remisePourcentage: l.remisePourcentage || 0 });
+        });
         form.resetFields();
         form.setFieldsValue({
             status: vente.status || 'DEVIS',
@@ -1687,6 +1739,8 @@ export default function Vente() {
                 return {
                     forfait: selectedForfait,
                     quantite: line.quantite || 1,
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
                     techniciens: (line.technicienIds || []).map((id: number) => techniciens.find((t) => t.id === id)).filter(Boolean),
                     datePlanification: line.datePlanification || existingVf?.datePlanification,
                     dateDebut: line.dateDebut || existingVf?.dateDebut,
@@ -1710,6 +1764,8 @@ export default function Vente() {
                 return {
                     service: services.find((s) => s.id === line.itemId),
                     quantite: line.quantite || 1,
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
                     techniciens: (line.technicienIds || []).map((id: number) => techniciens.find((t) => t.id === id)).filter(Boolean),
                     datePlanification: line.datePlanification || existingVs?.datePlanification,
                     dateDebut: line.dateDebut || existingVs?.dateDebut,
@@ -1724,31 +1780,51 @@ export default function Vente() {
                     documents: line.documents || existingVs?.documents || [],
                 };
             }),
-            produits: produitLines.flatMap((line) => {
-                const item = produits.find((produit) => produit.id === line.itemId);
-                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
-                return item ? Array.from({ length: safeQuantity }, () => item) : [];
-            }) as ProduitCatalogueEntity[],
-            bateauxCatalogue: bateauLines.flatMap((line) => {
-                const item = catalogueBateaux.find((b) => b.id === line.itemId);
-                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
-                return item ? Array.from({ length: safeQuantity }, () => item) : [];
-            }) as CatalogueBateauEntity[],
-            moteursCatalogue: moteurLines.flatMap((line) => {
-                const item = catalogueMoteurs.find((m) => m.id === line.itemId);
-                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
-                return item ? Array.from({ length: safeQuantity }, () => item) : [];
-            }) as CatalogueMoteurEntity[],
-            helicesCatalogue: heliceLines.flatMap((line) => {
-                const item = catalogueHelices.find((h) => h.id === line.itemId);
-                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
-                return item ? Array.from({ length: safeQuantity }, () => item) : [];
-            }) as CatalogueHeliceEntity[],
-            remorquesCatalogue: remorqueLines.flatMap((line) => {
-                const item = catalogueRemorques.find((r) => r.id === line.itemId);
-                const safeQuantity = Math.max(1, Math.floor(line.quantite || 1));
-                return item ? Array.from({ length: safeQuantity }, () => item) : [];
-            }) as CatalogueRemorqueEntity[],
+            venteProduits: produitLines.flatMap<VenteProduitLigne>((line) => {
+                const produit = produits.find((p) => p.id === line.itemId);
+                return produit ? [{
+                    produit,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+            venteBateauxCatalogue: bateauLines.flatMap<VenteBateauCatalogueLigne>((line) => {
+                const bateau = catalogueBateaux.find((b) => b.id === line.itemId);
+                return bateau ? [{
+                    bateau,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+            venteMoteursCatalogue: moteurLines.flatMap<VenteMoteurCatalogueLigne>((line) => {
+                const moteur = catalogueMoteurs.find((m) => m.id === line.itemId);
+                return moteur ? [{
+                    moteur,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+            venteHelicesCatalogue: heliceLines.flatMap<VenteHeliceCatalogueLigne>((line) => {
+                const helice = catalogueHelices.find((h) => h.id === line.itemId);
+                return helice ? [{
+                    helice,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
+            venteRemorquesCatalogue: remorqueLines.flatMap<VenteRemorqueCatalogueLigne>((line) => {
+                const remorque = catalogueRemorques.find((r) => r.id === line.itemId);
+                return remorque ? [{
+                    remorque,
+                    quantite: Math.max(1, Math.floor(line.quantite || 1)),
+                    remise: line.remise || 0,
+                    remisePourcentage: line.remisePourcentage || 0,
+                }] : [];
+            }),
             date: toBackendDateValue(values.date),
             dateEcheance: toBackendDateValue(values.dateEcheance),
             conditionsPaiement: values.conditionsPaiement,
@@ -2010,41 +2086,46 @@ export default function Vente() {
     };
 
     const buildDocumentLines = (vente: VenteEntity) => {
-        const forfaitLines = (vente.venteForfaits || []).map(vf => ({
-            type: 'Forfait', label: vf.forfait?.nom || '', quantite: vf.quantite || 1,
-            totalPrixTTC: (vf.forfait?.prixTTC || 0) * (vf.quantite || 1)
-        }));
-        const produitLines = Array.from(
-            (vente.produits || []).reduce((acc, item) => {
-                const label = `${item.nom}${item.marque ? ` (${item.marque})` : ''}`;
-                const key = item.id ? `id-${item.id}` : `label-${label}`;
-                const current = acc.get(key) || { type: 'Produit', label, quantite: 0, totalPrixTTC: 0 };
-                current.quantite += 1;
-                current.totalPrixTTC += item.prixVenteTTC || 0;
-                acc.set(key, current);
-                return acc;
-            }, new Map<string, { type: string; label: string; quantite: number; totalPrixTTC: number }>()).values()
-        );
-        const serviceLines = (vente.venteServices || []).map(vs => ({
-            type: 'Service', label: vs.service?.nom || '', quantite: vs.quantite || 1,
-            totalPrixTTC: (vs.service?.prixTTC || 0) * (vs.quantite || 1)
-        }));
-        const buildCatalogueLines = (items: Array<{ id: number; marque: string; modele: string; prixVenteTTC?: number }>, typeLabel: string) =>
-            Array.from(
-                (items || []).reduce((acc, item) => {
-                    const label = `${item.marque} ${item.modele}`;
-                    const key = `id-${item.id}`;
-                    const current = acc.get(key) || { type: typeLabel, label, quantite: 0, totalPrixTTC: 0 };
-                    current.quantite += 1;
-                    current.totalPrixTTC += item.prixVenteTTC || 0;
-                    acc.set(key, current);
-                    return acc;
-                }, new Map<string, { type: string; label: string; quantite: number; totalPrixTTC: number }>()).values()
-            );
-        const bateauLines = buildCatalogueLines(vente.bateauxCatalogue || [], 'Bateau');
-        const moteurCatLines = buildCatalogueLines(vente.moteursCatalogue || [], 'Moteur');
-        const heliceLines = buildCatalogueLines(vente.helicesCatalogue || [], 'Hélice');
-        const remorqueCatLines = buildCatalogueLines(vente.remorquesCatalogue || [], 'Remorque');
+        const lineFromForfait = (vf: VenteForfaitEntity) => {
+            const brut = (vf.forfait?.prixTTC || 0) * (vf.quantite || 1);
+            return {
+                type: 'Forfait', label: vf.forfait?.nom || '', quantite: vf.quantite || 1,
+                remise: vf.remise || 0,
+                totalPrixTTC: Math.max(0, brut - (vf.remise || 0)),
+            };
+        };
+        const lineFromService = (vs: VenteServiceEntity) => {
+            const brut = (vs.service?.prixTTC || 0) * (vs.quantite || 1);
+            return {
+                type: 'Service', label: vs.service?.nom || '', quantite: vs.quantite || 1,
+                remise: vs.remise || 0,
+                totalPrixTTC: Math.max(0, brut - (vs.remise || 0)),
+            };
+        };
+        const lineFromProduit = (vp: VenteProduitLigne) => {
+            const label = vp.produit ? `${vp.produit.nom}${vp.produit.marque ? ` (${vp.produit.marque})` : ''}` : '';
+            const brut = (vp.produit?.prixVenteTTC || 0) * (vp.quantite || 1);
+            return {
+                type: 'Produit', label, quantite: vp.quantite || 1,
+                remise: vp.remise || 0,
+                totalPrixTTC: Math.max(0, brut - (vp.remise || 0)),
+            };
+        };
+        const lineFromCatalogue = (item: { marque?: string; modele?: string; prixVenteTTC?: number } | undefined, typeLabel: string, qty: number, remise: number) => {
+            const brut = (item?.prixVenteTTC || 0) * (qty || 1);
+            return {
+                type: typeLabel, label: item ? `${item.marque || ''} ${item.modele || ''}`.trim() : '', quantite: qty || 1,
+                remise: remise || 0,
+                totalPrixTTC: Math.max(0, brut - (remise || 0)),
+            };
+        };
+        const forfaitLines = (vente.venteForfaits || []).map(lineFromForfait);
+        const produitLines = (vente.venteProduits || []).map(lineFromProduit);
+        const serviceLines = (vente.venteServices || []).map(lineFromService);
+        const bateauLines = (vente.venteBateauxCatalogue || []).map((vb) => lineFromCatalogue(vb.bateau, 'Bateau', vb.quantite, vb.remise || 0));
+        const moteurCatLines = (vente.venteMoteursCatalogue || []).map((vm) => lineFromCatalogue(vm.moteur, 'Moteur', vm.quantite, vm.remise || 0));
+        const heliceLines = (vente.venteHelicesCatalogue || []).map((vh) => lineFromCatalogue(vh.helice, 'Hélice', vh.quantite, vh.remise || 0));
+        const remorqueCatLines = (vente.venteRemorquesCatalogue || []).map((vr) => lineFromCatalogue(vr.remorque, 'Remorque', vr.quantite, vr.remise || 0));
         return [...forfaitLines, ...produitLines, ...bateauLines, ...moteurCatLines, ...heliceLines, ...remorqueCatLines, ...serviceLines];
     };
 
@@ -2079,15 +2160,17 @@ export default function Vente() {
                 ${societe.email ? `<div>Email : ${escapeHtml(societe.email)}</div>` : ''}
             </div>` : '';
 
+        const remiseColumn = showPrices ? '<th>Remise</th>' : '';
         const priceColumn = showPrices ? '<th>Prix total TTC</th>' : '';
         const tableHtml = lines.length > 0
             ? `<table class="invoice-table">
-                <thead><tr><th>Type</th><th>Désignation</th><th>Qté</th>${priceColumn}</tr></thead>
+                <thead><tr><th>Type</th><th>Désignation</th><th>Qté</th>${remiseColumn}${priceColumn}</tr></thead>
                 <tbody>${lines.map((line) => `
                     <tr>
                         <td>${escapeHtml(line.type)}</td>
                         <td>${escapeHtml(line.label)}</td>
                         <td>${line.quantite}</td>
+                        ${showPrices ? `<td>${line.remise > 0 ? escapeHtml(formatEuro(line.remise)) : '-'}</td>` : ''}
                         ${showPrices ? `<td>${escapeHtml(formatEuro(line.totalPrixTTC))}</td>` : ''}
                     </tr>`).join('')}
                 </tbody>
@@ -2280,21 +2363,23 @@ export default function Vente() {
         allLignes.forEach((line) => {
             if (!line.type || !line.itemId) return;
             const quantite = Math.max(1, Math.floor(line.quantite || 1));
+            let brut = 0;
             if (line.type === 'forfait') {
-                totalTTC += (allForfaits.find((f) => f.id === line.itemId)?.prixTTC || 0) * quantite;
+                brut = (allForfaits.find((f) => f.id === line.itemId)?.prixTTC || 0) * quantite;
             } else if (line.type === 'service') {
-                totalTTC += (allServices.find((s) => s.id === line.itemId)?.prixTTC || 0) * quantite;
+                brut = (allServices.find((s) => s.id === line.itemId)?.prixTTC || 0) * quantite;
             } else if (line.type === 'produit') {
-                totalTTC += (allProduits.find((p) => p.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+                brut = (allProduits.find((p) => p.id === line.itemId)?.prixVenteTTC || 0) * quantite;
             } else if (line.type === 'bateau') {
-                totalTTC += (catalogueBateaux.find((b) => b.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+                brut = (catalogueBateaux.find((b) => b.id === line.itemId)?.prixVenteTTC || 0) * quantite;
             } else if (line.type === 'moteur') {
-                totalTTC += (catalogueMoteurs.find((m) => m.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+                brut = (catalogueMoteurs.find((m) => m.id === line.itemId)?.prixVenteTTC || 0) * quantite;
             } else if (line.type === 'helice') {
-                totalTTC += (catalogueHelices.find((h) => h.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+                brut = (catalogueHelices.find((h) => h.id === line.itemId)?.prixVenteTTC || 0) * quantite;
             } else if (line.type === 'remorque') {
-                totalTTC += (catalogueRemorques.find((r) => r.id === line.itemId)?.prixVenteTTC || 0) * quantite;
+                brut = (catalogueRemorques.find((r) => r.id === line.itemId)?.prixVenteTTC || 0) * quantite;
             }
+            totalTTC += Math.max(0, brut - (line.remise || 0));
         });
 
         const montantTTC = Math.round((totalTTC + Number.EPSILON) * 100) / 100;
@@ -2319,11 +2404,44 @@ export default function Vente() {
         form.setFieldValue('prixVenteTTC', prixVenteTTC);
     };
 
+    const syncLineRemise = (changedLignes: Array<Partial<LigneUnifiee> | undefined>) => {
+        const currentLines: LigneUnifiee[] = form.getFieldValue('lignes') || [];
+        changedLignes.forEach((changed, index) => {
+            if (!changed) return;
+            const line = currentLines[index];
+            if (!line || !line.type || !line.itemId) return;
+            let pu = 0;
+            if (line.type === 'forfait') pu = forfaits.find((f) => f.id === line.itemId)?.prixTTC || 0;
+            else if (line.type === 'service') pu = services.find((s) => s.id === line.itemId)?.prixTTC || 0;
+            else if (line.type === 'produit') pu = produits.find((p) => p.id === line.itemId)?.prixVenteTTC || 0;
+            else if (line.type === 'bateau') pu = catalogueBateaux.find((b) => b.id === line.itemId)?.prixVenteTTC || 0;
+            else if (line.type === 'moteur') pu = catalogueMoteurs.find((m) => m.id === line.itemId)?.prixVenteTTC || 0;
+            else if (line.type === 'helice') pu = catalogueHelices.find((h) => h.id === line.itemId)?.prixVenteTTC || 0;
+            else if (line.type === 'remorque') pu = catalogueRemorques.find((r) => r.id === line.itemId)?.prixVenteTTC || 0;
+            const quantite = Math.max(1, Math.floor(line.quantite || 1));
+            const brut = Math.round(pu * quantite * 100) / 100;
+            if (changed.remisePourcentage !== undefined) {
+                const remise = Math.round(((brut * (changed.remisePourcentage || 0)) / 100 + Number.EPSILON) * 100) / 100;
+                form.setFieldValue(['lignes', index, 'remise'], remise);
+            } else if (changed.remise !== undefined) {
+                const remisePourcentage = brut > 0
+                    ? Math.round((((changed.remise || 0) / brut) * 100 + Number.EPSILON) * 100) / 100
+                    : 0;
+                form.setFieldValue(['lignes', index, 'remisePourcentage'], remisePourcentage);
+            }
+        });
+    };
+
     const onValuesChange = (changedValues: Partial<VenteFormValues>, allValues: VenteFormValues) => {
         if (!suppressDirtyRef.current) {
             setFormDirty(true);
         }
         if (changedValues.lignes !== undefined) {
+            const changedLignesArr = changedValues.lignes as Array<Partial<LigneUnifiee> | undefined>;
+            const lineRemiseChanged = changedLignesArr.some((l) => l && (l.remise !== undefined || l.remisePourcentage !== undefined));
+            if (lineRemiseChanged) {
+                syncLineRemise(changedLignesArr);
+            }
             const currentLignes = allValues.lignes || [];
             if (currentLignes.length === 0) {
                 form.setFieldValue('lignes', [{ quantite: 1 }]);
@@ -2333,6 +2451,9 @@ export default function Vente() {
                 if (isLastLineComplete) {
                     form.setFieldValue('lignes', [...currentLignes, { quantite: 1 }]);
                 }
+            }
+            if (lineRemiseChanged) {
+                recalculateFromLines('auto');
             }
         }
 
@@ -2880,19 +3001,35 @@ export default function Vente() {
                                                             {() => {
                                                                 const pu = getUnitPrice();
                                                                 return (
-                                                                    <Form.Item style={{ width: 120 }}>
+                                                                    <Form.Item style={{ width: 100 }}>
                                                                         <InputNumber addonAfter="EUR" value={pu ?? undefined} style={{ width: '100%' }} disabled placeholder="P.U." />
                                                                     </Form.Item>
                                                                 );
                                                             }}
                                                         </Form.Item>
+                                                        <Form.Item
+                                                            {...field}
+                                                            name={[field.name, 'remisePourcentage']}
+                                                            style={{ width: 100 }}
+                                                        >
+                                                            <InputNumber addonAfter="%" min={0} max={100} step={0.01} style={{ width: '100%' }} placeholder="Rem." />
+                                                        </Form.Item>
+                                                        <Form.Item
+                                                            {...field}
+                                                            name={[field.name, 'remise']}
+                                                            style={{ width: 110 }}
+                                                        >
+                                                            <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} placeholder="Rem." />
+                                                        </Form.Item>
                                                         <Form.Item noStyle shouldUpdate>
                                                             {() => {
                                                                 const pu = getUnitPrice() || 0;
                                                                 const quantite = form.getFieldValue(['lignes', field.name, 'quantite']) || 0;
-                                                                const total = Math.round(((pu * quantite) + Number.EPSILON) * 100) / 100;
+                                                                const remise = form.getFieldValue(['lignes', field.name, 'remise']) || 0;
+                                                                const brut = pu * quantite;
+                                                                const total = Math.max(0, Math.round(((brut - remise) + Number.EPSILON) * 100) / 100);
                                                                 return (
-                                                                    <Form.Item style={{ width: 120 }}>
+                                                                    <Form.Item style={{ width: 110 }}>
                                                                         <InputNumber addonAfter="EUR" value={total} style={{ width: '100%' }} disabled />
                                                                     </Form.Item>
                                                                 );


### PR DESCRIPTION
## Résumé

- Une remise (EUR et %) peut désormais être appliquée sur chaque ligne d'une vente comptoir ou d'une prestation, en plus de la remise globale.
- Modèle backend : ajout de `remise`/`remisePourcentage` sur `VenteForfaitEntity` et `VenteServiceEntity`, et création de 5 nouvelles entités lignes (`VenteProduitEntity`, `VenteBateauCatalogueEntity`, `VenteMoteurCatalogueEntity`, `VenteHeliceCatalogueEntity`, `VenteRemorqueCatalogueEntity`) avec `quantite` + remise par ligne, remplaçant les `@ManyToMany` où la quantité était encodée par duplication. Migrateur idempotent au démarrage pour convertir les données existantes.
- UI : colonnes Remise EUR et % par ligne dans `comptoir.tsx` et `vente.tsx`, synchronisation EUR ↔ %, recalcul des totaux et affichage sur les impressions facture/devis/ticket. Factur-X applique la remise en réduisant le prix HT effectif de la ligne.

## Impact

- 279 tests backend passent.
- `AvoirResource`, `FacturXService`, `TechnicienPortalResource` et `ClientPortalResource` adaptés à la nouvelle structure.
- Les `@ManyToMany` legacy sont conservés temporairement pour la migration au démarrage, puis nettoyés (à supprimer dans une PR de nettoyage ultérieure).

## Test plan

- [x] Comptoir : créer une vente avec plusieurs produits, appliquer une remise par ligne (EUR ou %), vérifier le total et l'impression facture/ticket.
- [x] Prestation : créer une vente avec forfait/service/produit, appliquer une remise par ligne, vérifier le total et l'impression facture/devis.
- [x] Ouvrir une vente existante (créée avant la migration) et confirmer que les lignes apparaissent avec quantité correcte et remise à 0.
- [x] Générer un Factur-X (PDF) sur une facture avec remise par ligne et vérifier que les totaux XML correspondent.
- [x] Vérifier la décrémentation de stock pour une vente avec quantité > 1 et marquée payée.
- [x] Générer un avoir depuis une vente avec remise par ligne et vérifier les montants.