### PR TITLE
fix: afficher la liste complète des clients sur prestation

### DIFF
--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -600,7 +600,6 @@ export default function Vente() {
     const [bpaPendingCallback, setBpaPendingCallback] = useState<(() => void) | null>(null);
     const signatureCanvasRef = useRef<HTMLCanvasElement | null>(null);
     const signatureDrawingRef = useRef(false);
-    const [clientSearchTimeout, setClientSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
     const [produitSearchTimeout, setProduitSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
     const capturedSignatureRef = useRef<string | null>(null);
 
@@ -609,31 +608,6 @@ export default function Vente() {
         prev.forEach((item) => { if (item?.id !== undefined) map.set(item.id, item); });
         next.forEach((item) => { if (item?.id !== undefined) map.set(item.id, item); });
         return Array.from(map.values());
-    };
-
-    const handleClientSearch = (value: string) => {
-        if (clientSearchTimeout) clearTimeout(clientSearchTimeout);
-        if (!value || value.trim() === '') {
-            const timeout = setTimeout(async () => {
-                try {
-                    const res = await api.get('/clients');
-                    setClients(res.data || []);
-                } catch {
-                    // ignore
-                }
-            }, 300);
-            setClientSearchTimeout(timeout);
-            return;
-        }
-        const timeout = setTimeout(async () => {
-            try {
-                const res = await api.get(`/clients/search?q=${encodeURIComponent(value)}`);
-                setClients((prev) => mergeById(prev, res.data || []));
-            } catch {
-                // ignore
-            }
-        }, 300);
-        setClientSearchTimeout(timeout);
     };
 
     const handleProduitSearch = (value: string) => {
@@ -2746,9 +2720,9 @@ export default function Vente() {
                                             options={clientOptions}
                                             style={{ width: '100%' }}
                                             onChange={handleClientChange}
-                                            filterOption={false}
-                                            onSearch={handleClientSearch}
-                                            notFoundContent={null}
+                                            filterOption={(input, option) =>
+                                                (option?.label as string ?? '').toLowerCase().includes(input.toLowerCase())
+                                            }
                                             placeholder="Rechercher un client par prénom ou nom"
                                         />
                                     </Form.Item>
@@ -3978,9 +3952,9 @@ export default function Vente() {
                                 showSearch
                                 allowClear
                                 placeholder="Rechercher un propriétaire par prénom ou nom"
-                                filterOption={false}
-                                onSearch={handleClientSearch}
-                                notFoundContent={null}
+                                filterOption={(input, option) =>
+                                    (option?.label as string ?? '').toLowerCase().includes(input.toLowerCase())
+                                }
                                 options={clientOptions}
                                 onChange={(values) => newBateauForm.setFieldValue('proprietaires', (values || []).map((id: number) => ({ id })))}
                                 style={{ width: '100%' }}
@@ -4073,9 +4047,9 @@ export default function Vente() {
                                 showSearch
                                 allowClear
                                 placeholder="Rechercher un propriétaire par prénom ou nom"
-                                filterOption={false}
-                                onSearch={handleClientSearch}
-                                notFoundContent={null}
+                                filterOption={(input, option) =>
+                                    (option?.label as string ?? '').toLowerCase().includes(input.toLowerCase())
+                                }
                                 options={clientOptions}
                                 onChange={(value) => newMoteurForm.setFieldValue('proprietaire', value ? { id: value } : undefined)}
                                 style={{ width: '100%' }}
@@ -4148,9 +4122,9 @@ export default function Vente() {
                                 showSearch
                                 allowClear
                                 placeholder="Rechercher un propriétaire par prénom ou nom"
-                                filterOption={false}
-                                onSearch={handleClientSearch}
-                                notFoundContent={null}
+                                filterOption={(input, option) =>
+                                    (option?.label as string ?? '').toLowerCase().includes(input.toLowerCase())
+                                }
                                 options={clientOptions}
                                 onChange={(value) => newRemorqueForm.setFieldValue('proprietaire', value ? { id: value } : undefined)}
                                 style={{ width: '100%' }}

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -613,7 +613,18 @@ export default function Vente() {
 
     const handleClientSearch = (value: string) => {
         if (clientSearchTimeout) clearTimeout(clientSearchTimeout);
-        if (!value || value.trim() === '') return;
+        if (!value || value.trim() === '') {
+            const timeout = setTimeout(async () => {
+                try {
+                    const res = await api.get('/clients');
+                    setClients(res.data || []);
+                } catch {
+                    // ignore
+                }
+            }, 300);
+            setClientSearchTimeout(timeout);
+            return;
+        }
         const timeout = setTimeout(async () => {
             try {
                 const res = await api.get(`/clients/search?q=${encodeURIComponent(value)}`);
@@ -822,6 +833,7 @@ export default function Vente() {
     const fetchOptions = async () => {
         try {
             const [
+                clientsRes,
                 bateauxRes,
                 moteursRes,
                 remorquesRes,
@@ -835,6 +847,7 @@ export default function Vente() {
                 catHelicesRes,
                 catRemorquesRes
             ] = await Promise.all([
+                api.get('/clients'),
                 api.get('/bateaux'),
                 api.get('/moteurs'),
                 api.get('/remorques'),
@@ -848,6 +861,7 @@ export default function Vente() {
                 api.get('/catalogue/helices'),
                 api.get('/catalogue/remorques')
             ]);
+            setClients(clientsRes.data || []);
             setBateaux(bateauxRes.data || []);
             setMoteurs(moteursRes.data || []);
             setRemorques(remorquesRes.data || []);


### PR DESCRIPTION
## Résumé

- Charge tous les clients au démarrage via `GET /clients` dans `fetchOptions` (au même titre que les produits du catalogue)
- Réinitialise la liste complète des clients lorsque la recherche est vidée, au lieu de ne rien afficher

## Comportement avant / après

**Avant** : le dropdown client était vide à l'ouverture du modal, il fallait taper au moins un caractère pour voir des résultats.

**Après** : tous les clients sont listés dès l'ouverture (comme la liste des produits), la recherche debounced filtre toujours en temps réel.

Closes #339