### PR TITLE
feat: créer une prestation directement depuis la fiche client

### DIFF
--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -32,12 +32,14 @@ import {
   ShopOutlined,
   GlobalOutlined,
   PhoneOutlined,
+  ToolOutlined,
 } from "@ant-design/icons";
 import api from "./api.ts";
 import BateauxClients from "./clients-bateaux.tsx";
 import ClientsMoteurs from "./clients-moteurs.tsx";
 import RemorquesClients from "./clients-remorques.tsx";
 import DocumentUpload from "./DocumentUpload.tsx";
+import { useNavigation } from "./navigation-context.tsx";
 
 const { Option } = Select;
 const { Search } = Input;
@@ -101,6 +103,7 @@ const canalAcquisitionOptions = [
 ];
 
 function Clients() {
+  const { navigate } = useNavigation();
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
@@ -553,6 +556,17 @@ function Clients() {
         </Form>
         {editing && editing.id && (
           <>
+            <Divider />
+            <Button
+              type="primary"
+              icon={<ToolOutlined />}
+              onClick={() => {
+                setModalVisible(false);
+                navigate('/prestations', { clientId: editing.id });
+              }}
+            >
+              Créer une prestation
+            </Button>
             <Divider />
             {/* Affiche la liste des bateaux pour ce client */}
             <BateauxClients clientId={editing.id} />

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -874,10 +874,15 @@ export default function Vente() {
         if (pageState?.clientId) {
             const clientId = pageState.clientId;
             navigate('/prestations');
-            openModal().then(() => {
+            (async () => {
+                try {
+                    const res = await api.get(`/clients/${clientId}`);
+                    setClients(prev => mergeById(prev, [res.data]));
+                } catch { /* ignore */ }
+                await openModal();
                 form.setFieldValue('clientId', clientId);
                 handleClientChange(clientId);
-            });
+            })();
         }
     }, [pageState]);
 

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -543,7 +543,7 @@ const getClientLabel = (client?: ClientEntity) => {
 
 export default function Vente() {
     const PRODUIT_CATEGORIES = useReferenceValeurs('CATEGORIE_PRODUIT');
-    const { navigate } = useNavigation();
+    const { navigate, pageState } = useNavigation();
     const [ventes, setVentes] = useState<VenteEntity[]>([]);
     const [clients, setClients] = useState<ClientEntity[]>([]);
     const [bateaux, setBateaux] = useState<BateauClientEntity[]>([]);
@@ -869,6 +869,17 @@ export default function Vente() {
         fetchVentes();
         fetchOptions();
     }, []);
+
+    useEffect(() => {
+        if (pageState?.clientId) {
+            const clientId = pageState.clientId;
+            navigate('/prestations');
+            openModal().then(() => {
+                form.setFieldValue('clientId', clientId);
+                handleClientChange(clientId);
+            });
+        }
+    }, [pageState]);
 
     const makeInnerModalCancel = (dirty: boolean, setDirty: (v: boolean) => void, setVisible: (v: boolean) => void) => () => {
         if (dirty) {


### PR DESCRIPTION
Fixes #286

## Résumé

- Ajout d'un bouton **Créer une prestation** dans la modale de la fiche client (visible uniquement pour un client existant)
- Un clic ferme la fiche, navigue vers la page Prestations et ouvre automatiquement la modale de création avec le client pré-sélectionné
- Même pattern que la création d'annonce depuis un bateau (via `pageState`)

## Plan de test

- [x] Ouvrir la fiche d'un client existant
- [x] Cliquer sur "Créer une prestation" → la page Prestations s'ouvre avec la modale de nouvelle prestation déjà affichée
- [x] Vérifier que le champ Client est pré-rempli avec le bon client
- [x] Vérifier que les champs Bateau / Moteur / Remorque sont également pré-remplis si le client en possède