### PR TITLE
fix: réinitialiser le statut « en attente » en changeant une ligne en produit (#398)

### DIFF
--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -2970,10 +2970,15 @@ export default function Vente() {
                                                                         const currentLignes: LigneUnifiee[] = form.getFieldValue('lignes') || [];
                                                                         const updated = [...currentLignes];
                                                                         if (parsed) {
-                                                                            const defaults: Partial<LigneUnifiee> = parsed.type !== 'produit'
+                                                                            const isPlanifiable = parsed.type === 'forfait' || parsed.type === 'service';
+                                                                            // Le statut de planification et les techniciens ne concernent que les
+                                                                            // forfaits/services : on les réinitialise quand la ligne devient un
+                                                                            // produit ou un article catalogue, sinon la mention « en attente »
+                                                                            // persiste sur la ligne (#398).
+                                                                            const planningReset: Partial<LigneUnifiee> = isPlanifiable
                                                                                 ? { status: 'EN_ATTENTE' }
-                                                                                : {};
-                                                                            updated[field.name] = { ...updated[field.name], type: parsed.type, itemId: parsed.id, ...defaults };
+                                                                                : { status: undefined, technicienIds: undefined };
+                                                                            updated[field.name] = { ...updated[field.name], type: parsed.type, itemId: parsed.id, ...planningReset };
                                                                             const lastLine = updated[updated.length - 1];
                                                                             if (lastLine?.type && lastLine?.itemId && (lastLine?.quantite || 0) > 0) {
                                                                                 updated.push({ quantite: 1 });

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -2938,14 +2938,12 @@ export default function Vente() {
                                                     return (
                                                     <Space key={field.key} align="baseline" style={{ display: 'flex', marginBottom: 8, flexWrap: 'nowrap' }}>
                                                         <Form.Item
-                                                            {...field}
                                                             name={[field.name, 'type']}
                                                             hidden
                                                         >
                                                             <Input />
                                                         </Form.Item>
                                                         <Form.Item
-                                                            {...field}
                                                             name={[field.name, 'itemId']}
                                                             hidden
                                                         >
@@ -3004,7 +3002,6 @@ export default function Vente() {
                                                             </Form.Item>
                                                         )}
                                                         <Form.Item
-                                                            {...field}
                                                             name={[field.name, 'quantite']}
                                                             rules={[
                                                                 {
@@ -3034,14 +3031,12 @@ export default function Vente() {
                                                             }}
                                                         </Form.Item>
                                                         <Form.Item
-                                                            {...field}
                                                             name={[field.name, 'remisePourcentage']}
                                                             style={{ width: 100 }}
                                                         >
                                                             <InputNumber addonAfter="%" min={0} max={100} step={0.01} style={{ width: '100%' }} placeholder="Rem." />
                                                         </Form.Item>
                                                         <Form.Item
-                                                            {...field}
                                                             name={[field.name, 'remise']}
                                                             style={{ width: 110 }}
                                                         >
@@ -3064,14 +3059,12 @@ export default function Vente() {
                                                         {isForfaitOrService && (
                                                             <>
                                                                 <Form.Item
-                                                                    {...field}
                                                                     name={[field.name, 'status']}
                                                                     style={{ width: 130 }}
                                                                 >
                                                                     <Select allowClear options={planningStatusOptions} placeholder="Statut" />
                                                                 </Form.Item>
                                                                 <Form.Item
-                                                                    {...field}
                                                                     name={[field.name, 'technicienIds']}
                                                                     style={{ width: 200 }}
                                                                 >


### PR DESCRIPTION
## Contexte

Closes #398

Dans le formulaire de prestation, si l'on sélectionne un **forfait** (qui applique le statut de planification `EN_ATTENTE`) puis que l'on change la ligne en **produit**, la mention « en attente » restait attachée à la ligne.

## Cause

Dans le `onChange` du sélecteur de ligne, seul le cas `type === 'produit'` ne réinitialisait rien : le statut hérité du forfait était donc conservé. Or Ant Design conserve la valeur d'un champ même lorsque son `Form.Item` n'est plus affiché — le statut restait donc dans le state du formulaire.

Les champs de planification (statut, techniciens) n'ont de sens que pour les **forfaits** et **services**.

## Correctif

Au changement de type de ligne :
- **forfait / service** → statut `EN_ATTENTE` (comportement inchangé) ;
- **produit / bateau / moteur / hélice / remorque** → statut et techniciens réinitialisés (`undefined`).

Frontend uniquement (`chantier-ui/src/vente.tsx`). Aucune modification backend.

## Vérification

- `CI=true npm run build` → compilation OK (seuls des warnings de source-map d'une lib tierce, sans rapport).

## Plan de test

- [x] Ouvrir une prestation, ajouter une ligne et sélectionner un forfait → statut « En attente » visible
- [ ] Changer la même ligne en produit → le statut « en attente » disparaît bien
- [ ] Vérifier qu'un forfait/service conserve son statut « En attente »