### PR TITLE
feat: afficher la fiche produit sur les lignes de prestation

### DIFF
--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -4,6 +4,7 @@ import {
     Button,
     Card,
     Col,
+    Descriptions,
     Form,
     Input,
     InputNumber,
@@ -20,11 +21,12 @@ import {
     Dropdown,
     message
 } from 'antd';
-import { CreditCardOutlined, DeleteOutlined, EditOutlined, EnvironmentOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, FileTextOutlined } from '@ant-design/icons';
+import { CreditCardOutlined, DeleteOutlined, EditOutlined, EnvironmentOutlined, InfoCircleOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, FileTextOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import axios from 'axios';
 import api from './api.ts';
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
+import { useNavigation } from './navigation-context.tsx';
 import ImageUpload from './ImageUpload.tsx';
 
 interface ClientEntity {
@@ -349,8 +351,124 @@ const getClientLabel = (client?: ClientEntity) => {
     return fullName || `Client #${client.id}`;
 };
 
+const formatEuroCatalogue = (v?: number) => v != null ? v.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' }) : '-';
+
+function FicheCataloguePopover({ type, itemId, produits, catalogueBateaux, catalogueMoteurs, catalogueHelices, catalogueRemorques, forfaits, services, navigate }: {
+    type?: string; itemId?: number;
+    produits: ProduitCatalogueEntity[];
+    catalogueBateaux: CatalogueBateauEntity[];
+    catalogueMoteurs: CatalogueMoteurEntity[];
+    catalogueHelices: CatalogueHeliceEntity[];
+    catalogueRemorques: CatalogueRemorqueEntity[];
+    forfaits: any[];
+    services: any[];
+    navigate: (route: string) => void;
+}) {
+    if (!type || !itemId) return null;
+
+    let items: { label: string; value: React.ReactNode }[] = [];
+    let catalogueRoute: string | null = null;
+    let titre = '';
+
+    if (type === 'produit') {
+        const p = produits.find((x) => x.id === itemId);
+        if (!p) return null;
+        titre = p.nom;
+        catalogueRoute = '/catalogue/produits';
+        items = [
+            { label: 'Marque', value: p.marque || '-' },
+            { label: 'Référence', value: p.ref || '-' },
+            { label: 'Catégorie', value: p.categorie || '-' },
+            { label: 'Stock', value: p.stock != null ? p.stock : '-' },
+            { label: 'Emplacement', value: p.emplacement || '-' },
+            { label: 'Prix TTC', value: formatEuroCatalogue(p.prixVenteTTC) },
+        ];
+        if (p.description) items.push({ label: 'Description', value: p.description });
+    } else if (type === 'bateau') {
+        const b = catalogueBateaux.find((x) => x.id === itemId);
+        if (!b) return null;
+        titre = `${b.marque} ${b.modele}`;
+        catalogueRoute = '/catalogue/bateaux';
+        items = [
+            { label: 'Marque', value: b.marque },
+            { label: 'Modèle', value: b.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(b.prixVenteTTC) },
+        ];
+    } else if (type === 'moteur') {
+        const m = catalogueMoteurs.find((x) => x.id === itemId);
+        if (!m) return null;
+        titre = `${m.marque} ${m.modele}`;
+        catalogueRoute = '/catalogue/moteurs';
+        items = [
+            { label: 'Marque', value: m.marque },
+            { label: 'Modèle', value: m.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(m.prixVenteTTC) },
+        ];
+    } else if (type === 'helice') {
+        const h = catalogueHelices.find((x) => x.id === itemId);
+        if (!h) return null;
+        titre = `${h.marque} ${h.modele}`;
+        catalogueRoute = '/catalogue/helices';
+        items = [
+            { label: 'Marque', value: h.marque },
+            { label: 'Modèle', value: h.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(h.prixVenteTTC) },
+        ];
+    } else if (type === 'remorque') {
+        const r = catalogueRemorques.find((x) => x.id === itemId);
+        if (!r) return null;
+        titre = `${r.marque} ${r.modele}`;
+        catalogueRoute = '/catalogue/remorques';
+        items = [
+            { label: 'Marque', value: r.marque },
+            { label: 'Modèle', value: r.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(r.prixVenteTTC) },
+        ];
+    } else if (type === 'forfait') {
+        const f = forfaits.find((x: any) => x.id === itemId);
+        if (!f) return null;
+        titre = f.nom;
+        items = [
+            { label: 'Prix TTC', value: formatEuroCatalogue(f.prixTTC) },
+            { label: 'Durée estimée', value: f.dureeEstimee != null ? `${f.dureeEstimee}h` : '-' },
+        ];
+        if (f.description) items.push({ label: 'Description', value: f.description });
+    } else if (type === 'service') {
+        const s = services.find((x: any) => x.id === itemId);
+        if (!s) return null;
+        titre = s.nom;
+        items = [
+            { label: 'Prix TTC', value: formatEuroCatalogue(s.prixTTC) },
+            { label: 'Durée estimée', value: s.dureeEstimee != null ? `${s.dureeEstimee}h` : '-' },
+        ];
+        if (s.description) items.push({ label: 'Description', value: s.description });
+    } else {
+        return null;
+    }
+
+    const content = (
+        <div style={{ maxWidth: 280 }}>
+            <Descriptions column={1} size="small" items={items.map((it, i) => ({ key: i, label: it.label, children: it.value }))} />
+            {catalogueRoute && (
+                <div style={{ marginTop: 8, textAlign: 'right' }}>
+                    <Button type="link" size="small" onClick={() => navigate(catalogueRoute!)}>
+                        Voir dans le catalogue
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+
+    return (
+        <Popover title={titre} content={content} trigger="click" placement="right">
+            <Button icon={<InfoCircleOutlined />} title="Fiche produit" size="small" />
+        </Popover>
+    );
+}
+
 export default function Comptoir() {
     const PRODUIT_CATEGORIES = useReferenceValeurs('CATEGORIE_PRODUIT');
+    const { navigate } = useNavigation();
     const [ventes, setVentes] = useState<VenteEntity[]>([]);
     const [clients, setClients] = useState<ClientEntity[]>([]);
     const [bateaux, setBateaux] = useState<BateauClientEntity[]>([]);
@@ -1603,6 +1721,8 @@ export default function Comptoir() {
                                                     ? Math.max(0, Math.round((brutLigne - remiseLigne) * 100) / 100)
                                                     : undefined;
                                                 const isEmptyLine = !produitRef;
+                                                const [ligneType, ligneIdStr] = (produitRef || '').split(':');
+                                                const ligneItemId = parseInt(ligneIdStr, 10);
                                                 return (
                                                 <Space align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
                                                     <Form.Item
@@ -1685,8 +1805,21 @@ export default function Comptoir() {
                                                             placeholder="Total"
                                                         />
                                                     </Form.Item>
-                                                    {isEmptyLine && (
+                                                    {isEmptyLine ? (
                                                         <Button icon={<PlusOutlined />} title="Créer un produit" onClick={() => openNewProduitModal(field.name)} />
+                                                    ) : (
+                                                        <FicheCataloguePopover
+                                                            type={ligneType}
+                                                            itemId={Number.isNaN(ligneItemId) ? undefined : ligneItemId}
+                                                            produits={produits}
+                                                            catalogueBateaux={catalogueBateaux}
+                                                            catalogueMoteurs={catalogueMoteurs}
+                                                            catalogueHelices={catalogueHelices}
+                                                            catalogueRemorques={catalogueRemorques}
+                                                            forfaits={forfaits}
+                                                            services={services}
+                                                            navigate={navigate}
+                                                        />
                                                     )}
                                                     {emplacement && (
                                                         <Popover content={emplacement} title="Emplacement" trigger="click">

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -4,6 +4,7 @@ import {
     Button,
     Card,
     Col,
+    Descriptions,
     Divider,
     Form,
     Input,
@@ -23,7 +24,7 @@ import {
     Dropdown,
     message
 } from 'antd';
-import { CalendarOutlined, CheckCircleOutlined, CreditCardOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, EnvironmentOutlined, FileDoneOutlined, FileTextOutlined, LeftOutlined, MailOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, RightOutlined, RollbackOutlined, SendOutlined, SolutionOutlined, WalletOutlined } from '@ant-design/icons';
+import { CalendarOutlined, CheckCircleOutlined, CreditCardOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, EnvironmentOutlined, FileDoneOutlined, FileTextOutlined, InfoCircleOutlined, LeftOutlined, MailOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, RightOutlined, RollbackOutlined, SendOutlined, SolutionOutlined, WalletOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import api from './api.ts';
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
@@ -587,6 +588,121 @@ const getClientLabel = (client?: ClientEntity) => {
     const fullName = `${client.prenom || ''} ${client.nom || ''}`.trim();
     return fullName || `Client #${client.id}`;
 };
+
+const formatEuroCatalogue = (v?: number) => v != null ? v.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' }) : '-';
+
+function FicheCataloguePopover({ type, itemId, produits, catalogueBateaux, catalogueMoteurs, catalogueHelices, catalogueRemorques, forfaits, services, navigate }: {
+    type?: string; itemId?: number;
+    produits: ProduitCatalogueEntity[];
+    catalogueBateaux: CatalogueBateauEntity[];
+    catalogueMoteurs: CatalogueMoteurEntity[];
+    catalogueHelices: CatalogueHeliceEntity[];
+    catalogueRemorques: CatalogueRemorqueEntity[];
+    forfaits: any[];
+    services: any[];
+    navigate: (route: string) => void;
+}) {
+    if (!type || !itemId) return null;
+
+    let items: { label: string; value: React.ReactNode }[] = [];
+    let catalogueRoute: string | null = null;
+    let titre = '';
+
+    if (type === 'produit') {
+        const p = produits.find((x) => x.id === itemId);
+        if (!p) return null;
+        titre = p.nom;
+        catalogueRoute = '/catalogue/produits';
+        items = [
+            { label: 'Marque', value: p.marque || '-' },
+            { label: 'Référence', value: p.ref || '-' },
+            { label: 'Catégorie', value: p.categorie || '-' },
+            { label: 'Stock', value: p.stock != null ? p.stock : '-' },
+            { label: 'Emplacement', value: p.emplacement || '-' },
+            { label: 'Prix TTC', value: formatEuroCatalogue(p.prixVenteTTC) },
+        ];
+        if (p.description) items.push({ label: 'Description', value: p.description });
+    } else if (type === 'bateau') {
+        const b = catalogueBateaux.find((x) => x.id === itemId);
+        if (!b) return null;
+        titre = `${b.marque} ${b.modele}`;
+        catalogueRoute = '/catalogue/bateaux';
+        items = [
+            { label: 'Marque', value: b.marque },
+            { label: 'Modèle', value: b.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(b.prixVenteTTC) },
+        ];
+    } else if (type === 'moteur') {
+        const m = catalogueMoteurs.find((x) => x.id === itemId);
+        if (!m) return null;
+        titre = `${m.marque} ${m.modele}`;
+        catalogueRoute = '/catalogue/moteurs';
+        items = [
+            { label: 'Marque', value: m.marque },
+            { label: 'Modèle', value: m.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(m.prixVenteTTC) },
+        ];
+    } else if (type === 'helice') {
+        const h = catalogueHelices.find((x) => x.id === itemId);
+        if (!h) return null;
+        titre = `${h.marque} ${h.modele}`;
+        catalogueRoute = '/catalogue/helices';
+        items = [
+            { label: 'Marque', value: h.marque },
+            { label: 'Modèle', value: h.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(h.prixVenteTTC) },
+        ];
+    } else if (type === 'remorque') {
+        const r = catalogueRemorques.find((x) => x.id === itemId);
+        if (!r) return null;
+        titre = `${r.marque} ${r.modele}`;
+        catalogueRoute = '/catalogue/remorques';
+        items = [
+            { label: 'Marque', value: r.marque },
+            { label: 'Modèle', value: r.modele },
+            { label: 'Prix TTC', value: formatEuroCatalogue(r.prixVenteTTC) },
+        ];
+    } else if (type === 'forfait') {
+        const f = forfaits.find((x: any) => x.id === itemId);
+        if (!f) return null;
+        titre = f.nom;
+        items = [
+            { label: 'Prix TTC', value: formatEuroCatalogue(f.prixTTC) },
+            { label: 'Durée estimée', value: f.dureeEstimee != null ? `${f.dureeEstimee}h` : '-' },
+        ];
+        if (f.description) items.push({ label: 'Description', value: f.description });
+    } else if (type === 'service') {
+        const s = services.find((x: any) => x.id === itemId);
+        if (!s) return null;
+        titre = s.nom;
+        items = [
+            { label: 'Prix TTC', value: formatEuroCatalogue(s.prixTTC) },
+            { label: 'Durée estimée', value: s.dureeEstimee != null ? `${s.dureeEstimee}h` : '-' },
+        ];
+        if (s.description) items.push({ label: 'Description', value: s.description });
+    } else {
+        return null;
+    }
+
+    const content = (
+        <div style={{ maxWidth: 280 }}>
+            <Descriptions column={1} size="small" items={items.map((it, i) => ({ key: i, label: it.label, children: it.value }))} />
+            {catalogueRoute && (
+                <div style={{ marginTop: 8, textAlign: 'right' }}>
+                    <Button type="link" size="small" onClick={() => navigate(catalogueRoute!)}>
+                        Voir dans le catalogue
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+
+    return (
+        <Popover title={titre} content={content} trigger="click" placement="right">
+            <Button icon={<InfoCircleOutlined />} title="Fiche produit" size="small" />
+        </Popover>
+    );
+}
 
 export default function Vente() {
     const PRODUIT_CATEGORIES = useReferenceValeurs('CATEGORIE_PRODUIT');
@@ -2993,6 +3109,20 @@ export default function Vente() {
                                                             <Tag color={lineType === 'forfait' ? 'blue' : lineType === 'service' ? 'green' : lineType === 'produit' ? 'orange' : 'purple'} style={{ marginRight: 0 }}>
                                                                 {lineType === 'forfait' ? 'F' : lineType === 'service' ? 'S' : lineType === 'produit' ? 'P' : lineType === 'bateau' ? 'B' : lineType === 'moteur' ? 'M' : lineType === 'helice' ? 'H' : 'R'}
                                                             </Tag>
+                                                        )}
+                                                        {!isEmptyLine && (
+                                                            <FicheCataloguePopover
+                                                                type={lineType}
+                                                                itemId={itemId}
+                                                                produits={produits}
+                                                                catalogueBateaux={catalogueBateaux}
+                                                                catalogueMoteurs={catalogueMoteurs}
+                                                                catalogueHelices={catalogueHelices}
+                                                                catalogueRemorques={catalogueRemorques}
+                                                                forfaits={forfaits}
+                                                                services={services}
+                                                                navigate={navigate}
+                                                            />
                                                         )}
                                                         <Form.Item
                                                             {...field}


### PR DESCRIPTION
Closes #287

## Résumé

- Ajout d'un bouton ℹ (`InfoCircleOutlined`) sur chaque ligne non-vide du formulaire de prestation
- Au clic, une `Popover` affiche les détails de l'article catalogue :
  - **Produit** : marque, référence, catégorie, stock, emplacement, prix TTC, description
  - **Bateau / Moteur / Hélice / Remorque** : marque, modèle, prix TTC
  - **Forfait / Service** : prix TTC, durée estimée, description
- Un lien "Voir dans le catalogue" permet de naviguer vers la page catalogue correspondante
- Frontend uniquement — les données sont déjà chargées en mémoire dans le composant

## Plan de test

- [x] Ouvrir une prestation avec des lignes de types variés (produit, bateau, moteur…)
- [x] Cliquer sur le bouton ℹ d'une ligne produit → vérifier que la popover affiche marque, ref, stock, emplacement, prix TTC
- [x] Cliquer sur ℹ d'une ligne bateau/moteur/hélice/remorque → marque + modèle + prix TTC
- [x] Cliquer sur "Voir dans le catalogue" → navigation vers la bonne page catalogue
- [x] Vérifier que le bouton n'apparaît pas sur les lignes vides