### PR TITLE
Corriger l'affichage du logo sur les écrans de login client et technicien

### DIFF
--- a/client-ui/src/login.tsx
+++ b/client-ui/src/login.tsx
@@ -70,7 +70,7 @@ export default function Login({ setUser }: LoginProps) {
                     animation: 'fadeInUp 0.5s ease-out',
                 }}>
                     <div style={{ textAlign: 'center', marginBottom: 32 }}>
-                        <Image src="./logo.png" preview={false} width={80} style={{ marginBottom: 16 }} />
+                        <Image src="/logo.png" preview={false} width={80} style={{ marginBottom: 16 }} />
                         <Title level={3} style={{ margin: 0, fontWeight: 700 }}>
                             Espace Client
                         </Title>

--- a/client-ui/src/login.tsx
+++ b/client-ui/src/login.tsx
@@ -45,7 +45,7 @@ export default function Login({ setUser }: LoginProps) {
             left: 0,
             width: '100vw',
             height: '100vh',
-            backgroundImage: 'url(./login-background.jpg)',
+            backgroundImage: `url(${process.env.PUBLIC_URL}/login-background.jpg)`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
             backgroundRepeat: 'no-repeat',
@@ -70,7 +70,7 @@ export default function Login({ setUser }: LoginProps) {
                     animation: 'fadeInUp 0.5s ease-out',
                 }}>
                     <div style={{ textAlign: 'center', marginBottom: 32 }}>
-                        <Image src="/logo.png" preview={false} width={80} style={{ marginBottom: 16 }} />
+                        <Image src={process.env.PUBLIC_URL + '/logo.png'} preview={false} width={80} style={{ marginBottom: 16 }} />
                         <Title level={3} style={{ margin: 0, fontWeight: 700 }}>
                             Espace Client
                         </Title>

--- a/technicien-ui/src/login.tsx
+++ b/technicien-ui/src/login.tsx
@@ -47,7 +47,7 @@ export default function Login({ setUser }: LoginProps) {
             left: 0,
             width: '100vw',
             height: '100vh',
-            backgroundImage: 'url(./login-background.jpg)',
+            backgroundImage: `url(${process.env.PUBLIC_URL}/login-background.jpg)`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
             backgroundRepeat: 'no-repeat',
@@ -72,7 +72,7 @@ export default function Login({ setUser }: LoginProps) {
                     animation: 'fadeInUp 0.5s ease-out',
                 }}>
                     <div style={{ textAlign: 'center', marginBottom: 32 }}>
-                        <Image src="/logo.png" preview={false} width={80} style={{ marginBottom: 16 }} />
+                        <Image src={process.env.PUBLIC_URL + '/logo.png'} preview={false} width={80} style={{ marginBottom: 16 }} />
                         <Title level={3} style={{ margin: 0, fontWeight: 700 }}>
                             Espace Technicien
                         </Title>

--- a/technicien-ui/src/login.tsx
+++ b/technicien-ui/src/login.tsx
@@ -72,7 +72,7 @@ export default function Login({ setUser }: LoginProps) {
                     animation: 'fadeInUp 0.5s ease-out',
                 }}>
                     <div style={{ textAlign: 'center', marginBottom: 32 }}>
-                        <Image src="./logo.png" preview={false} width={80} style={{ marginBottom: 16 }} />
+                        <Image src="/logo.png" preview={false} width={80} style={{ marginBottom: 16 }} />
                         <Title level={3} style={{ margin: 0, fontWeight: 700 }}>
                             Espace Technicien
                         </Title>


### PR DESCRIPTION
## Résumé

- Le logo et le background n'apparaissaient pas sur les écrans de login des espaces client et technicien
- Cause : `client-ui` a `homepage: /client` et `technicien-ui` a `homepage: /technicien` dans leur `package.json` (CRA). Les assets du dossier `public/` sont donc servis sous ce sous-chemin (`/client/logo.png`, `/technicien/logo.png`), et non à la racine
- Les chemins codés en dur (`./logo.png`, `/logo.png`, `./login-background.jpg`) ne résolvent pas correctement dans ce contexte
- Fix : utilisation de `process.env.PUBLIC_URL` (renseigné automatiquement par CRA à partir du champ `homepage`) pour construire les chemins d'assets — même pattern que dans `chantier-ui`

Fixes #372