### PR TITLE
feat: ajouter historique et statistiques sur les produits

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/ProduitMouvementEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/ProduitMouvementEntity.java
@@ -1,0 +1,50 @@
+package net.nanthrax.moussaillon.persistence;
+
+import java.sql.Timestamp;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTransient;
+import jakarta.json.bind.annotation.JsonbTypeAdapter;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class ProduitMouvementEntity extends PanacheEntity {
+
+    public enum Type {
+        VENTE,
+        AJUSTEMENT_MANUEL
+    }
+
+    @ManyToOne
+    @JsonbTransient
+    public ProduitCatalogueEntity produit;
+
+    @JsonbProperty("produitId")
+    public Long getProduitId() {
+        return produit != null ? produit.id : null;
+    }
+
+    @Enumerated(EnumType.STRING)
+    public Type type;
+
+    public int quantite;
+
+    public int stockApres;
+
+    @ManyToOne
+    @JsonbTransient
+    public VenteEntity vente;
+
+    @JsonbProperty("venteId")
+    public Long getVenteId() {
+        return vente != null ? vente.id : null;
+    }
+
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp date;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ProduitCatalogueResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ProduitCatalogueResource.java
@@ -7,7 +7,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import net.nanthrax.moussaillon.persistence.FournisseurProduitEntity;
 import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.ProduitMouvementEntity;
 
+import java.sql.Timestamp;
 import java.util.List;
 
 @Path("/catalogue/produits")
@@ -64,6 +66,58 @@ public class ProduitCatalogueResource {
         return entity;
     }
 
+    @GET
+    @Path("{id}/mouvements")
+    public List<ProduitMouvementEntity> mouvements(@PathParam("id") long id) {
+        ProduitCatalogueEntity entity = ProduitCatalogueEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("Le produit (" + id + ") n'est pas trouvé", 404);
+        }
+        return ProduitMouvementEntity.list("produit.id = ?1 ORDER BY date DESC", id);
+    }
+
+    public static class StatistiquesProduit {
+        public int quantiteVendue30j;
+        public int quantiteVendue90j;
+        public int quantiteVendueTotal;
+        public double chiffreAffaires30j;
+        public double chiffreAffaires90j;
+        public double chiffreAffairesTotal;
+    }
+
+    @GET
+    @Path("{id}/statistiques")
+    public StatistiquesProduit statistiques(@PathParam("id") long id) {
+        ProduitCatalogueEntity entity = ProduitCatalogueEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException("Le produit (" + id + ") n'est pas trouvé", 404);
+        }
+
+        List<ProduitMouvementEntity> ventes = ProduitMouvementEntity.list(
+            "produit.id = ?1 AND type = ?2", id, ProduitMouvementEntity.Type.VENTE);
+
+        long maintenant = System.currentTimeMillis();
+        long jour = 24L * 60 * 60 * 1000;
+
+        StatistiquesProduit stats = new StatistiquesProduit();
+        for (ProduitMouvementEntity mouvement : ventes) {
+            long age = mouvement.date != null ? maintenant - mouvement.date.getTime() : Long.MAX_VALUE;
+            double montant = mouvement.quantite * entity.prixVenteTTC;
+
+            stats.quantiteVendueTotal += mouvement.quantite;
+            stats.chiffreAffairesTotal += montant;
+            if (age <= 90 * jour) {
+                stats.quantiteVendue90j += mouvement.quantite;
+                stats.chiffreAffaires90j += montant;
+            }
+            if (age <= 30 * jour) {
+                stats.quantiteVendue30j += mouvement.quantite;
+                stats.chiffreAffaires30j += montant;
+            }
+        }
+        return stats;
+    }
+
     @DELETE
     @Path("{id}")
     @Transactional
