### PR TITLE
Afficher l'emplacement de stockage sur les lignes de devis

### DIFF
--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -2810,6 +2810,10 @@ export default function Vente() {
                                                         return undefined;
                                                     };
 
+                                                    const emplacement = lineType === 'produit' && itemId
+                                                        ? produits.find((p) => p.id === itemId)?.emplacement
+                                                        : undefined;
+
                                                     return (
                                                     <Space key={field.key} align="baseline" style={{ display: 'flex', marginBottom: 8, flexWrap: 'nowrap' }}>
                                                         <Form.Item
@@ -2867,6 +2871,11 @@ export default function Vente() {
                                                             <Tag color={lineType === 'forfait' ? 'blue' : lineType === 'service' ? 'green' : lineType === 'produit' ? 'orange' : 'purple'} style={{ marginRight: 0 }}>
                                                                 {lineType === 'forfait' ? 'F' : lineType === 'service' ? 'S' : lineType === 'produit' ? 'P' : lineType === 'bateau' ? 'B' : lineType === 'moteur' ? 'M' : lineType === 'helice' ? 'H' : 'R'}
                                                             </Tag>
+                                                        )}
+                                                        {lineType === 'produit' && itemId && (
+                                                            <Form.Item style={{ width: 110 }}>
+                                                                <Input disabled value={emplacement || ''} placeholder="Emplacement" />
+                                                            </Form.Item>
                                                         )}
                                                         <Form.Item
                                                             {...field}

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -2872,9 +2872,9 @@ export default function Vente() {
                                                                 {lineType === 'forfait' ? 'F' : lineType === 'service' ? 'S' : lineType === 'produit' ? 'P' : lineType === 'bateau' ? 'B' : lineType === 'moteur' ? 'M' : lineType === 'helice' ? 'H' : 'R'}
                                                             </Tag>
                                                         )}
-                                                        {lineType === 'produit' && itemId && (
-                                                            <Form.Item style={{ width: 110 }}>
-                                                                <Input disabled value={emplacement || ''} placeholder="Emplacement" />
+                                                        {lineType === 'produit' && itemId && emplacement && (
+                                                            <Form.Item style={{ width: 200 }}>
+                                                                <Input disabled value={emplacement} title={emplacement} placeholder="Emplacement" />
                                                             </Form.Item>
                                                         )}
                                                         <Form.Item


### PR DESCRIPTION
## Résumé
- Affiche l'emplacement de stockage de chaque produit directement sur sa ligne de devis dans chantier-ui
- Le champ `emplacement` existait déjà dans `ProduitCatalogueEntity` (backend) et était déjà exposé par l'API et le type TypeScript correspondant ; seul l'affichage manquait
- Le champ s'affiche vide si l'emplacement n'est pas renseigné pour l'article

Closes #361

## Test plan
- [x] Ouvrir un devis avec au moins un produit ayant un emplacement renseigné dans le catalogue
- [x] Vérifier que l'emplacement s'affiche sur la ligne correspondante
- [x] Vérifier qu'une ligne produit sans emplacement renseigné affiche un champ vide
- [x] Vérifier que les lignes forfait/service/bateau/moteur/hélice/remorque n'affichent pas ce champ