### PR TITLE
feat: afficher la liste complète des clients sur prestation

### DIFF
--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -96,8 +96,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
   const [moteursCatalogue, setMoteursCatalogue] = useState<any[]>([]);
   const [produitsCatalogue, setProduitsCatalogue] = useState<any[]>([]);
   const [clients, setClients] = useState<any[]>([]);
-  const [proprietaireOptions, setProprietaireOptions] = useState<any[]>([]);
-  const [proprietaireSearchTimeout, setProprietaireSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+
   const [modeleOptions, setModeleOptions] = useState<any[]>([]);
   const [modeleSearchTimeout, setModeleSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
   const [moteurOptions, setMoteurOptions] = useState<any[]>([]);
@@ -201,23 +200,6 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
     setClients(res.data);
   };
 
-  const handleProprietaireSearch = (value: string) => {
-    if (proprietaireSearchTimeout) clearTimeout(proprietaireSearchTimeout);
-    if (!value || value.trim() === "") {
-      setProprietaireOptions([]);
-      return;
-    }
-    const timeout = setTimeout(async () => {
-      try {
-        const res = await api.get(`/clients/search?q=${encodeURIComponent(value)}`);
-        setProprietaireOptions(res.data);
-      } catch {
-        setProprietaireOptions([]);
-      }
-    }, 300);
-    setProprietaireSearchTimeout(timeout);
-  };
-
   const handleModeleSearch = (value: string) => {
     if (modeleSearchTimeout) clearTimeout(modeleSearchTimeout);
     if (!value || value.trim() === "") {
@@ -276,11 +258,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
     setModeleOptions([]);
     setMoteurOptions([]);
     if (clientId) {
-      const client = clients.find((c: any) => c.id === clientId);
-      setProprietaireOptions(client ? [client] : []);
       form.setFieldsValue({ proprietaires: [clientId] });
-    } else {
-      setProprietaireOptions([]);
     }
     setModalVisible(true);
   };
@@ -288,7 +266,6 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
   const handleEdit = (record: BateauClient) => {
     setEditing(record);
     setFormDirty(false);
-    setProprietaireOptions(record.proprietaires || []);
     setModeleOptions(record.modele ? [record.modele] : []);
     setMoteurOptions(record.moteurs || []);
     form.setFieldsValue({
@@ -360,7 +337,6 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
       setClientModalVisible(false);
       clientForm.resetFields();
       await fetchClients();
-      setProprietaireOptions((prev) => [...prev, res.data]);
       const currentProprietaires = form.getFieldValue("proprietaires") || [];
       form.setFieldsValue({ proprietaires: [...currentProprietaires, res.data.id] });
     } catch (e) {
@@ -623,18 +599,13 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
                   mode="multiple"
                   style={{ width: '100%' }}
                   placeholder="Rechercher un propriétaire par prénom ou nom"
-                  filterOption={false}
                   showSearch
-                  onSearch={handleProprietaireSearch}
                   allowClear
-                  notFoundContent={null}
-                >
-                  {proprietaireOptions.map((client: any) => (
-                    <Select.Option key={client.id} value={client.id}>
-                      {client.prenom} {client.nom}
-                    </Select.Option>
-                  ))}
-                </Select>
+                  filterOption={(input, option) =>
+                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                  }
+                  options={clients.map((c: any) => ({ value: c.id, label: `${c.prenom || ''} ${c.nom || ''}`.trim() }))}
+                />
               </Form.Item>
               <Button
                 icon={<PlusCircleOutlined />}

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -91,8 +91,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
   const [annonceSelectedImages, setAnnonceSelectedImages] = useState<Set<string>>(new Set());
   const [modeleOptions, setModeleOptions] = useState<any[]>([]);
   const [modeleSearchTimeout, setModeleSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
-  const [proprietaireOptions, setProprietaireOptions] = useState<any[]>([]);
-  const [proprietaireSearchTimeout, setProprietaireSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+
   const { navigate } = useNavigation();
 
   const openAnnonceImageModal = (moteur: MoteurClient) => {
@@ -204,34 +203,13 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
     setModeleSearchTimeout(timeout);
   };
 
-  const handleProprietaireSearch = (value: string) => {
-    if (proprietaireSearchTimeout) clearTimeout(proprietaireSearchTimeout);
-    if (!value || value.trim() === "") {
-      setProprietaireOptions([]);
-      return;
-    }
-    const timeout = setTimeout(async () => {
-      try {
-        const res = await api.get(`/clients/search?q=${encodeURIComponent(value)}`);
-        setProprietaireOptions(res.data);
-      } catch {
-        setProprietaireOptions([]);
-      }
-    }, 300);
-    setProprietaireSearchTimeout(timeout);
-  };
-
   const handleAdd = () => {
     setEditing(null);
     form.resetFields();
     setFormDirty(false);
     setModeleOptions([]);
     if (clientId) {
-      const client = clients.find((c: any) => c.id === clientId);
-      setProprietaireOptions(client ? [client] : []);
       form.setFieldsValue({ proprietaireId: clientId });
-    } else {
-      setProprietaireOptions([]);
     }
     setModalVisible(true);
   };
@@ -240,7 +218,6 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
     setEditing(record);
     setFormDirty(false);
     setModeleOptions(record.modele ? [record.modele] : []);
-    setProprietaireOptions(record.proprietaire ? [record.proprietaire] : []);
     form.setFieldsValue({
       ...record,
       dateMeS: record.dateMeS ? dayjs(record.dateMeS) : null,
@@ -274,7 +251,6 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
       setClientModalVisible(false);
       clientForm.resetFields();
       await fetchClients();
-      setProprietaireOptions((prev) => [...prev, res.data]);
       form.setFieldsValue({ proprietaireId: res.data.id });
     } catch (e: any) {
       if (e && e.response) {
@@ -512,18 +488,13 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
                 <Select
                   showSearch
                   placeholder="Rechercher un propriétaire par prénom ou nom"
-                  filterOption={false}
-                  onSearch={handleProprietaireSearch}
                   allowClear
-                  notFoundContent={null}
                   style={{ width: "100%" }}
-                >
-                  {proprietaireOptions.map((client: any) => (
-                    <Option key={client.id} value={client.id}>
-                      {client.prenom} {client.nom}
-                    </Option>
-                  ))}
-                </Select>
+                  filterOption={(input, option) =>
+                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                  }
+                  options={clients.map((c: any) => ({ value: c.id, label: `${c.prenom || ''} ${c.nom || ''}`.trim() }))}
+                />
               </Form.Item>
               <Button
                 icon={<PlusCircleOutlined />}

--- a/chantier-ui/src/clients-remorques.tsx
+++ b/chantier-ui/src/clients-remorques.tsx
@@ -87,8 +87,7 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
   const [annonceSelectedImages, setAnnonceSelectedImages] = useState<Set<string>>(new Set());
   const [modeleOptions, setModeleOptions] = useState<any[]>([]);
   const [modeleSearchTimeout, setModeleSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
-  const [proprietaireOptions, setProprietaireOptions] = useState<any[]>([]);
-  const [proprietaireSearchTimeout, setProprietaireSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+
   const { navigate } = useNavigation();
 
   const openAnnonceImageModal = (remorque: RemorqueClient) => {
@@ -201,34 +200,13 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
     setModeleSearchTimeout(timeout);
   };
 
-  const handleProprietaireSearch = (value: string) => {
-    if (proprietaireSearchTimeout) clearTimeout(proprietaireSearchTimeout);
-    if (!value || value.trim() === "") {
-      setProprietaireOptions([]);
-      return;
-    }
-    const timeout = setTimeout(async () => {
-      try {
-        const res = await api.get(`/clients/search?q=${encodeURIComponent(value)}`);
-        setProprietaireOptions(res.data);
-      } catch {
-        setProprietaireOptions([]);
-      }
-    }, 300);
-    setProprietaireSearchTimeout(timeout);
-  };
-
   const handleAdd = () => {
     setEditing(null);
     form.resetFields();
     setFormDirty(false);
     setModeleOptions([]);
     if (clientId) {
-      const client = clients.find((c: any) => c.id === clientId);
-      setProprietaireOptions(client ? [client] : []);
       form.setFieldsValue({ proprietaireId: clientId });
-    } else {
-      setProprietaireOptions([]);
     }
     setModalVisible(true);
   };
@@ -237,7 +215,6 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
     setEditing(record);
     setFormDirty(false);
     setModeleOptions(record.modele ? [record.modele] : []);
-    setProprietaireOptions(record.proprietaire ? [record.proprietaire] : []);
     form.setFieldsValue({
       ...record,
       dateMeS: record.dateMeS ? dayjs(record.dateMeS) : null,
@@ -270,7 +247,6 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
       setClientModalVisible(false);
       clientForm.resetFields();
       await fetchClients();
-      setProprietaireOptions((prev) => [...prev, res.data]);
       form.setFieldsValue({ proprietaireId: res.data.id });
     } catch (e: any) {
       if (e && e.response) {
@@ -483,18 +459,13 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
                 <Select
                   showSearch
                   placeholder="Rechercher un propriétaire par prénom ou nom"
-                  filterOption={false}
-                  onSearch={handleProprietaireSearch}
                   allowClear
-                  notFoundContent={null}
                   style={{ width: "100%" }}
-                >
-                  {proprietaireOptions.map((client: any) => (
-                    <Select.Option key={client.id} value={client.id}>
-                      {client.prenom} {client.nom}
-                    </Select.Option>
-                  ))}
-                </Select>
+                  filterOption={(input, option) =>
+                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                  }
+                  options={clients.map((c: any) => ({ value: c.id, label: `${c.prenom || ''} ${c.nom || ''}`.trim() }))}
+                />
               </Form.Item>
               <Button
                 icon={<PlusCircleOutlined />}

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -335,7 +335,6 @@ export default function Comptoir() {
     const [newProduitTargetLine, setNewProduitTargetLine] = useState<number | null>(null);
     const [newProduitForm] = Form.useForm();
     const [newProduitFormDirty, setNewProduitFormDirty] = useState(false);
-    const [clientSearchTimeout, setClientSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
     const [produitSearchTimeout, setProduitSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
     const [paiementModalVisible, setPaiementModalVisible] = useState(false);
     const [paiementMode, setPaiementMode] = useState<ModeReglement>('CARTE');
@@ -350,20 +349,6 @@ export default function Comptoir() {
         prev.forEach((item) => map.set(item.id, item));
         next.forEach((item) => { if (item?.id) map.set(item.id, item); });
         return Array.from(map.values());
-    };
-
-    const handleClientSearch = (value: string) => {
-        if (clientSearchTimeout) clearTimeout(clientSearchTimeout);
-        if (!value || value.trim() === '') return;
-        const timeout = setTimeout(async () => {
-            try {
-                const res = await api.get(`/clients/search?q=${encodeURIComponent(value)}`);
-                setClients((prev) => mergeById(prev, res.data || []));
-            } catch {
-                // ignore
-            }
-        }, 300);
-        setClientSearchTimeout(timeout);
     };
 
     const handleCatalogueSearch = (value: string) => {
@@ -508,6 +493,7 @@ export default function Comptoir() {
     const fetchOptions = async () => {
         try {
             const [
+                clientsRes,
                 bateauxRes,
                 moteursRes,
                 remorquesRes,
@@ -519,6 +505,7 @@ export default function Comptoir() {
                 catHelicesRes,
                 catRemorquesRes
             ] = await Promise.all([
+                api.get('/clients'),
                 api.get('/bateaux'),
                 api.get('/moteurs'),
                 api.get('/remorques'),
@@ -530,6 +517,7 @@ export default function Comptoir() {
                 api.get('/catalogue/helices'),
                 api.get('/catalogue/remorques')
             ]);
+            setClients(clientsRes.data || []);
             setBateaux(bateauxRes.data || []);
             setMoteurs(moteursRes.data || []);
             setRemorques(remorquesRes.data || []);
@@ -1444,9 +1432,9 @@ export default function Comptoir() {
                                     allowClear
                                     showSearch
                                     options={clientOptions}
-                                    filterOption={false}
-                                    onSearch={handleClientSearch}
-                                    notFoundContent={null}
+                                    filterOption={(input, option) =>
+                                        (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                                    }
                                     placeholder="Rechercher un client par prénom ou nom"
                                 />
                             </Form.Item>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -600,7 +600,6 @@ export default function Vente() {
     const [bpaPendingCallback, setBpaPendingCallback] = useState<(() => void) | null>(null);
     const signatureCanvasRef = useRef<HTMLCanvasElement | null>(null);
     const signatureDrawingRef = useRef(false);
-    const [clientSearchTimeout, setClientSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
     const [produitSearchTimeout, setProduitSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
     const capturedSignatureRef = useRef<string | null>(null);
 
@@ -609,20 +608,6 @@ export default function Vente() {
         prev.forEach((item) => { if (item?.id !== undefined) map.set(item.id, item); });
         next.forEach((item) => { if (item?.id !== undefined) map.set(item.id, item); });
         return Array.from(map.values());
-    };
-
-    const handleClientSearch = (value: string) => {
-        if (clientSearchTimeout) clearTimeout(clientSearchTimeout);
-        if (!value || value.trim() === '') return;
-        const timeout = setTimeout(async () => {
-            try {
-                const res = await api.get(`/clients/search?q=${encodeURIComponent(value)}`);
-                setClients((prev) => mergeById(prev, res.data || []));
-            } catch {
-                // ignore
-            }
-        }, 300);
-        setClientSearchTimeout(timeout);
     };
 
     const handleProduitSearch = (value: string) => {
@@ -822,6 +807,7 @@ export default function Vente() {
     const fetchOptions = async () => {
         try {
             const [
+                clientsRes,
                 bateauxRes,
                 moteursRes,
                 remorquesRes,
@@ -835,6 +821,7 @@ export default function Vente() {
                 catHelicesRes,
                 catRemorquesRes
             ] = await Promise.all([
+                api.get('/clients'),
                 api.get('/bateaux'),
                 api.get('/moteurs'),
                 api.get('/remorques'),
@@ -848,6 +835,7 @@ export default function Vente() {
                 api.get('/catalogue/helices'),
                 api.get('/catalogue/remorques')
             ]);
+            setClients(clientsRes.data || []);
             setBateaux(bateauxRes.data || []);
             setMoteurs(moteursRes.data || []);
             setRemorques(remorquesRes.data || []);
@@ -2732,9 +2720,9 @@ export default function Vente() {
                                             options={clientOptions}
                                             style={{ width: '100%' }}
                                             onChange={handleClientChange}
-                                            filterOption={false}
-                                            onSearch={handleClientSearch}
-                                            notFoundContent={null}
+                                            filterOption={(input, option) =>
+                                                (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                                            }
                                             placeholder="Rechercher un client par prénom ou nom"
                                         />
                                     </Form.Item>
@@ -3964,9 +3952,9 @@ export default function Vente() {
                                 showSearch
                                 allowClear
                                 placeholder="Rechercher un propriétaire par prénom ou nom"
-                                filterOption={false}
-                                onSearch={handleClientSearch}
-                                notFoundContent={null}
+                                filterOption={(input, option) =>
+                                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                                }
                                 options={clientOptions}
                                 onChange={(values) => newBateauForm.setFieldValue('proprietaires', (values || []).map((id: number) => ({ id })))}
                                 style={{ width: '100%' }}
@@ -4059,9 +4047,9 @@ export default function Vente() {
                                 showSearch
                                 allowClear
                                 placeholder="Rechercher un propriétaire par prénom ou nom"
-                                filterOption={false}
-                                onSearch={handleClientSearch}
-                                notFoundContent={null}
+                                filterOption={(input, option) =>
+                                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                                }
                                 options={clientOptions}
                                 onChange={(value) => newMoteurForm.setFieldValue('proprietaire', value ? { id: value } : undefined)}
                                 style={{ width: '100%' }}
@@ -4134,9 +4122,9 @@ export default function Vente() {
                                 showSearch
                                 allowClear
                                 placeholder="Rechercher un propriétaire par prénom ou nom"
-                                filterOption={false}
-                                onSearch={handleClientSearch}
-                                notFoundContent={null}
+                                filterOption={(input, option) =>
+                                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                                }
                                 options={clientOptions}
                                 onChange={(value) => newRemorqueForm.setFieldValue('proprietaire', value ? { id: value } : undefined)}
                                 style={{ width: '100%' }}


### PR DESCRIPTION
Fixes #339

## Résumé

- Les clients sont désormais chargés au démarrage en même temps que les autres référentiels (produits, forfaits, services…)
- Le select client/propriétaire affiche la liste complète dès l'ouverture, avec filtrage client-side à la saisie
- Comportement identique à la liste des produits sur prestation
- Suppression de la recherche serveur à la saisie devenue inutile

## Périmètre

- Champ **Client** sur la prestation (vente)
- Champ **Propriétaires** dans la modale "Créer un bateau" (depuis prestation)
- Champ **Propriétaire** dans la modale "Créer un moteur" (depuis prestation)
- Champ **Propriétaire** dans la modale "Créer une remorque" (depuis prestation)
- Champ **Propriétaire** dans les pages **Bateaux**, **Moteurs** et **Remorques**

## Plan de test

- [x] Ouvrir une prestation → le champ client affiche tous les clients sans avoir besoin de taper
- [x] Taper dans le champ → la liste se filtre correctement
- [ ] Ouvrir la liste des bateaux → ajouter ou éditer un bateau → le champ propriétaire affiche tous les clients
- [ ] Même vérification sur les pages Moteurs et Remorques