### PR TITLE
feat: afficher l'emplacement d'une pièce en popup lors d'une vente (#396, #390)

### DIFF
--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -9,6 +9,7 @@ import {
     InputNumber,
     Modal,
     Popconfirm,
+    Popover,
     Rate,
     Row,
     Select,
@@ -19,7 +20,7 @@ import {
     Dropdown,
     message
 } from 'antd';
-import { CreditCardOutlined, DeleteOutlined, EditOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, FileTextOutlined } from '@ant-design/icons';
+import { CreditCardOutlined, DeleteOutlined, EditOutlined, EnvironmentOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, FileTextOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import axios from 'axios';
 import api from './api.ts';
@@ -466,7 +467,7 @@ export default function Comptoir() {
             options: produits.map((p) => ({
                 value: `produit:${p.id}`,
                 label: `${p.nom}${p.marque ? ` (${p.marque})` : ''}`,
-                searchText: `${p.nom} ${p.marque || ''} ${p.ref || ''} ${(p.refs || []).join(' ')}`.toLowerCase(),
+                searchText: `${p.nom} ${p.marque || ''} ${p.ref || ''} ${(p.refs || []).join(' ')} ${p.emplacement || ''}`.toLowerCase(),
             })),
         },
         {
@@ -514,6 +515,15 @@ export default function Comptoir() {
         if (type === 'helice') return catalogueHelices.find((h) => h.id === id)?.prixVenteTTC || 0;
         if (type === 'remorque') return catalogueRemorques.find((r) => r.id === id)?.prixVenteTTC || 0;
         return 0;
+    };
+
+    const getProduitEmplacement = (ref?: string): string | undefined => {
+        if (!ref) return undefined;
+        const [type, idStr] = ref.split(':');
+        if (type !== 'produit') return undefined;
+        const id = parseInt(idStr, 10);
+        if (isNaN(id)) return undefined;
+        return produits.find((p) => p.id === id)?.emplacement || undefined;
     };
     const serviceOptions = useMemo(
         () => services.map((service) => ({ value: service.id, label: service.nom })),
@@ -1585,6 +1595,7 @@ export default function Comptoir() {
                                             {() => {
                                                 const produitRef = form.getFieldValue(['produits', field.name, 'produitRef']);
                                                 const prixUnitaire = getCatalogueItemPrice(produitRef) || undefined;
+                                                const emplacement = getProduitEmplacement(produitRef);
                                                 const quantite = form.getFieldValue(['produits', field.name, 'quantite']);
                                                 const remiseLigne = form.getFieldValue(['produits', field.name, 'remise']) || 0;
                                                 const brutLigne = (prixUnitaire && quantite) ? Math.round(prixUnitaire * quantite * 100) / 100 : undefined;
@@ -1676,6 +1687,11 @@ export default function Comptoir() {
                                                     </Form.Item>
                                                     {isEmptyLine && (
                                                         <Button icon={<PlusOutlined />} title="Créer un produit" onClick={() => openNewProduitModal(field.name)} />
+                                                    )}
+                                                    {emplacement && (
+                                                        <Popover content={emplacement} title="Emplacement" trigger="click">
+                                                            <Button icon={<EnvironmentOutlined />} title="Emplacement de la pièce" />
+                                                        </Popover>
                                                     )}
                                                     <Button danger icon={<DeleteOutlined />} onClick={() => remove(field.name)} />
                                                 </Space>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -10,6 +10,7 @@ import {
     InputNumber,
     Modal,
     Popconfirm,
+    Popover,
     Rate,
     Row,
     Select,
@@ -22,7 +23,7 @@ import {
     Dropdown,
     message
 } from 'antd';
-import { CalendarOutlined, CheckCircleOutlined, CreditCardOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, FileDoneOutlined, FileTextOutlined, LeftOutlined, MailOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, RightOutlined, RollbackOutlined, SendOutlined, SolutionOutlined, WalletOutlined } from '@ant-design/icons';
+import { CalendarOutlined, CheckCircleOutlined, CreditCardOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, EnvironmentOutlined, FileDoneOutlined, FileTextOutlined, LeftOutlined, MailOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, RightOutlined, RollbackOutlined, SendOutlined, SolutionOutlined, WalletOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import api from './api.ts';
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
@@ -2993,11 +2994,6 @@ export default function Vente() {
                                                                 {lineType === 'forfait' ? 'F' : lineType === 'service' ? 'S' : lineType === 'produit' ? 'P' : lineType === 'bateau' ? 'B' : lineType === 'moteur' ? 'M' : lineType === 'helice' ? 'H' : 'R'}
                                                             </Tag>
                                                         )}
-                                                        {lineType === 'produit' && itemId && emplacement && (
-                                                            <Form.Item style={{ width: 200 }}>
-                                                                <Input disabled value={emplacement} title={emplacement} placeholder="Emplacement" />
-                                                            </Form.Item>
-                                                        )}
                                                         <Form.Item
                                                             {...field}
                                                             name={[field.name, 'quantite']}
@@ -3096,6 +3092,11 @@ export default function Vente() {
                                                                     <Button icon={<CalendarOutlined />} title="Planifier" disabled={!watchedBonPourAccord} onClick={() => { setModalVisible(false); navigate('/planning'); }} />
                                                                 )}
                                                             </>
+                                                        )}
+                                                        {emplacement && (
+                                                            <Popover content={emplacement} title="Emplacement" trigger="click">
+                                                                <Button icon={<EnvironmentOutlined />} title="Emplacement de la pièce" />
+                                                            </Popover>
                                                         )}
                                                         <Button danger icon={<DeleteOutlined />} onClick={() => remove(field.name)} />
                                                     </Space>


### PR DESCRIPTION
## Contexte

Closes #396
Closes #390

Deux issues complémentaires sur l'affichage de l'emplacement de stockage d'une pièce lors d'une vente :
- **#396** : l'emplacement n'était affiché nulle part dans la vente comptoir.
- **#390** : l'emplacement doit apparaître en popup (et non dans une case de texte), en comptoir **et** en prestation.

## Solution

Un **bouton 📍** est ajouté sur chaque ligne produit, à droite des colonnes de prix et à gauche du bouton de suppression. Au clic, il ouvre un **popover** affichant l'emplacement de la pièce.

Ce choix (bouton + popover au clic, plutôt que tooltip au survol) est volontaire : les ventes comptoir se font souvent sur tablette/écran tactile, où le survol n'existe pas. Le bouton est aussi plus découvrable.

Le bouton n'apparaît que pour les produits disposant d'un emplacement.

## Modifications

Frontend uniquement, sans changement backend (le champ `emplacement` est déjà exposé par `/catalogue/produits`).

### Comptoir (`comptoir.tsx`)
- Bouton 📍 + popover au clic sur chaque ligne produit.
- L'emplacement reste **recherchable** dans la liste déroulante (ajouté au `searchText`).

### Prestation (`vente.tsx`)
- Remplacement de l'ancienne case de texte « Emplacement » (Input désactivée) par le même bouton 📍 + popover.