### PR TITLE
fix: resizer les miniatures dans les tables du catalogue (#338)

### DIFF
--- a/chantier-ui/src/catalogue-bateaux.tsx
+++ b/chantier-ui/src/catalogue-bateaux.tsx
@@ -257,7 +257,7 @@ const CatalogueBateaux: React.FC = () => {
             render: (_,record) => (
                 <Space>
                     {record.images && record.images[0] && (
-                        <Image width={50} src={record.images[0]} />
+                        <Image width={32} height={32} style={{ objectFit: 'cover' }} src={record.images[0]} />
                     )}
                     {record.modele}
                 </Space>

--- a/chantier-ui/src/catalogue-helices.tsx
+++ b/chantier-ui/src/catalogue-helices.tsx
@@ -305,7 +305,7 @@ const HeliceCatalogueView: React.FC = () => {
             render: (_, record) => (
                 <Space>
                     {record.images && record.images[0] && (
-                        <Image width={50} src={record.images[0]} />
+                        <Image width={32} height={32} style={{ objectFit: 'cover' }} src={record.images[0]} />
                     )}
                     {record.modele}
                 </Space>

--- a/chantier-ui/src/catalogue-moteurs.tsx
+++ b/chantier-ui/src/catalogue-moteurs.tsx
@@ -319,7 +319,7 @@ const MoteurCatalogue = () => {
       render: (_: any, record: any) => (
         <Space>
           {record.images && record.images[0] && (
-            <Image width={50} src={record.images[0]} />
+            <Image width={32} height={32} style={{ objectFit: 'cover' }} src={record.images[0]} />
           )}
           {record.modele}
         </Space>


### PR DESCRIPTION
## Résumé

- Réduit les miniatures de 50px à 32×32px dans les colonnes des tables de catalogue
- Ajoute `objectFit: cover` pour éviter que des images portrait n'allongent les lignes
- Appliqué aux trois tables concernées : moteurs, bateaux et hélices

Fixes #338