### PR TITLE
fix: persister le canal d'acquisition lors de la mise à jour d'un client

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
@@ -119,6 +119,7 @@ public class ClientResource {
         entity.siret = client.siret;
         entity.tva = client.tva;
         entity.naf = client.naf;
+        entity.canalAcquisition = client.canalAcquisition;
         entity.documents = client.documents != null ? client.documents : new java.util.ArrayList<>();
         if (client.motDePasse != null && !client.motDePasse.isBlank()) {
             entity.motDePasse = PasswordUtil.hash(client.motDePasse);


### PR DESCRIPTION
Fixes #342

## Résumé

- La méthode `update` de `ClientResource` n'assignait pas `canalAcquisition` depuis l'entité reçue, contrairement à tous les autres champs du client.
- Ajout de `entity.canalAcquisition = client.canalAcquisition;` pour corriger la persistance.

## Plan de test

- [x] Ouvrir un client existant avec un canal d'acquisition défini
- [x] Modifier le canal d'acquisition et sauvegarder
- [ ] Recharger la page et vérifier que le nouveau canal est bien affiché
- [ ] Vérifier qu'un client sans canal d'acquisition peut en recevoir un via la modification