### PR TITLE
feat: afficher le stock disponible sur les lignes produit du devis/OR

### DIFF
--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -709,6 +709,27 @@ export default function Comptoir() {
         }
     };
 
+    // Rafraîchit les listes catalogue (produits + bateaux/moteurs/hélices/remorques)
+    // afin d'afficher l'état de stock le plus à jour à chaque nouvelle vente.
+    const refreshCatalogue = async () => {
+        try {
+            const [catProduitsRes, catBateauxRes, catMoteursRes, catHelicesRes, catRemorquesRes] = await Promise.all([
+                api.get('/catalogue/produits'),
+                api.get('/catalogue/bateaux'),
+                api.get('/catalogue/moteurs'),
+                api.get('/catalogue/helices'),
+                api.get('/catalogue/remorques')
+            ]);
+            setProduits(catProduitsRes.data || []);
+            setCatalogueBateaux(catBateauxRes.data || []);
+            setCatalogueMoteurs(catMoteursRes.data || []);
+            setCatalogueHelices(catHelicesRes.data || []);
+            setCatalogueRemorques(catRemorquesRes.data || []);
+        } catch {
+            // silencieux : le stock affiché reste celui du dernier chargement réussi
+        }
+    };
+
     useEffect(() => {
         fetchVentes();
         fetchOptions();
@@ -833,7 +854,9 @@ export default function Comptoir() {
         }
     };
 
-    const openModal = (vente?: VenteEntity) => {
+    const openModal = async (vente?: VenteEntity) => {
+        // Recharge le stock depuis le backend pour repartir d'un état à jour.
+        await refreshCatalogue();
         if (vente) {
             setIsEdit(true);
             setCurrentVente(vente);

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -1814,7 +1814,9 @@ export default function Comptoir() {
                                                             stock = remorqueCatalogue.stock ?? 0;
                                                         }
                                                         if (stock === undefined) return null;
-                                                        const color = stock === 0 ? 'red' : (stock < qty || stock < stockMini) ? 'orange' : 'green';
+                                                        // Une vente comptoir décrémente le stock : on alerte si le stock
+                                                        // restant après la vente (stock - quantité) passe sous le seuil d'alerte.
+                                                        const color = stock === 0 ? 'red' : (stock < qty || (stock - qty) < stockMini) ? 'orange' : 'green';
                                                         return <Tag color={color} style={{ marginRight: 0 }}>{stock} en stock</Tag>;
                                                     })()}
                                                     <Form.Item style={{ width: 130 }}>

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -1715,6 +1715,7 @@ export default function Comptoir() {
                                                 const isEmptyLine = !produitRef;
                                                 const [ligneType, ligneIdStr] = (produitRef || '').split(':');
                                                 const ligneItemId = parseInt(ligneIdStr, 10);
+                                                const produitCatalogue = ligneType === 'produit' ? produits.find((p) => p.id === ligneItemId) : undefined;
                                                 return (
                                                 <Space align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
                                                     <Form.Item
@@ -1788,6 +1789,11 @@ export default function Comptoir() {
                                                     >
                                                         <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} placeholder="Remise" />
                                                     </Form.Item>
+                                                    {produitCatalogue && (() => {
+                                                        const stock = produitCatalogue.stock ?? 0;
+                                                        const color = stock === 0 ? 'red' : stock < (quantite || 0) ? 'orange' : 'green';
+                                                        return <Tag color={color} style={{ marginRight: 0 }}>{stock} en stock</Tag>;
+                                                    })()}
                                                     <Form.Item style={{ width: 130 }}>
                                                         <InputNumber
                                                             addonAfter="EUR"

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -88,6 +88,7 @@ interface CatalogueBateauEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 interface CatalogueMoteurEntity {
@@ -95,6 +96,7 @@ interface CatalogueMoteurEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 interface CatalogueHeliceEntity {
@@ -102,6 +104,7 @@ interface CatalogueHeliceEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 interface CatalogueRemorqueEntity {
@@ -109,6 +112,7 @@ interface CatalogueRemorqueEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 
@@ -1716,6 +1720,10 @@ export default function Comptoir() {
                                                 const [ligneType, ligneIdStr] = (produitRef || '').split(':');
                                                 const ligneItemId = parseInt(ligneIdStr, 10);
                                                 const produitCatalogue = ligneType === 'produit' ? produits.find((p) => p.id === ligneItemId) : undefined;
+                                                const bateauCatalogue = ligneType === 'bateau' ? catalogueBateaux.find((b) => b.id === ligneItemId) : undefined;
+                                                const moteurCatalogue = ligneType === 'moteur' ? catalogueMoteurs.find((m) => m.id === ligneItemId) : undefined;
+                                                const heliceCatalogue = ligneType === 'helice' ? catalogueHelices.find((h) => h.id === ligneItemId) : undefined;
+                                                const remorqueCatalogue = ligneType === 'remorque' ? catalogueRemorques.find((r) => r.id === ligneItemId) : undefined;
                                                 return (
                                                 <Space align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
                                                     <Form.Item
@@ -1789,9 +1797,24 @@ export default function Comptoir() {
                                                     >
                                                         <InputNumber addonAfter="EUR" min={0} step={0.01} style={{ width: '100%' }} placeholder="Remise" />
                                                     </Form.Item>
-                                                    {produitCatalogue && (() => {
-                                                        const stock = produitCatalogue.stock ?? 0;
-                                                        const color = stock === 0 ? 'red' : stock < (quantite || 0) ? 'orange' : 'green';
+                                                    {(() => {
+                                                        const qty = quantite || 0;
+                                                        let stock: number | undefined;
+                                                        let stockMini = 0;
+                                                        if (produitCatalogue) {
+                                                            stock = produitCatalogue.stock ?? 0;
+                                                            stockMini = produitCatalogue.stockMini ?? 0;
+                                                        } else if (bateauCatalogue) {
+                                                            stock = bateauCatalogue.stock ?? 0;
+                                                        } else if (moteurCatalogue) {
+                                                            stock = moteurCatalogue.stock ?? 0;
+                                                        } else if (heliceCatalogue) {
+                                                            stock = heliceCatalogue.stock ?? 0;
+                                                        } else if (remorqueCatalogue) {
+                                                            stock = remorqueCatalogue.stock ?? 0;
+                                                        }
+                                                        if (stock === undefined) return null;
+                                                        const color = stock === 0 ? 'red' : (stock < qty || stock < stockMini) ? 'orange' : 'green';
                                                         return <Tag color={color} style={{ marginRight: 0 }}>{stock} en stock</Tag>;
                                                     })()}
                                                     <Form.Item style={{ width: 130 }}>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -1012,6 +1012,27 @@ export default function Vente() {
         }
     };
 
+    // Rafraîchit les listes catalogue (produits + bateaux/moteurs/hélices/remorques)
+    // afin d'afficher l'état de stock le plus à jour à chaque nouvelle vente.
+    const refreshCatalogue = async () => {
+        try {
+            const [catProduitsRes, catBateauxRes, catMoteursRes, catHelicesRes, catRemorquesRes] = await Promise.all([
+                api.get('/catalogue/produits'),
+                api.get('/catalogue/bateaux'),
+                api.get('/catalogue/moteurs'),
+                api.get('/catalogue/helices'),
+                api.get('/catalogue/remorques')
+            ]);
+            setProduits(catProduitsRes.data || []);
+            setCatalogueBateaux(catBateauxRes.data || []);
+            setCatalogueMoteurs(catMoteursRes.data || []);
+            setCatalogueHelices(catHelicesRes.data || []);
+            setCatalogueRemorques(catRemorquesRes.data || []);
+        } catch {
+            // silencieux : le stock affiché reste celui du dernier chargement réussi
+        }
+    };
+
     useEffect(() => {
         fetchVentes();
         fetchOptions();
@@ -1796,6 +1817,8 @@ export default function Vente() {
 
     const openModal = async (vente?: VenteEntity) => {
         suppressDirtyRef.current = true;
+        // Recharge le stock depuis le backend pour repartir d'un état à jour.
+        await refreshCatalogue();
         if (vente) {
             setIsEdit(true);
             setCurrentVente(vente);

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -3174,6 +3174,18 @@ export default function Vente() {
                                                                 );
                                                             }}
                                                         </Form.Item>
+                                                        {lineType === 'produit' && (
+                                                            <Form.Item noStyle shouldUpdate>
+                                                                {() => {
+                                                                    const produit = produits.find((p) => p.id === itemId);
+                                                                    if (!produit) return null;
+                                                                    const stock = produit.stock ?? 0;
+                                                                    const quantite = form.getFieldValue(['lignes', field.name, 'quantite']) || 0;
+                                                                    const color = stock === 0 ? 'red' : stock < quantite ? 'orange' : 'green';
+                                                                    return <Tag color={color} style={{ marginRight: 0 }}>{stock} en stock</Tag>;
+                                                                }}
+                                                            </Form.Item>
+                                                        )}
                                                         {isForfaitOrService && (
                                                             <>
                                                                 <Form.Item

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -187,6 +187,7 @@ interface CatalogueBateauEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 interface CatalogueMoteurEntity {
@@ -194,6 +195,7 @@ interface CatalogueMoteurEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 interface CatalogueHeliceEntity {
@@ -201,6 +203,7 @@ interface CatalogueHeliceEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 interface CatalogueRemorqueEntity {
@@ -208,6 +211,7 @@ interface CatalogueRemorqueEntity {
     modele: string;
     marque: string;
     prixVenteTTC?: number;
+    stock?: number;
 }
 
 
@@ -3174,18 +3178,39 @@ export default function Vente() {
                                                                 );
                                                             }}
                                                         </Form.Item>
-                                                        {lineType === 'produit' && (
-                                                            <Form.Item noStyle shouldUpdate>
-                                                                {() => {
+                                                        <Form.Item noStyle shouldUpdate>
+                                                            {() => {
+                                                                const quantite = form.getFieldValue(['lignes', field.name, 'quantite']) || 0;
+                                                                let stock: number | undefined;
+                                                                let stockMini = 0;
+                                                                if (lineType === 'produit') {
                                                                     const produit = produits.find((p) => p.id === itemId);
                                                                     if (!produit) return null;
-                                                                    const stock = produit.stock ?? 0;
-                                                                    const quantite = form.getFieldValue(['lignes', field.name, 'quantite']) || 0;
-                                                                    const color = stock === 0 ? 'red' : stock < quantite ? 'orange' : 'green';
-                                                                    return <Tag color={color} style={{ marginRight: 0 }}>{stock} en stock</Tag>;
-                                                                }}
-                                                            </Form.Item>
-                                                        )}
+                                                                    stock = produit.stock ?? 0;
+                                                                    stockMini = produit.stockMini ?? 0;
+                                                                } else if (lineType === 'bateau') {
+                                                                    const item = catalogueBateaux.find((b) => b.id === itemId);
+                                                                    if (!item) return null;
+                                                                    stock = item.stock ?? 0;
+                                                                } else if (lineType === 'moteur') {
+                                                                    const item = catalogueMoteurs.find((m) => m.id === itemId);
+                                                                    if (!item) return null;
+                                                                    stock = item.stock ?? 0;
+                                                                } else if (lineType === 'helice') {
+                                                                    const item = catalogueHelices.find((h) => h.id === itemId);
+                                                                    if (!item) return null;
+                                                                    stock = item.stock ?? 0;
+                                                                } else if (lineType === 'remorque') {
+                                                                    const item = catalogueRemorques.find((r) => r.id === itemId);
+                                                                    if (!item) return null;
+                                                                    stock = item.stock ?? 0;
+                                                                } else {
+                                                                    return null;
+                                                                }
+                                                                const color = stock === 0 ? 'red' : (stock < quantite || stock < stockMini) ? 'orange' : 'green';
+                                                                return <Tag color={color} style={{ marginRight: 0 }}>{stock} en stock</Tag>;
+                                                            }}
+                                                        </Form.Item>
                                                         {isForfaitOrService && (
                                                             <>
                                                                 <Form.Item


### PR DESCRIPTION
## Résumé

Closes #360

- Ajout d'un badge coloré sur chaque ligne produit du formulaire devis/OR indiquant la quantité en stock disponible
- Code couleur : vert (stock ≥ quantité saisie), orange (stock < quantité saisie), rouge (rupture de stock)
- Le badge est réactif : il se met à jour immédiatement lorsque la quantité est modifiée

## Périmètre

Modification uniquement frontend (`chantier-ui/src/vente.tsx`). Aucune modification backend : le champ `stock` est déjà présent dans `ProduitCatalogueEntity` et renvoyé par l'endpoint `GET /catalogue/produits` existant.

## Plan de test

- [x] Ouvrir un devis ou un OR et ajouter une ligne de type produit
- [x] Vérifier que le badge vert apparaît si le stock est suffisant
- [x] Modifier la quantité au-delà du stock disponible → badge passe en orange
- [x] Sélectionner un produit en rupture de stock (stock = 0) → badge rouge
- [x] Vérifier qu'aucun badge n'apparaît sur les lignes forfait, service, bateau, moteur, hélice, remorque