### PR TITLE
feat(dashboard): page d'accueil dashboard et widget bateaux dans le chantier

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/DashboardResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/DashboardResource.java
@@ -113,6 +113,31 @@ public class DashboardResource {
             }
         }
 
+        // Bateaux dans le chantier
+        LocalDate startOfWeek = now.with(java.time.DayOfWeek.MONDAY);
+        Timestamp weekStart = Timestamp.valueOf(startOfWeek.atStartOfDay());
+        List<VenteEntity> ventesActives = VenteEntity.list("status in (?1, ?2, ?3)",
+                VenteEntity.Status.DEVIS, VenteEntity.Status.FACTURE_EN_ATTENTE, VenteEntity.Status.FACTURE_PRETE);
+        java.util.Set<Long> bateauxIds = new java.util.HashSet<>();
+        java.util.Set<Long> bateauxSemaine = new java.util.HashSet<>();
+        java.util.Set<Long> bateauxEnAttente = new java.util.HashSet<>();
+        for (VenteEntity v : ventesActives) {
+            if (v.bateau != null) {
+                bateauxIds.add(v.bateau.id);
+                if (v.date != null && !v.date.before(weekStart)) {
+                    bateauxSemaine.add(v.bateau.id);
+                }
+                boolean hasEnAttente = v.venteForfaits.stream().anyMatch(vf -> vf.status == VenteForfaitEntity.Status.EN_ATTENTE)
+                        || v.venteServices.stream().anyMatch(vs -> vs.status == VenteServiceEntity.Status.EN_ATTENTE);
+                if (hasEnAttente) {
+                    bateauxEnAttente.add(v.bateau.id);
+                }
+            }
+        }
+        data.bateauxDansLeChantier = bateauxIds.size();
+        data.bateauxEntreesSemaine = bateauxSemaine.size();
+        data.bateauxEnAttenteIntervention = bateauxEnAttente.size();
+
         // Stock a surveiller
         data.stockAlerts = new ArrayList<>();
         for (ProduitCatalogueEntity produit : produitsEnAlerte) {
@@ -166,6 +191,9 @@ public class DashboardResource {
         public int heuresAtelierPct;
         public int ventesComptoirPct;
         public int contratsMaintenancePct;
+        public int bateauxDansLeChantier;
+        public int bateauxEntreesSemaine;
+        public int bateauxEnAttenteIntervention;
     }
 
     public static class InterventionRow {

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/DashboardResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/DashboardResourceTest.java
@@ -23,6 +23,9 @@ public class DashboardResourceTest {
             .body("stockAlerts", notNullValue())
             .body("heuresAtelierPct", notNullValue())
             .body("ventesComptoirPct", notNullValue())
-            .body("contratsMaintenancePct", notNullValue());
+            .body("contratsMaintenancePct", notNullValue())
+            .body("bateauxDansLeChantier", notNullValue())
+            .body("bateauxEntreesSemaine", notNullValue())
+            .body("bateauxEnAttenteIntervention", notNullValue());
     }
 }

--- a/chantier-ui/package.json
+++ b/chantier-ui/package.json
@@ -26,8 +26,8 @@
     "typescript": "^6.0.3"
   },
   "scripts": {
-    "start": "NODE_OPTIONS='--localstorage-file=/tmp/moussaillon-localstorage' react-scripts start",
-    "build": "BUILD_PATH=target/classes/META-INF/resources react-scripts build",
+    "start": "NODE_OPTIONS='--localstorage-file=/tmp/moussaillon-localstorage' REACT_APP_VERSION=$npm_package_version REACT_APP_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) react-scripts start",
+    "build": "BUILD_PATH=target/classes/META-INF/resources REACT_APP_VERSION=$npm_package_version REACT_APP_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/chantier-ui/src/dashboard.tsx
+++ b/chantier-ui/src/dashboard.tsx
@@ -6,6 +6,7 @@ import { Column, Pie } from '@ant-design/charts';
 import dayjs from 'dayjs';
 import { useNavigation } from './navigation-context.tsx';
 import Home from './home.tsx';
+import { VERSION_LABEL } from './version.ts';
 
 const { Title, Paragraph, Text } = Typography;
 
@@ -335,13 +336,16 @@ export default function Dashboard({ user }: { user?: string }) {
                         </Paragraph>
                     </Col>
                     <Col>
-                        <Space>
-                            {lastUpdated && (
-                                <Text type="secondary" style={{ fontSize: 12 }}>Mis à jour à {lastUpdated}</Text>
-                            )}
-                            <Button icon={<ReloadOutlined />} loading={loading} onClick={loadData}>
-                                Actualiser
-                            </Button>
+                        <Space direction="vertical" align="end" size={4}>
+                            <Space>
+                                {lastUpdated && (
+                                    <Text type="secondary" style={{ fontSize: 12 }}>Mis à jour à {lastUpdated}</Text>
+                                )}
+                                <Button icon={<ReloadOutlined />} loading={loading} onClick={loadData}>
+                                    Actualiser
+                                </Button>
+                            </Space>
+                            <Text type="secondary" style={{ fontSize: 11 }}>{VERSION_LABEL}</Text>
                         </Space>
                     </Col>
                 </Row>

--- a/chantier-ui/src/dashboard.tsx
+++ b/chantier-ui/src/dashboard.tsx
@@ -1,9 +1,11 @@
 import { fetchWithAuth } from './api.ts';
-import React, { useEffect, useState } from 'react';
-import { ArrowDownOutlined, ArrowUpOutlined, ClockCircleOutlined, WarningOutlined, AimOutlined } from '@ant-design/icons';
-import { Badge, Button, Card, Col, Empty, List, Progress, Row, Space, Spin, Statistic, Table, Tag, Typography } from 'antd';
+import React, { useCallback, useEffect, useState } from 'react';
+import { ArrowDownOutlined, ArrowUpOutlined, ClockCircleOutlined, WarningOutlined, AimOutlined, PlusOutlined, CalendarOutlined, ReloadOutlined, RobotOutlined, DownOutlined, UpOutlined } from '@ant-design/icons';
+import { Alert, Badge, Button, Card, Col, Empty, List, Progress, Row, Space, Spin, Statistic, Table, Tag, Typography } from 'antd';
 import { Column, Pie } from '@ant-design/charts';
 import dayjs from 'dayjs';
+import { useNavigation } from './navigation-context.tsx';
+import Home from './home.tsx';
 
 const { Title, Paragraph, Text } = Typography;
 
@@ -175,7 +177,7 @@ const interventionColumns = [
         sorter: (a: InterventionRow, b: InterventionRow) => (a.client || '').localeCompare(b.client || ''),
     },
     {
-        title: 'Unite',
+        title: 'Unité',
         dataIndex: 'unite',
         key: 'unite',
         sorter: (a: InterventionRow, b: InterventionRow) => (a.unite || '').localeCompare(b.unite || ''),
@@ -204,15 +206,22 @@ const interventionColumns = [
     }
 ];
 
-export default function Dashboard() {
+export default function Dashboard({ user }: { user?: string }) {
     const [data, setData] = useState<DashboardData | null>(null);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [lastUpdated, setLastUpdated] = useState<string | null>(null);
     const [warnings, setWarnings] = useState<PlanningWarning[]>([]);
     const [canalData, setCanalData] = useState<{ canal: string; count: number }[]>([]);
     const [ventesParJour, setVentesParJour] = useState<{ date: string; ventes: number }[]>([]);
     const [caParJour, setCaParJour] = useState<{ date: string; ca: number }[]>([]);
+    const [assistantOpen, setAssistantOpen] = useState(false);
+    const { navigate } = useNavigation();
 
-    useEffect(() => {
+    const loadData = useCallback(() => {
+        setLoading(true);
+        setError(null);
+
         const ventesPromise = fetchWithAuth('/ventes')
             .then(res => res.json())
             .then((ventes: Array<Record<string, unknown>>) => {
@@ -275,28 +284,126 @@ export default function Dashboard() {
         ])
             .then(([d, caDuMois]: [DashboardData, number]) => {
                 setData({ ...d, caDuMois });
+                setLastUpdated(dayjs().format('DD/MM/YYYY HH:mm'));
             })
+            .catch(() => setError("Impossible de charger les données du tableau de bord."))
             .finally(() => setLoading(false));
     }, []);
 
-    if (loading || !data) {
+    useEffect(() => {
+        loadData();
+    }, [loadData]);
+
+    if (loading && !data) {
         return <Spin size="large" style={{ display: 'flex', justifyContent: 'center', marginTop: 100 }} />;
     }
 
+    if (error && !data) {
+        return (
+            <Alert
+                type="error"
+                showIcon
+                message="Erreur de chargement"
+                description={error}
+                action={<Button size="small" danger icon={<ReloadOutlined />} onClick={loadData}>Réessayer</Button>}
+            />
+        );
+    }
+
+    if (!data) {
+        return null;
+    }
+
+    const dateLabel = (() => {
+        const formatted = new Intl.DateTimeFormat('fr-FR', {
+            weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
+        }).format(new Date());
+        return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+    })();
+
     return (
         <Space direction="vertical" size={16} style={{ width: '100%' }}>
+            {error && (
+                <Alert type="error" showIcon closable message={error} onClose={() => setError(null)} />
+            )}
             <Card>
-                <Space direction="vertical" size={0}>
-                    <Title level={3} style={{ margin: 0 }}>Tableau de bord</Title>
-                    <Paragraph style={{ marginBottom: 0, color: '#8c8c8c' }}>
-                        Vue synthese de l'activite atelier et comptoir.
-                    </Paragraph>
-                </Space>
+                <Row align="middle" justify="space-between" gutter={[16, 8]}>
+                    <Col>
+                        <Title level={3} style={{ margin: 0 }}>Bonjour{user ? ` ${user}` : ''} 👋</Title>
+                        <Paragraph style={{ marginBottom: 0, color: '#8c8c8c' }}>
+                            {dateLabel} · Vue synthèse de l'activité atelier et comptoir.
+                        </Paragraph>
+                    </Col>
+                    <Col>
+                        <Space>
+                            {lastUpdated && (
+                                <Text type="secondary" style={{ fontSize: 12 }}>Mis à jour à {lastUpdated}</Text>
+                            )}
+                            <Button icon={<ReloadOutlined />} loading={loading} onClick={loadData}>
+                                Actualiser
+                            </Button>
+                        </Space>
+                    </Col>
+                </Row>
+            </Card>
+
+            {assistantOpen ? (
+                <div>
+                    <div style={{ textAlign: 'right', marginBottom: 8 }}>
+                        <Button type="text" size="small" icon={<UpOutlined />} onClick={() => setAssistantOpen(false)}>
+                            Masquer l'assistant
+                        </Button>
+                    </div>
+                    <Home />
+                </div>
+            ) : (
+                <Card
+                    hoverable
+                    onClick={() => setAssistantOpen(true)}
+                    style={{ cursor: 'pointer' }}
+                    styles={{ body: { padding: '12px 16px' } }}
+                >
+                    <Row align="middle" justify="space-between">
+                        <Space>
+                            <div style={{
+                                width: 36, height: 36, borderRadius: 10,
+                                background: 'linear-gradient(135deg, #722ed1, #9254de)',
+                                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            }}>
+                                <RobotOutlined style={{ color: '#fff', fontSize: 18 }} />
+                            </div>
+                            <div>
+                                <div style={{ fontWeight: 600, fontSize: 15 }}>Assistant IA</div>
+                                <div style={{ color: '#8c8c8c', fontSize: 12 }}>
+                                    Cliquez pour poser une question ou taper une commande
+                                </div>
+                            </div>
+                        </Space>
+                        <DownOutlined style={{ color: '#8c8c8c' }} />
+                    </Row>
+                </Card>
+            )}
+
+            <Card title="Actions rapides">
+                <Row gutter={[12, 12]}>
+                    <Col xs={24} sm={12} lg={6}>
+                        <Button type="primary" icon={<PlusOutlined />} block size="large" onClick={() => navigate('/prestations')}>Créer une intervention</Button>
+                    </Col>
+                    <Col xs={24} sm={12} lg={6}>
+                        <Button icon={<CalendarOutlined />} block size="large" onClick={() => navigate('/planning')}>Planifier un rendez-vous atelier</Button>
+                    </Col>
+                    <Col xs={24} sm={12} lg={6}>
+                        <Button icon={<ClockCircleOutlined />} block size="large" onClick={() => navigate('/planning')}>Vérifier les retards en cours</Button>
+                    </Col>
+                    <Col xs={24} sm={12} lg={6}>
+                        <Button icon={<WarningOutlined />} block size="large" onClick={() => navigate('/catalogue/produits')}>Consulter le stock critique</Button>
+                    </Col>
+                </Row>
             </Card>
 
             <Row gutter={[16, 16]}>
                 <Col xs={24} sm={12} lg={6}>
-                    <Card style={{ borderTop: '3px solid #52c41a' }}>
+                    <Card hoverable onClick={() => navigate('/prestations')} style={{ borderTop: '3px solid #52c41a', cursor: 'pointer' }}>
                         <Statistic
                             title="CA du mois"
                             value={data.caDuMois}
@@ -308,7 +415,7 @@ export default function Dashboard() {
                     </Card>
                 </Col>
                 <Col xs={24} sm={12} lg={6}>
-                    <Card style={{ borderTop: '3px solid #1677ff' }}>
+                    <Card hoverable onClick={() => navigate('/prestations')} style={{ borderTop: '3px solid #1677ff', cursor: 'pointer' }}>
                         <Statistic
                             title="Interventions ouvertes"
                             value={data.interventionsOuvertes}
@@ -318,7 +425,7 @@ export default function Dashboard() {
                     </Card>
                 </Col>
                 <Col xs={24} sm={12} lg={6}>
-                    <Card style={{ borderTop: '3px solid #ff4d4f' }}>
+                    <Card hoverable onClick={() => navigate('/planning')} style={{ borderTop: '3px solid #ff4d4f', cursor: 'pointer' }}>
                         <Statistic
                             title="Retards > 48h"
                             value={data.retards48h}
@@ -328,7 +435,7 @@ export default function Dashboard() {
                     </Card>
                 </Col>
                 <Col xs={24} sm={12} lg={6}>
-                    <Card style={{ borderTop: '3px solid #faad14' }}>
+                    <Card hoverable onClick={() => navigate('/catalogue/produits')} style={{ borderTop: '3px solid #faad14', cursor: 'pointer' }}>
                         <Statistic
                             title="Alertes stock"
                             value={data.alertesStock}
@@ -341,7 +448,7 @@ export default function Dashboard() {
 
             <Row gutter={[16, 16]}>
                 <Col xs={24} sm={8}>
-                    <Card style={{ borderTop: '3px solid #722ed1' }}>
+                    <Card hoverable onClick={() => navigate('/clients/bateaux')} style={{ borderTop: '3px solid #722ed1', cursor: 'pointer' }}>
                         <Statistic
                             title="Bateaux dans le chantier"
                             value={data.bateauxDansLeChantier}
@@ -351,7 +458,7 @@ export default function Dashboard() {
                     </Card>
                 </Col>
                 <Col xs={24} sm={8}>
-                    <Card style={{ borderTop: '3px solid #13c2c2' }}>
+                    <Card hoverable onClick={() => navigate('/clients/bateaux')} style={{ borderTop: '3px solid #13c2c2', cursor: 'pointer' }}>
                         <Statistic
                             title="Entrées cette semaine"
                             value={data.bateauxEntreesSemaine}
@@ -360,7 +467,7 @@ export default function Dashboard() {
                     </Card>
                 </Col>
                 <Col xs={24} sm={8}>
-                    <Card style={{ borderTop: '3px solid #fa8c16' }}>
+                    <Card hoverable onClick={() => navigate('/prestations')} style={{ borderTop: '3px solid #fa8c16', cursor: 'pointer' }}>
                         <Statistic
                             title="En attente d'intervention"
                             value={data.bateauxEnAttenteIntervention}
@@ -389,9 +496,9 @@ export default function Dashboard() {
                 </Card>
             )}
 
-            <Row gutter={[16, 16]}>
+            <Row gutter={[16, 16]} align="stretch">
                 <Col xs={24} xl={16}>
-                    <Card title="Interventions du jour">
+                    <Card title="Interventions du jour" style={{ height: '100%' }}>
                         <Table
                             columns={interventionColumns}
                             dataSource={data.interventions}
@@ -401,7 +508,7 @@ export default function Dashboard() {
                     </Card>
                 </Col>
                 <Col xs={24} xl={8}>
-                    <Card title="Stock a surveiller">
+                    <Card title="Stock à surveiller" style={{ height: '100%' }}>
                         <List
                             dataSource={data.stockAlerts}
                             renderItem={(item) => (
@@ -448,9 +555,9 @@ export default function Dashboard() {
                 )}
             </Card>
 
-            <Row gutter={[16, 16]}>
+            <Row gutter={[16, 16]} align="stretch">
                 <Col xs={24} md={12}>
-                    <Card title="Canal d'acquisition clients">
+                    <Card title="Canal d'acquisition clients" style={{ height: '100%' }}>
                         {canalData.length > 0 ? (
                             <Pie
                                 data={canalData}
@@ -467,10 +574,10 @@ export default function Dashboard() {
                     </Card>
                 </Col>
                 <Col xs={24} md={12}>
-                    <Card title="Objectifs mensuels">
+                    <Card title="Objectifs mensuels" style={{ height: '100%' }}>
                         <Space direction="vertical" style={{ width: '100%' }} size={12}>
                             <div>
-                                <Text>Heures atelier facturees</Text>
+                                <Text>Heures atelier facturées</Text>
                                 <Progress percent={data.heuresAtelierPct} status="active" />
                             </div>
                             <div>
@@ -481,19 +588,6 @@ export default function Dashboard() {
                                 <Text>Contrats de maintenance</Text>
                                 <Progress percent={data.contratsMaintenancePct} />
                             </div>
-                        </Space>
-                    </Card>
-                </Col>
-            </Row>
-
-            <Row gutter={[16, 16]}>
-                <Col xs={24} md={12}>
-                    <Card title="Actions rapides">
-                        <Space direction="vertical" style={{ width: '100%' }} size={10}>
-                            <Button type="primary" block>Creer une intervention</Button>
-                            <Button block>Planifier un rendez-vous atelier</Button>
-                            <Button block>Verifier les retards en cours</Button>
-                            <Button block>Consulter le stock critique</Button>
                         </Space>
                     </Card>
                 </Col>

--- a/chantier-ui/src/dashboard.tsx
+++ b/chantier-ui/src/dashboard.tsx
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useEffect, useState } from 'react';
-import { ArrowDownOutlined, ArrowUpOutlined, ClockCircleOutlined, WarningOutlined } from '@ant-design/icons';
+import { ArrowDownOutlined, ArrowUpOutlined, ClockCircleOutlined, WarningOutlined, AimOutlined } from '@ant-design/icons';
 import { Badge, Button, Card, Col, Empty, List, Progress, Row, Space, Spin, Statistic, Table, Tag, Typography } from 'antd';
 import { Column, Pie } from '@ant-design/charts';
 import dayjs from 'dayjs';
@@ -32,6 +32,9 @@ type DashboardData = {
     heuresAtelierPct: number;
     ventesComptoirPct: number;
     contratsMaintenancePct: number;
+    bateauxDansLeChantier: number;
+    bateauxEntreesSemaine: number;
+    bateauxEnAttenteIntervention: number;
 };
 
 type PlanningWarning = {
@@ -331,6 +334,37 @@ export default function Dashboard() {
                             value={data.alertesStock}
                             valueStyle={{ color: '#d48806', fontWeight: 700 }}
                             prefix={<WarningOutlined />}
+                        />
+                    </Card>
+                </Col>
+            </Row>
+
+            <Row gutter={[16, 16]}>
+                <Col xs={24} sm={8}>
+                    <Card style={{ borderTop: '3px solid #722ed1' }}>
+                        <Statistic
+                            title="Bateaux dans le chantier"
+                            value={data.bateauxDansLeChantier}
+                            valueStyle={{ color: '#722ed1', fontWeight: 700 }}
+                            prefix={<AimOutlined />}
+                        />
+                    </Card>
+                </Col>
+                <Col xs={24} sm={8}>
+                    <Card style={{ borderTop: '3px solid #13c2c2' }}>
+                        <Statistic
+                            title="Entrées cette semaine"
+                            value={data.bateauxEntreesSemaine}
+                            valueStyle={{ color: '#08979c', fontWeight: 700 }}
+                        />
+                    </Card>
+                </Col>
+                <Col xs={24} sm={8}>
+                    <Card style={{ borderTop: '3px solid #fa8c16' }}>
+                        <Statistic
+                            title="En attente d'intervention"
+                            value={data.bateauxEnAttenteIntervention}
+                            valueStyle={{ color: '#d46b08', fontWeight: 700 }}
                         />
                     </Card>
                 </Col>

--- a/chantier-ui/src/home.tsx
+++ b/chantier-ui/src/home.tsx
@@ -1,17 +1,13 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Typography, Row, Col, Card, Input, Button, Space, Divider, Tag, Modal, theme } from 'antd';
+import { Typography, Row, Card, Input, Button, Space, Divider, Tag, Modal, theme } from 'antd';
 import {
-    SmileOutlined, RobotOutlined, SendOutlined, QuestionCircleOutlined,
-    AudioOutlined, AudioMutedOutlined, TeamOutlined, ToolOutlined,
-    ShoppingCartOutlined, CalendarOutlined, DashboardOutlined, ReadOutlined
+    RobotOutlined, SendOutlined, QuestionCircleOutlined,
+    AudioOutlined, AudioMutedOutlined
 } from '@ant-design/icons';
-import Icon from '@ant-design/icons';
-import { ReactComponent as BoatOutlined } from './boat.svg';
-import { ReactComponent as ParcOutlined } from './parc.svg';
 import { useNavigation } from './navigation-context.tsx';
 
-const { Title, Paragraph } = Typography;
+const { Paragraph } = Typography;
 const { TextArea } = Input;
 
 type ChatMessage = {
@@ -743,90 +739,8 @@ export default function Home() {
         }
     };
 
-    const quickAccessItems = [
-        { title: 'Clients', description: 'Gérer vos clients et contacts', icon: <TeamOutlined style={{ fontSize: 28 }} />, route: '/clients', color: '#1677ff' },
-        { title: 'Parc', description: 'Bateaux, moteurs et remorques', icon: <Icon component={ParcOutlined} style={{ fontSize: 28 }} />, route: '/clients/bateaux', color: '#52c41a' },
-        { title: 'Catalogue', description: 'Produits et fournisseurs', icon: <ReadOutlined style={{ fontSize: 28 }} />, route: '/catalogue/produits', color: '#fa8c16' },
-        { title: 'Ventes', description: 'Comptoir et prestations', icon: <ShoppingCartOutlined style={{ fontSize: 28 }} />, route: '/prestations', color: '#eb2f96' },
-        { title: 'Atelier', description: 'Planning et équipe technique', icon: <ToolOutlined style={{ fontSize: 28 }} />, route: '/planning', color: '#722ed1' },
-        { title: 'Tableau de bord', description: 'Statistiques et indicateurs', icon: <DashboardOutlined style={{ fontSize: 28 }} />, route: '/dashboard', color: '#13c2c2' },
-    ];
-
     return (
         <>
-            {/* Hero Section */}
-            <div
-                style={{
-                    position: 'relative',
-                    borderRadius: 16,
-                    overflow: 'hidden',
-                    marginBottom: 24,
-                    background: `linear-gradient(135deg, #0958d9 0%, #1677ff 40%, #4096ff 100%)`,
-                    padding: '40px 36px',
-                    boxShadow: '0 8px 24px rgba(22, 119, 255, 0.25)',
-                }}
-            >
-                <div style={{
-                    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, opacity: 0.08,
-                    backgroundImage: 'url(/logo.png)',
-                    backgroundRepeat: 'no-repeat',
-                    backgroundPosition: 'right -40px bottom -40px',
-                    backgroundSize: '320px',
-                    pointerEvents: 'none',
-                }} />
-                <Row align="middle" gutter={24}>
-                    <Col flex="auto">
-                        <Title level={2} style={{ color: '#fff', marginBottom: 4, fontWeight: 700, letterSpacing: -0.5 }}>
-                            Bienvenue sur moussAIllon
-                        </Title>
-                        <Paragraph style={{ color: 'rgba(255,255,255,0.85)', fontSize: 16, marginBottom: 0, maxWidth: 600 }}>
-                            Votre plateforme de gestion de chantier naval.
-                            Gérez vos clients, bateaux, moteurs, remorques et prestations en toute simplicité.
-                        </Paragraph>
-                    </Col>
-                    <Col>
-                        <Icon component={BoatOutlined} style={{ fontSize: 80, color: 'rgba(255,255,255,0.35)' }} />
-                    </Col>
-                </Row>
-            </div>
-
-            {/* Quick Access Cards */}
-            <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
-                {quickAccessItems.map((item) => (
-                    <Col xs={24} sm={12} md={8} key={item.title}>
-                        <Card
-                            hoverable
-                            onClick={() => navigate(item.route)}
-                            style={{
-                                borderRadius: 12,
-                                border: `1px solid ${token.colorBorderSecondary}`,
-                                cursor: 'pointer',
-                                height: '100%',
-                                transition: 'all 0.3s ease',
-                            }}
-                            styles={{ body: { padding: '20px 24px' } }}
-                        >
-                            <Row align="middle" gutter={16}>
-                                <Col>
-                                    <div style={{
-                                        width: 52, height: 52, borderRadius: 12,
-                                        background: item.color + '15',
-                                        display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                        color: item.color,
-                                    }}>
-                                        {item.icon}
-                                    </div>
-                                </Col>
-                                <Col flex="auto">
-                                    <div style={{ fontWeight: 600, fontSize: 15, color: token.colorText }}>{item.title}</div>
-                                    <div style={{ fontSize: 13, color: token.colorTextSecondary, marginTop: 2 }}>{item.description}</div>
-                                </Col>
-                            </Row>
-                        </Card>
-                    </Col>
-                ))}
-            </Row>
-
             {/* AI Assistant Chat */}
             <Card
                 style={{

--- a/chantier-ui/src/home.tsx
+++ b/chantier-ui/src/home.tsx
@@ -777,8 +777,8 @@ export default function Home() {
                 <div
                     ref={chatMessagesRef}
                     style={{
-                        height: 350,
-                        maxHeight: 350,
+                        height: 220,
+                        maxHeight: 220,
                         overflowY: 'auto',
                         borderRadius: 10,
                         padding: 16,

--- a/chantier-ui/src/version.ts
+++ b/chantier-ui/src/version.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+
+// Injectés au build via les scripts npm (REACT_APP_VERSION = $npm_package_version,
+// REACT_APP_BUILD_DATE = date du build). Valeurs de repli quand non défini (ex: react-scripts lancé directement).
+export const APP_VERSION: string = process.env.REACT_APP_VERSION || 'dev';
+
+const rawBuildDate = process.env.REACT_APP_BUILD_DATE || '';
+export const BUILD_DATE: string = rawBuildDate && dayjs(rawBuildDate).isValid()
+    ? dayjs(rawBuildDate).format('DD/MM/YYYY HH:mm')
+    : '';
+
+export const VERSION_LABEL: string = BUILD_DATE
+    ? `v${APP_VERSION} · build ${BUILD_DATE}`
+    : `v${APP_VERSION}`;

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -1,7 +1,7 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Layout, Input, Col, Row, Image, Menu, Form, Modal, message, ConfigProvider, theme as antdTheme, Switch as AntSwitch } from 'antd';
-import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, RobotOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined, RollbackOutlined } from '@ant-design/icons';
+import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined, RollbackOutlined } from '@ant-design/icons';
 import { NavigationContext } from './navigation-context.tsx';
 import Icon from '@ant-design/icons';
 import { ReactComponent as BoatOutlined } from './boat.svg';
@@ -10,7 +10,6 @@ import { ReactComponent as ParcOutlined } from './parc.svg';
 import { ReactComponent as TailerOutlined } from './remorque.svg';
 import { Result } from 'antd';
 import GlobalSearch from './global-search.tsx';
-import Home from './home.tsx';
 import Clients from './clients.tsx';
 import Produits from './catalogue-produits.tsx';
 import CatalogueBateaux from './catalogue-bateaux.tsx';
@@ -87,7 +86,6 @@ function SideMenu(props) {
     const roles = props.roles || '';
 
     const allMenuItems = [
-      { key: '/', label: 'Chatbot', icon: <RobotOutlined/> },
       { key: '/dashboard', label: 'Accueil', icon: <HomeOutlined/> },
       { key: 'Vente', label: 'Vente', icon: <DollarOutlined/>, requiredRole: 'vendeur', children: [
         { key: '/comptoir', label: 'Comptoir', icon: <ShopOutlined/> },
@@ -448,9 +446,10 @@ export default function Workspace(props) {
     const isDarkTheme = theme === 'DARK';
 
     const renderPage = () => {
+        const accueil = <Dashboard user={props.user} />;
         switch (currentPage) {
             case '/dashboard':
-                return <Dashboard />;
+                return accueil;
             case '/clients':
                 return <ProtectedRoute roles={props.roles} requiredRole="manager"><Clients /></ProtectedRoute>;
             case '/clients/bateaux':
@@ -502,7 +501,7 @@ export default function Workspace(props) {
             case '/reference-valeurs':
                 return <ProtectedRoute roles={props.roles} requiredRole="admin"><ReferenceValeurs /></ProtectedRoute>;
             default:
-                return <Home />;
+                return accueil;
         }
     };
 

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as ParcOutlined } from './parc.svg';
 import { ReactComponent as TailerOutlined } from './remorque.svg';
 import { Result } from 'antd';
 import GlobalSearch from './global-search.tsx';
+import { VERSION_LABEL } from './version.ts';
 import Clients from './clients.tsx';
 import Produits from './catalogue-produits.tsx';
 import CatalogueBateaux from './catalogue-bateaux.tsx';
@@ -534,6 +535,8 @@ export default function Workspace(props) {
                   padding: '16px 50px',
               }}>
                   Copyright © 2025-2026 - NOSE Experts - Tous droits réservés
+                  <span style={{ margin: '0 8px', opacity: 0.5 }}>·</span>
+                  {VERSION_LABEL}
               </Layout.Footer>
             </Layout>
             </NavigationContext.Provider>

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -417,7 +417,7 @@ function ProtectedRoute({ roles, requiredRole, children }) {
 
 export default function Workspace(props) {
     const [ theme, setTheme ] = useState<UserTheme>('LIGHT');
-    const [ currentPage, setCurrentPage ] = useState('/');
+    const [ currentPage, setCurrentPage ] = useState('/dashboard');
     const [ pageState, setPageState ] = useState<any>(null);
 
     const navigate = useCallback((page: string, state?: any) => {

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -1,7 +1,7 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Layout, Input, Col, Row, Image, Menu, Form, Modal, message, ConfigProvider, theme as antdTheme, Switch as AntSwitch } from 'antd';
-import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, DashboardOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined, RollbackOutlined } from '@ant-design/icons';
+import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, RobotOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined, RollbackOutlined } from '@ant-design/icons';
 import { NavigationContext } from './navigation-context.tsx';
 import Icon from '@ant-design/icons';
 import { ReactComponent as BoatOutlined } from './boat.svg';
@@ -87,8 +87,8 @@ function SideMenu(props) {
     const roles = props.roles || '';
 
     const allMenuItems = [
-      { key: '/', label: 'Accueil', icon: <HomeOutlined/> },
-      { key: '/dashboard', label: 'Tableau de Bord', icon: <DashboardOutlined/> },
+      { key: '/', label: 'Chatbot', icon: <RobotOutlined/> },
+      { key: '/dashboard', label: 'Accueil', icon: <HomeOutlined/> },
       { key: 'Vente', label: 'Vente', icon: <DollarOutlined/>, requiredRole: 'vendeur', children: [
         { key: '/comptoir', label: 'Comptoir', icon: <ShopOutlined/> },
         { key: '/prestations', label: 'Prestations', icon: <SolutionOutlined/> },


### PR DESCRIPTION
Closes #358

## Résumé

- Le dashboard devient la page d'accueil par défaut du chantier-ui (la route `/` reste accessible via le menu "Accueil")
- Nouveau widget **Bateaux dans le chantier** avec 3 indicateurs :
  - Nombre total de bateaux sur ventes actives (non payées)
  - Entrées cette semaine (ventes créées depuis le lundi courant)
  - En attente d'intervention (bateaux avec au moins une prestation EN_ATTENTE)
- Backend : 3 nouveaux champs dans `DashboardData` calculés à partir des entités existantes
- Test `DashboardResourceTest` étendu pour les nouveaux champs

## Fusion de l'assistant IA et améliorations UX

- Le chatbot est fusionné dans la page **Accueil** : une seule page regroupe les deux fonctionnalités, l'entrée de menu "Chatbot" est supprimée
- L'assistant IA est **replié par défaut** et se déploie au clic sur sa bannière (bouton pour le masquer à nouveau), sous l'en-tête de salutation
- En-tête personnalisé **"Bonjour {utilisateur}"** avec la date du jour, un bouton **Actualiser** et l'horodatage de mise à jour
- Gestion des **erreurs de chargement** (fin du spinner infini) avec possibilité de réessayer
- **Actions rapides** déplacées en haut du tableau de bord et rendues fonctionnelles (navigation)
- **Cartes de statistiques cliquables** vers les vues correspondantes
- Hauteur uniformisée des cartes "Interventions du jour"/"Stock à surveiller" et "Canal d'acquisition"/"Objectifs mensuels"
- Hauteur de la zone de conversation de l'assistant réduite
- Correction des accents des libellés français

## Version et date de build

- Nouveau module `version.ts` exposant la version applicative et la date de build
- Injection de `REACT_APP_VERSION` (`$npm_package_version`) et `REACT_APP_BUILD_DATE` dans les scripts `start`/`build`
- Affichage de la version/date de build sur la card **"Bonjour ..."** et dans le **footer** (près du copyright)

## Critères d'acceptation

- [x] Le dashboard est la page d'accueil par défaut du chantier-ui
- [x] Les 4 widgets affichent des données réelles issues du backend
- [x] Mise en page responsive (desktop + tablette)
- [x] Tests unitaires pour les nouveaux endpoints backend
