### PR TITLE
fix: décrémenter le stock lors d'une vente comptoir

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -710,8 +710,10 @@ public class VenteResource {
             }
         }
 
-        // Fallback: decrement stock at FACTURE_PRETE for sales without EN_COURS phase (e.g. comptoir)
-        if (!entity.stockDecremented && entity.status == VenteEntity.Status.FACTURE_PRETE) {
+        // Fallback: decrement stock once the sale reaches FACTURE_PRETE or FACTURE_PAYEE,
+        // for sales without EN_COURS phase (e.g. comptoir, which can skip FACTURE_PRETE entirely)
+        if (!entity.stockDecremented
+                && (entity.status == VenteEntity.Status.FACTURE_PRETE || entity.status == VenteEntity.Status.FACTURE_PAYEE)) {
             decrementStock(entity);
             entity.stockDecremented = true;
         }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -710,6 +710,12 @@ public class VenteResource {
             }
         }
 
+        // Fallback: decrement stock at FACTURE_PRETE for sales without EN_COURS phase (e.g. comptoir)
+        if (!entity.stockDecremented && entity.status == VenteEntity.Status.FACTURE_PRETE) {
+            decrementStock(entity);
+            entity.stockDecremented = true;
+        }
+
         entity.images = vente.images != null ? vente.images : new java.util.ArrayList<>();
         entity.documents = vente.documents != null ? vente.documents : new java.util.ArrayList<>();
         entity.date = vente.date;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -558,13 +558,21 @@ public class VenteResource {
 
         // Update venteProduits (new line entity with quantite + remise per line)
         entity.venteProduits.clear();
-        if (vente.venteProduits != null) {
+        if (vente.venteProduits != null && !vente.venteProduits.isEmpty()) {
             for (VenteProduitEntity incoming : vente.venteProduits) {
                 VenteProduitEntity cloned = new VenteProduitEntity();
                 cloned.produit = incoming.produit;
                 cloned.quantite = incoming.quantite;
                 cloned.remise = incoming.remise;
                 cloned.remisePourcentage = incoming.remisePourcentage;
+                entity.venteProduits.add(cloned);
+            }
+        } else if (vente.produits != null) {
+            // Legacy @ManyToMany list (no quantite/remise) sent instead of venteProduits
+            for (ProduitCatalogueEntity incoming : vente.produits) {
+                VenteProduitEntity cloned = new VenteProduitEntity();
+                cloned.produit = incoming;
+                cloned.quantite = 1;
                 entity.venteProduits.add(cloned);
             }
         }

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/VenteResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/VenteResourceTest.java
@@ -389,4 +389,29 @@ public class VenteResourceTest {
             .then()
             .statusCode(400);
     }
+
+    @Test
+    void testDecrementStockComptoir() {
+        int stockAvant = given()
+            .when().get("/catalogue/produits/100")
+            .then().statusCode(200).extract().path("stock");
+
+        int id = given()
+            .contentType("application/json")
+            .body("{\"status\":\"DEVIS\",\"comptoir\":true,\"prixVenteTTC\":24.0,\"produits\":[{\"id\":100}]}")
+            .when().post("/ventes")
+            .then().statusCode(201).extract().path("id");
+
+        given()
+            .contentType("application/json")
+            .body("{\"status\":\"FACTURE_PRETE\",\"comptoir\":true,\"prixVenteTTC\":24.0,\"produits\":[{\"id\":100}]}")
+            .when().put("/ventes/" + id)
+            .then().statusCode(200);
+
+        int stockApres = given()
+            .when().get("/catalogue/produits/100")
+            .then().statusCode(200).extract().path("stock");
+
+        org.junit.jupiter.api.Assertions.assertEquals(stockAvant - 1, stockApres);
+    }
 }

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/VenteResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/VenteResourceTest.java
@@ -391,7 +391,7 @@ public class VenteResourceTest {
     }
 
     @Test
-    void testDecrementStockComptoir() {
+    void testDecrementStock() {
         int stockAvant = given()
             .when().get("/catalogue/produits/100")
             .then().statusCode(200).extract().path("stock");
@@ -405,6 +405,31 @@ public class VenteResourceTest {
         given()
             .contentType("application/json")
             .body("{\"status\":\"FACTURE_PRETE\",\"comptoir\":true,\"prixVenteTTC\":24.0,\"produits\":[{\"id\":100}]}")
+            .when().put("/ventes/" + id)
+            .then().statusCode(200);
+
+        int stockApres = given()
+            .when().get("/catalogue/produits/100")
+            .then().statusCode(200).extract().path("stock");
+
+        org.junit.jupiter.api.Assertions.assertEquals(stockAvant - 1, stockApres);
+    }
+
+    @Test
+    void testDecrementStockComptoirDirectementFacturePayee() {
+        int stockAvant = given()
+            .when().get("/catalogue/produits/100")
+            .then().statusCode(200).extract().path("stock");
+
+        int id = given()
+            .contentType("application/json")
+            .body("{\"status\":\"DEVIS\",\"comptoir\":true,\"prixVenteTTC\":24.0,\"produits\":[{\"id\":100}]}")
+            .when().post("/ventes")
+            .then().statusCode(201).extract().path("id");
+
+        given()
+            .contentType("application/json")
+            .body("{\"status\":\"FACTURE_PAYEE\",\"comptoir\":true,\"prixVenteTTC\":24.0,\"produits\":[{\"id\":100}]}")
             .when().put("/ventes/" + id)
             .then().statusCode(200);
 


### PR DESCRIPTION
Fixes #344

## Résumé

- Le stock des produits n'était pas décrémenté lors d'une vente comptoir (ou prestation sans phase EN_COURS)
- La logique existante ne se déclenchait qu'au passage d'un forfait/service en `EN_COURS`, ce qui excluait les ventes comptoir (sans forfait ni service)
- Ajout d'un fallback dans `VenteResource.update()` qui décrémente le stock à la transition `FACTURE_PRETE` si ce n'est pas déjà fait (via le flag `stockDecremented`)

## Plan de test

- [x] Créer une vente comptoir avec un ou plusieurs produits du catalogue
- [x] Passer la vente en `FACTURE_PRETE`
- [x] Vérifier que le stock des produits concernés a bien diminué dans le catalogue
- [x] Vérifier qu'une deuxième mise à jour ne décrémente pas à nouveau (flag `stockDecremented`)