@@ -96,6 +150,15 @@ public class ProduitCatalogueResource {
         entity.anneeDebut = produit.anneeDebut;
         entity.anneeFin = produit.anneeFin;
         entity.evaluation = produit.evaluation;
+        if (produit.stock != entity.stock) {
+            ProduitMouvementEntity mouvement = new ProduitMouvementEntity();
+            mouvement.produit = entity;
+            mouvement.type = ProduitMouvementEntity.Type.AJUSTEMENT_MANUEL;
+            mouvement.quantite = produit.stock - entity.stock;
+            mouvement.stockApres = produit.stock;
+            mouvement.date = new Timestamp(System.currentTimeMillis());
+            mouvement.persist();
+        }
         entity.stock = produit.stock;
         entity.stockMini = produit.stockMini;
         entity.emplacement = produit.emplacement;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -2,7 +2,9 @@ package net.nanthrax.moussaillon.services;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.Mailer;
@@ -29,6 +31,7 @@ import net.nanthrax.moussaillon.persistence.ForfaitProduitEntity;
 import net.nanthrax.moussaillon.persistence.HeliceCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.MoteurCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.ProduitMouvementEntity;
 import net.nanthrax.moussaillon.persistence.RemorqueCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.ServiceEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
@@ -899,13 +902,37 @@ public class VenteResource {
     }
 
     private void decrementStock(VenteEntity vente) {
+        Map<Long, Integer> produitQuantites = new HashMap<>();
         if (vente.venteProduits != null) {
             for (VenteProduitEntity vp : vente.venteProduits) {
                 if (vp.produit == null || vp.produit.id == null) continue;
-                ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(vp.produit.id);
-                if (p != null) {
-                    p.stock = Math.max(0, p.stock - Math.max(1, vp.quantite));
+                produitQuantites.merge(vp.produit.id, Math.max(1, vp.quantite), Integer::sum);
+            }
+        }
+        for (VenteForfaitEntity vf : vente.venteForfaits) {
+            if (vf.forfait != null) {
+                ForfaitEntity f = ForfaitEntity.findById(vf.forfait.id);
+                if (f != null && f.produits != null) {
+                    for (ForfaitProduitEntity fp : f.produits) {
+                        if (fp.produit != null) {
+                            produitQuantites.merge(fp.produit.id, fp.quantite * vf.quantite, Integer::sum);
+                        }
+                    }
                 }
+            }
+        }
+        for (Map.Entry<Long, Integer> entry : produitQuantites.entrySet()) {
+            ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(entry.getKey());
+            if (p != null) {
+                p.stock = Math.max(0, p.stock - entry.getValue());
+                ProduitMouvementEntity mouvement = new ProduitMouvementEntity();
+                mouvement.produit = p;
+                mouvement.type = ProduitMouvementEntity.Type.VENTE;
+                mouvement.quantite = entry.getValue();
+                mouvement.stockApres = p.stock;
+                mouvement.vente = vente;
+                mouvement.date = new Timestamp(System.currentTimeMillis());
+                mouvement.persist();
             }
         }
         if (vente.venteBateauxCatalogue != null) {
@@ -932,21 +959,6 @@ public class VenteResource {
                 RemorqueCatalogueEntity r = RemorqueCatalogueEntity.findById(vr.remorque.id);
                 if (r != null) {
                     r.stock = Math.max(0, r.stock - Math.max(1, vr.quantite));
-                }
-            }
-        }
-        for (VenteForfaitEntity vf : vente.venteForfaits) {
-            if (vf.forfait != null) {
-                ForfaitEntity f = ForfaitEntity.findById(vf.forfait.id);
-                if (f != null && f.produits != null) {
-                    for (ForfaitProduitEntity fp : f.produits) {
-                        if (fp.produit != null) {
-                            ProduitCatalogueEntity p = ProduitCatalogueEntity.findById(fp.produit.id);
-                            if (p != null) {
-                                p.stock = Math.max(0, p.stock - fp.quantite * vf.quantite);
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/ProduitCatalogueResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/ProduitCatalogueResourceTest.java
@@ -85,6 +85,72 @@ public class ProduitCatalogueResourceTest {
     }
 
     @Test
+    void testAjustementManuelStockCreeMouvement() {
+        int id = given()
+            .contentType("application/json")
+            .body("{\"nom\":\"ProduitAjustement\",\"marque\":\"Test\",\"categorie\":\"Test\",\"stock\":10}")
+            .when().post("/catalogue/produits")
+            .then().statusCode(200).extract().path("id");
+
+        given()
+            .contentType("application/json")
+            .body("{\"nom\":\"ProduitAjustement\",\"marque\":\"Test\",\"categorie\":\"Test\",\"stock\":7}")
+            .when().put("/catalogue/produits/" + id)
+            .then().statusCode(200);
+
+        given()
+            .when().get("/catalogue/produits/" + id + "/mouvements")
+            .then()
+            .statusCode(200)
+            .body("size()", is(1))
+            .body("[0].type", is("AJUSTEMENT_MANUEL"))
+            .body("[0].quantite", is(-3))
+            .body("[0].stockApres", is(7));
+    }
+
+    @Test
+    void testStatistiquesApresVente() {
+        int id = given()
+            .contentType("application/json")
+            .body("{\"nom\":\"ProduitStats\",\"marque\":\"Test\",\"categorie\":\"Test\",\"stock\":10,\"prixVenteTTC\":20.0}")
+            .when().post("/catalogue/produits")
+            .then().statusCode(200).extract().path("id");
+
+        int venteId = given()
+            .contentType("application/json")
+            .body("{\"status\":\"DEVIS\",\"comptoir\":true,\"prixVenteTTC\":20.0,\"produits\":[{\"id\":" + id + "}],"
+                + "\"venteForfaits\":[{\"forfait\":{\"id\":100},\"quantite\":1,\"status\":\"PLANIFIEE\"}]}")
+            .when().post("/ventes")
+            .then().statusCode(201).extract().path("id");
+
+        given()
+            .contentType("application/json")
+            .body("{\"status\":\"DEVIS\",\"bonPourAccord\":true,\"comptoir\":true,\"prixVenteTTC\":20.0,\"produits\":[{\"id\":" + id + "}],"
+                + "\"venteForfaits\":[{\"forfait\":{\"id\":100},\"quantite\":1,\"status\":\"EN_COURS\"}]}")
+            .when().put("/ventes/" + venteId)
+            .then().statusCode(200);
+
+        given()
+            .when().get("/catalogue/produits/" + id)
+            .then()
+            .statusCode(200)
+            .body("stock", is(9));
+
+        given()
+            .when().get("/catalogue/produits/" + id + "/mouvements")
+            .then()
+            .statusCode(200)
+            .body("size()", is(1));
+
+        given()
+            .when().get("/catalogue/produits/" + id + "/statistiques")
+            .then()
+            .statusCode(200)
+            .body("quantiteVendueTotal", is(1))
+            .body("chiffreAffairesTotal", is(20.0f));
+    }
+
+    @Test
     void testSupprimerProduit() {
         int id = given()
             .contentType("application/json")

--- a/chantier-ui/src/catalogue-produits.tsx
+++ b/chantier-ui/src/catalogue-produits.tsx
@@ -4,6 +4,7 @@ import { PlusCircleOutlined, EditOutlined, DeleteOutlined } from '@ant-design/ic
 import api from './api.ts';
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
 import FournisseurProduits from './fournisseur-produits.tsx';
+import ProduitHistorique from './produit-historique.tsx';
 import ImageUpload from './ImageUpload.tsx';
 import DocumentUpload from './DocumentUpload.tsx';
 
@@ -464,7 +465,10 @@ const CatalogueProduits: React.FC = () => {
                                 </Row>
                             </Form>
                             {isEdit && currentProduit && currentProduit.id && (
-                            <FournisseurProduits produitId={currentProduit?.id} />  
+                            <>
+                                <FournisseurProduits produitId={currentProduit?.id} />
+                                <ProduitHistorique produitId={currentProduit?.id} />
+                            </>
                             )}
                         </Modal>
                     </Col>

--- a/chantier-ui/src/produit-historique.tsx
+++ b/chantier-ui/src/produit-historique.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Col, Row, Spin, Statistic, Table, Tag, message } from 'antd';
+import api from './api.ts';
+
+type Mouvement = {
+    id: number;
+    type: 'VENTE' | 'AJUSTEMENT_MANUEL';
+    quantite: number;
+    stockApres: number;
+    venteId?: number;
+    date?: string;
+};
+
+type Statistiques = {
+    quantiteVendue30j: number;
+    quantiteVendue90j: number;
+    quantiteVendueTotal: number;
+    chiffreAffaires30j: number;
+    chiffreAffaires90j: number;
+    chiffreAffairesTotal: number;
+};
+
+const typeLabel: Record<Mouvement['type'], string> = {
+    VENTE: 'Vente',
+    AJUSTEMENT_MANUEL: 'Ajustement manuel',
+};
+
+const ProduitHistorique = ({ produitId }: { produitId?: number }) => {
+    const [mouvements, setMouvements] = useState<Mouvement[]>([]);
+    const [statistiques, setStatistiques] = useState<Statistiques | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (!produitId) return;
+        setLoading(true);
+        Promise.all([
+            api.get(`/catalogue/produits/${produitId}/mouvements`),
+            api.get(`/catalogue/produits/${produitId}/statistiques`),
+        ])
+            .then(([mouvementsRes, statistiquesRes]) => {
+                setMouvements(mouvementsRes.data);
+                setStatistiques(statistiquesRes.data);
+            })
+            .catch(() => message.error("Erreur lors du chargement de l'historique du produit"))
+            .finally(() => setLoading(false));
+    }, [produitId]);
+
+    const columns = [
+        {
+            title: 'Date',
+            dataIndex: 'date',
+            render: (value?: string) => (value ? new Date(value).toLocaleString('fr-FR') : '-'),
+            sorter: (a: Mouvement, b: Mouvement) => (a.date || '').localeCompare(b.date || ''),
+            defaultSortOrder: 'descend' as const,
+        },
+        {
+            title: 'Type',
+            dataIndex: 'type',
+            render: (value: Mouvement['type']) => (
+                <Tag color={value === 'VENTE' ? 'blue' : 'orange'}>{typeLabel[value] || value}</Tag>
+            ),
+        },
+        {
+            title: 'Quantité',
+            dataIndex: 'quantite',
+            render: (value: number) => (value > 0 ? `+${value}` : value),
+        },
+        {
+            title: 'Stock après',
+            dataIndex: 'stockApres',
+        },
+        {
+            title: 'Vente liée',
+            dataIndex: 'venteId',
+            render: (value?: number) => (value ? `#${value}` : '-'),
+        },
+    ];
+
+    return (
+        <Card title="Historique et statistiques" style={{ marginTop: 24 }}>
+            <Spin spinning={loading}>
+                <Row gutter={16} style={{ marginBottom: 16 }}>
+                    <Col span={8}>
+                        <Statistic
+                            title="Vendu sur 30 jours"
+                            value={statistiques?.quantiteVendue30j ?? 0}
+                            suffix={`/ ${(statistiques?.chiffreAffaires30j ?? 0).toFixed(2)} €`}
+                        />
+                    </Col>
+                    <Col span={8}>
+                        <Statistic
+                            title="Vendu sur 90 jours"
+                            value={statistiques?.quantiteVendue90j ?? 0}
+                            suffix={`/ ${(statistiques?.chiffreAffaires90j ?? 0).toFixed(2)} €`}
+                        />
+                    </Col>
+                    <Col span={8}>
+                        <Statistic
+                            title="Vendu au total"
+                            value={statistiques?.quantiteVendueTotal ?? 0}
+                            suffix={`/ ${(statistiques?.chiffreAffairesTotal ?? 0).toFixed(2)} €`}
+                        />
+                    </Col>
+                </Row>
+                <Table
+                    rowKey="id"
+                    columns={columns}
+                    dataSource={mouvements}
+                    bordered
+                    pagination={{ pageSize: 10 }}
+                />
+            </Spin>
+        </Card>
+    );
+};
+
+export default ProduitHistorique;


### PR DESCRIPTION
## Résumé

Closes #164

- Nouvelle entité `ProduitMouvementEntity` traçant chaque mouvement de stock (vente ou ajustement manuel) avec quantité, stock après mouvement et vente liée le cas échéant
- `VenteResource.decrementStock()` enregistre désormais un mouvement `VENTE` agrégé par produit (vente directe + produits issus des forfaits) au lieu de se contenter de décrémenter le stock
- `ProduitCatalogueResource.update()` enregistre un mouvement `AJUSTEMENT_MANUEL` quand le stock est modifié à la main
- Deux nouveaux endpoints :
  - `GET /catalogue/produits/{id}/mouvements` : historique trié par date
  - `GET /catalogue/produits/{id}/statistiques` : quantité vendue et chiffre d'affaires sur 30j / 90j / total
- Frontend (`catalogue-produits.tsx`) : nouveau composant `produit-historique.tsx` affiché dans le formulaire produit (à côté des fournisseurs), avec les statistiques clés et le tableau d'historique

## Plan de test

- [x] Modifier manuellement le stock d'un produit → un mouvement `AJUSTEMENT_MANUEL` apparaît dans l'historique
- [x] Passer une vente comptoir (ou avec forfait) en EN_COURS/FACTURE_PRETE → un mouvement `VENTE` apparaît et les statistiques se mettent à jour
- [x] Vérifier l'affichage des statistiques (30j/90j/total) et de l'historique dans le formulaire produit du catalogue
- [x] Tests backend (`ProduitCatalogueResourceTest`, `VenteResourceTest`) verts