### PR TITLE
feat(technicien): section « Mes objectifs » (#395)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/TechnicienEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/TechnicienEntity.java
@@ -18,4 +18,9 @@ public class TechnicienEntity extends PanacheEntity {
 
     public String couleur;
 
+    // Objectifs mensuels fixes par le manager
+    public Integer cibleInterventions;
+
+    public Double cibleHeures;
+
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
@@ -332,6 +332,24 @@ public class TechnicienPortalResource {
         return Response.noContent().build();
     }
 
+    public static class ObjectifResponse {
+        public Integer cibleInterventions;
+        public Double cibleHeures;
+    }
+
+    @GET
+    @Path("/techniciens/{id}/objectif")
+    public ObjectifResponse getTechnicienObjectif(@PathParam("id") long technicienId) {
+        TechnicienEntity technicien = TechnicienEntity.findById(technicienId);
+        if (technicien == null) {
+            throw new WebApplicationException("Technicien non trouve", Response.Status.NOT_FOUND);
+        }
+        ObjectifResponse response = new ObjectifResponse();
+        response.cibleInterventions = technicien.cibleInterventions;
+        response.cibleHeures = technicien.cibleHeures;
+        return response;
+    }
+
     @GET
     @Path("/techniciens/{id}/taches")
     public List<PlanningItemWithVente> getTechnicienTasks(@PathParam("id") long technicienId) {

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienResource.java
@@ -94,6 +94,8 @@ public class TechnicienResource {
         entity.email = technicien.email;
         entity.telephone = technicien.telephone;
         entity.couleur = technicien.couleur;
+        entity.cibleInterventions = technicien.cibleInterventions;
+        entity.cibleHeures = technicien.cibleHeures;
 
         entity.flush();
         TechnicienEntity.getEntityManager().detach(entity);

--- a/chantier-ui/src/techniciens.tsx
+++ b/chantier-ui/src/techniciens.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Space, Table, Button, Input, Form, Modal, Card, Row, Col, Popconfirm, message, Drawer, Statistic, Progress, Divider, Spin, Checkbox, ColorPicker } from 'antd';
+import { Space, Table, Button, Input, InputNumber, Form, Modal, Card, Row, Col, Popconfirm, message, Drawer, Statistic, Progress, Divider, Spin, Checkbox, ColorPicker } from 'antd';
 import { PlusCircleOutlined, EditOutlined, DeleteOutlined, UserOutlined, BarChartOutlined, CheckCircleOutlined, ClockCircleOutlined, ExclamationCircleOutlined, WarningOutlined, EuroCircleOutlined, KeyOutlined, MailOutlined } from '@ant-design/icons';
 import api from './api.ts';
 
@@ -13,6 +13,8 @@ interface TechnicienEntity {
     email: string;
     telephone?: string;
     couleur?: string;
+    cibleInterventions?: number;
+    cibleHeures?: number;
 }
 
 interface TechnicienKpi {
@@ -42,6 +44,8 @@ interface TechnicienFormValues {
     email: string;
     telephone?: string;
     couleur?: string;
+    cibleInterventions?: number;
+    cibleHeures?: number;
 }
 
 const defaultTechnicien: TechnicienFormValues = {
@@ -445,6 +449,25 @@ const Techniciens: React.FC = () => {
                                                 </Popconfirm>
                                             )}
                                         </Space>
+                                    </Col>
+                                </Row>
+                                <Divider orientation="left" plain>Objectifs mensuels</Divider>
+                                <Row gutter={16}>
+                                    <Col span={12}>
+                                        <Form.Item
+                                            name="cibleInterventions"
+                                            label="Cible interventions / mois"
+                                        >
+                                            <InputNumber min={0} step={1} style={{ width: '100%' }} placeholder="Ex : 18" />
+                                        </Form.Item>
+                                    </Col>
+                                    <Col span={12}>
+                                        <Form.Item
+                                            name="cibleHeures"
+                                            label="Cible heures / mois"
+                                        >
+                                            <InputNumber min={0} step={0.5} style={{ width: '100%' }} addonAfter="h" placeholder="Ex : 40" />
+                                        </Form.Item>
                                     </Col>
                                 </Row>
                                 <Form.Item

--- a/technicien-ui/src/app.tsx
+++ b/technicien-ui/src/app.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Layout, Menu, Image, Button } from 'antd';
 import {
+    AimOutlined,
     KeyOutlined,
     ScheduleOutlined,
     UserOutlined,
@@ -8,6 +9,7 @@ import {
 } from '@ant-design/icons';
 import Login from './login.tsx';
 import Planning from './planning.tsx';
+import Objectifs from './objectifs.tsx';
 import MobileApp from './mobile-app.tsx';
 import ChangePasswordModal from './change-password-modal.tsx';
 import useIsMobile from './use-is-mobile.tsx';
@@ -31,6 +33,7 @@ export default function App() {
         return stored ? JSON.parse(stored) : null;
     });
     const [passwordModalOpen, setPasswordModalOpen] = useState(false);
+    const [section, setSection] = useState<'planning' | 'objectifs'>('planning');
     const isMobile = useIsMobile();
 
     const handleLogout = () => {
@@ -68,9 +71,11 @@ export default function App() {
                 <Menu
                     theme="dark"
                     mode="inline"
-                    selectedKeys={['planning']}
+                    selectedKeys={[section]}
+                    onClick={({ key }) => setSection(key as 'planning' | 'objectifs')}
                     items={[
                         { key: 'planning', icon: <ScheduleOutlined />, label: 'Mon planning' },
+                        { key: 'objectifs', icon: <AimOutlined />, label: 'Mes objectifs' },
                     ]}
                 />
             </Sider>
@@ -112,7 +117,9 @@ export default function App() {
                     boxShadow: '0 1px 4px rgba(0, 0, 0, 0.04)',
                     animation: 'fadeInUp 0.3s ease-out',
                 }}>
-                    <Planning technicienId={user.id} />
+                    {section === 'planning'
+                        ? <Planning technicienId={user.id} />
+                        : <Objectifs technicienId={user.id} />}
                 </Content>
                 <Footer style={{ background: 'transparent', padding: '16px 50px' }}>
                     moussAIllon - Espace Technicien

--- a/technicien-ui/src/mobile-app.tsx
+++ b/technicien-ui/src/mobile-app.tsx
@@ -18,6 +18,7 @@ import {
     message,
 } from 'antd';
 import {
+    AimOutlined,
     CheckCircleOutlined,
     ClockCircleOutlined,
     ExclamationCircleOutlined,
@@ -36,6 +37,7 @@ import dayjs from 'dayjs';
 import api from './api.ts';
 import ImageUpload from './ImageUpload.tsx';
 import DocumentUpload from './DocumentUpload.tsx';
+import Objectifs from './objectifs.tsx';
 
 interface Technicien {
     id: number;
@@ -93,7 +95,7 @@ interface MobileAppProps {
     onChangePassword: () => void;
 }
 
-type Tab = 'today' | 'all' | 'incidents';
+type Tab = 'today' | 'all' | 'incidents' | 'objectifs';
 
 const taskStatusOptions: Array<{ value: TaskStatus; label: string }> = [
     { value: 'EN_ATTENTE', label: 'En attente' },
@@ -294,21 +296,27 @@ export default function MobileApp({ user, onLogout, onChangePassword }: MobileAp
 
             {/* Content */}
             <div style={{ flex: 1, padding: 12, background: '#f5f5f5', overflowY: 'auto' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-                    <h3 style={{ margin: 0 }}>
-                        {tab === 'today' && `Aujourd'hui (${todayIso()})`}
-                        {tab === 'all' && 'Toutes les taches'}
-                        {tab === 'incidents' && 'Incidents'}
-                    </h3>
-                    <Button size="small" icon={<ReloadOutlined />} onClick={fetchItems} />
-                </div>
-                <Spin spinning={loading}>
-                    {displayedItems.length > 0 ? (
-                        <List dataSource={displayedItems} renderItem={renderItemCard} />
-                    ) : (
-                        <Card style={{ textAlign: 'center', color: '#999' }}>Aucune tache</Card>
-                    )}
-                </Spin>
+                {tab === 'objectifs' ? (
+                    <Objectifs technicienId={user.id} />
+                ) : (
+                    <>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+                            <h3 style={{ margin: 0 }}>
+                                {tab === 'today' && `Aujourd'hui (${todayIso()})`}
+                                {tab === 'all' && 'Toutes les taches'}
+                                {tab === 'incidents' && 'Incidents'}
+                            </h3>
+                            <Button size="small" icon={<ReloadOutlined />} onClick={fetchItems} />
+                        </div>
+                        <Spin spinning={loading}>
+                            {displayedItems.length > 0 ? (
+                                <List dataSource={displayedItems} renderItem={renderItemCard} />
+                            ) : (
+                                <Card style={{ textAlign: 'center', color: '#999' }}>Aucune tache</Card>
+                            )}
+                        </Spin>
+                    </>
+                )}
             </div>
 
             {/* Bottom tab bar */}
@@ -321,6 +329,7 @@ export default function MobileApp({ user, onLogout, onChangePassword }: MobileAp
                         { value: 'today', icon: <ScheduleOutlined />, label: "Aujourd'hui" },
                         { value: 'all', icon: <UnorderedListOutlined />, label: 'Toutes' },
                         { value: 'incidents', icon: <ExclamationCircleOutlined />, label: 'Incidents' },
+                        { value: 'objectifs', icon: <AimOutlined />, label: 'Objectifs' },
                     ]}
                     style={{ borderRadius: 0 }}
                 />

--- a/technicien-ui/src/objectifs.tsx
+++ b/technicien-ui/src/objectifs.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Alert, Card, Col, Empty, Progress, Row, Spin, Statistic, message } from 'antd';
+import { Alert, Card, Col, Progress, Row, Spin, Statistic, message } from 'antd';
 import { CheckCircleOutlined, ClockCircleOutlined, AimOutlined } from '@ant-design/icons';
 import api from './api.ts';
 
@@ -122,46 +122,50 @@ export default function Objectifs({ technicienId }: ObjectifsProps) {
                         message="Aucun objectif n'a encore été défini par votre responsable. Les indicateurs ci-dessous reflètent votre activité du mois."
                     />
                 )}
-                {stats.total === 0 ? (
-                    <Empty description="Aucune intervention ce mois-ci" />
-                ) : (
-                    <Row gutter={[16, 16]}>
-                        <Col xs={24} sm={8}>
-                            <Card>
-                                <Statistic
-                                    title="Interventions terminées"
-                                    value={stats.done}
-                                    suffix={interventionsSuffix}
-                                    prefix={<CheckCircleOutlined />}
-                                />
-                                <Progress percent={interventionsPct} status="active" />
-                            </Card>
-                        </Col>
-                        <Col xs={24} sm={8}>
-                            <Card>
-                                <Statistic
-                                    title="Heures réalisées"
-                                    value={stats.heuresRealisees}
-                                    suffix={cibleHeures ? `/ ${cibleHeures} h` : 'h'}
-                                    prefix={<ClockCircleOutlined />}
-                                />
-                                <Progress percent={heuresPct} />
-                                <div style={{ fontSize: 12, color: '#999', marginTop: 4 }}>{heuresHint}</div>
-                            </Card>
-                        </Col>
-                        <Col xs={24} sm={8}>
-                            <Card>
-                                <Statistic
-                                    title="Taux de complétion"
-                                    value={stats.completionPct}
-                                    suffix="%"
-                                    prefix={<AimOutlined />}
-                                />
-                                <Progress percent={stats.completionPct} />
-                            </Card>
-                        </Col>
-                    </Row>
+                {stats.total === 0 && (
+                    <Alert
+                        type="info"
+                        showIcon
+                        style={{ marginBottom: 16 }}
+                        message="Aucune intervention ne vous est assignée ce mois-ci pour le moment."
+                    />
                 )}
+                <Row gutter={[16, 16]}>
+                    <Col xs={24} sm={8}>
+                        <Card>
+                            <Statistic
+                                title="Interventions terminées"
+                                value={stats.done}
+                                suffix={interventionsSuffix}
+                                prefix={<CheckCircleOutlined />}
+                            />
+                            <Progress percent={interventionsPct} status="active" />
+                        </Card>
+                    </Col>
+                    <Col xs={24} sm={8}>
+                        <Card>
+                            <Statistic
+                                title="Heures réalisées"
+                                value={stats.heuresRealisees}
+                                suffix={cibleHeures ? `/ ${cibleHeures} h` : 'h'}
+                                prefix={<ClockCircleOutlined />}
+                            />
+                            <Progress percent={heuresPct} />
+                            <div style={{ fontSize: 12, color: '#999', marginTop: 4 }}>{heuresHint}</div>
+                        </Card>
+                    </Col>
+                    <Col xs={24} sm={8}>
+                        <Card>
+                            <Statistic
+                                title="Taux de complétion"
+                                value={stats.completionPct}
+                                suffix="%"
+                                prefix={<AimOutlined />}
+                            />
+                            <Progress percent={stats.completionPct} />
+                        </Card>
+                    </Col>
+                </Row>
             </Card>
         </Spin>
     );

--- a/technicien-ui/src/objectifs.tsx
+++ b/technicien-ui/src/objectifs.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Card, Col, Empty, Progress, Row, Spin, Statistic, message } from 'antd';
+import { CheckCircleOutlined, ClockCircleOutlined, AimOutlined } from '@ant-design/icons';
+import api from './api.ts';
+
+type TaskStatus = 'EN_ATTENTE' | 'PLANIFIEE' | 'EN_COURS' | 'TERMINEE' | 'INCIDENT' | 'ANNULEE';
+
+interface PlanningItem {
+    itemStatus?: TaskStatus;
+    datePlanification?: string;
+    dateDebut?: string;
+    dateFin?: string;
+    statusDate?: string;
+    dureeReelle?: number;
+    dureeEstimee?: number;
+}
+
+interface ObjectifsProps {
+    technicienId: number;
+}
+
+const MONTH_LABELS = [
+    'janvier', 'février', 'mars', 'avril', 'mai', 'juin',
+    'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre',
+];
+
+const isSameMonth = (value: string | undefined, year: number, month: number): boolean => {
+    if (!value) return false;
+    const d = new Date(value);
+    if (isNaN(d.getTime())) return false;
+    return d.getFullYear() === year && d.getMonth() === month;
+};
+
+// Date de référence servant à rattacher une intervention à un mois :
+// la date de fin si terminée, sinon la date planifiée / de début.
+const referenceDate = (t: PlanningItem) => t.dateFin || t.statusDate || t.datePlanification || t.dateDebut;
+
+export default function Objectifs({ technicienId }: ObjectifsProps) {
+    const [items, setItems] = useState<PlanningItem[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        let mounted = true;
+        const fetchItems = async () => {
+            setLoading(true);
+            try {
+                const res = await api.get(`/technicien-portal/techniciens/${technicienId}/taches`);
+                if (mounted) setItems(res.data || []);
+            } catch {
+                message.error('Erreur lors du chargement des objectifs');
+            } finally {
+                if (mounted) setLoading(false);
+            }
+        };
+        fetchItems();
+        return () => { mounted = false; };
+    }, [technicienId]);
+
+    const stats = useMemo(() => {
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = now.getMonth();
+        const monthTasks = items.filter((t) =>
+            t.itemStatus !== 'ANNULEE' && isSameMonth(referenceDate(t), year, month)
+        );
+        const completed = monthTasks.filter((t) => t.itemStatus === 'TERMINEE');
+        const heuresRealisees = completed.reduce((sum, t) => sum + (t.dureeReelle || 0), 0);
+        const heuresEstimees = monthTasks.reduce((sum, t) => sum + (t.dureeEstimee || 0), 0);
+        const total = monthTasks.length;
+        const done = completed.length;
+        return {
+            monthLabel: MONTH_LABELS[month],
+            total,
+            done,
+            completionPct: total > 0 ? Math.round((done / total) * 100) : 0,
+            heuresRealisees: Math.round(heuresRealisees * 100) / 100,
+            heuresEstimees: Math.round(heuresEstimees * 100) / 100,
+            heuresPct: heuresEstimees > 0 ? Math.min(100, Math.round((heuresRealisees / heuresEstimees) * 100)) : 0,
+        };
+    }, [items]);
+
+    return (
+        <Spin spinning={loading}>
+            <Card title={`Mes objectifs — ${stats.monthLabel}`}>
+                {stats.total === 0 ? (
+                    <Empty description="Aucune intervention ce mois-ci" />
+                ) : (
+                    <Row gutter={[16, 16]}>
+                        <Col xs={24} sm={8}>
+                            <Card>
+                                <Statistic
+                                    title="Interventions terminées"
+                                    value={stats.done}
+                                    suffix={`/ ${stats.total}`}
+                                    prefix={<CheckCircleOutlined />}
+                                />
+                                <Progress percent={stats.completionPct} status="active" />
+                            </Card>
+                        </Col>
+                        <Col xs={24} sm={8}>
+                            <Card>
+                                <Statistic
+                                    title="Heures réalisées"
+                                    value={stats.heuresRealisees}
+                                    suffix="h"
+                                    prefix={<ClockCircleOutlined />}
+                                />
+                                <Progress percent={stats.heuresPct} />
+                                <div style={{ fontSize: 12, color: '#999', marginTop: 4 }}>
+                                    Estimé : {stats.heuresEstimees} h
+                                </div>
+                            </Card>
+                        </Col>
+                        <Col xs={24} sm={8}>
+                            <Card>
+                                <Statistic
+                                    title="Taux de complétion"
+                                    value={stats.completionPct}
+                                    suffix="%"
+                                    prefix={<AimOutlined />}
+                                />
+                                <Progress percent={stats.completionPct} />
+                            </Card>
+                        </Col>
+                    </Row>
+                )}
+            </Card>
+        </Spin>
+    );
+}

--- a/technicien-ui/src/objectifs.tsx
+++ b/technicien-ui/src/objectifs.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Card, Col, Empty, Progress, Row, Spin, Statistic, message } from 'antd';
+import { Alert, Card, Col, Empty, Progress, Row, Spin, Statistic, message } from 'antd';
 import { CheckCircleOutlined, ClockCircleOutlined, AimOutlined } from '@ant-design/icons';
 import api from './api.ts';
 
@@ -13,6 +13,11 @@ interface PlanningItem {
     statusDate?: string;
     dureeReelle?: number;
     dureeEstimee?: number;
+}
+
+interface Objectif {
+    cibleInterventions?: number | null;
+    cibleHeures?: number | null;
 }
 
 interface ObjectifsProps {
@@ -35,24 +40,33 @@ const isSameMonth = (value: string | undefined, year: number, month: number): bo
 // la date de fin si terminée, sinon la date planifiée / de début.
 const referenceDate = (t: PlanningItem) => t.dateFin || t.statusDate || t.datePlanification || t.dateDebut;
 
+const pct = (value: number, target: number) => (target > 0 ? Math.min(100, Math.round((value / target) * 100)) : 0);
+
 export default function Objectifs({ technicienId }: ObjectifsProps) {
     const [items, setItems] = useState<PlanningItem[]>([]);
+    const [objectif, setObjectif] = useState<Objectif>({});
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {
         let mounted = true;
-        const fetchItems = async () => {
+        const fetchData = async () => {
             setLoading(true);
             try {
-                const res = await api.get(`/technicien-portal/techniciens/${technicienId}/taches`);
-                if (mounted) setItems(res.data || []);
+                const [tachesRes, objectifRes] = await Promise.all([
+                    api.get(`/technicien-portal/techniciens/${technicienId}/taches`),
+                    api.get(`/technicien-portal/techniciens/${technicienId}/objectif`),
+                ]);
+                if (mounted) {
+                    setItems(tachesRes.data || []);
+                    setObjectif(objectifRes.data || {});
+                }
             } catch {
                 message.error('Erreur lors du chargement des objectifs');
             } finally {
                 if (mounted) setLoading(false);
             }
         };
-        fetchItems();
+        fetchData();
         return () => { mounted = false; };
     }, [technicienId]);
 
@@ -75,13 +89,39 @@ export default function Objectifs({ technicienId }: ObjectifsProps) {
             completionPct: total > 0 ? Math.round((done / total) * 100) : 0,
             heuresRealisees: Math.round(heuresRealisees * 100) / 100,
             heuresEstimees: Math.round(heuresEstimees * 100) / 100,
-            heuresPct: heuresEstimees > 0 ? Math.min(100, Math.round((heuresRealisees / heuresEstimees) * 100)) : 0,
         };
     }, [items]);
+
+    const cibleInterventions = objectif.cibleInterventions ?? undefined;
+    const cibleHeures = objectif.cibleHeures ?? undefined;
+    const hasCible = (cibleInterventions != null && cibleInterventions > 0)
+        || (cibleHeures != null && cibleHeures > 0);
+
+    // Interventions : progression vers la cible si définie, sinon part du mois réalisée.
+    const interventionsSuffix = cibleInterventions ? `/ ${cibleInterventions}` : `/ ${stats.total}`;
+    const interventionsPct = cibleInterventions
+        ? pct(stats.done, cibleInterventions)
+        : stats.completionPct;
+
+    // Heures : progression vers la cible si définie, sinon vs estimé du mois.
+    const heuresPct = cibleHeures
+        ? pct(stats.heuresRealisees, cibleHeures)
+        : pct(stats.heuresRealisees, stats.heuresEstimees);
+    const heuresHint = cibleHeures
+        ? `Objectif : ${cibleHeures} h`
+        : `Estimé : ${stats.heuresEstimees} h`;
 
     return (
         <Spin spinning={loading}>
             <Card title={`Mes objectifs — ${stats.monthLabel}`}>
+                {!hasCible && (
+                    <Alert
+                        type="info"
+                        showIcon
+                        style={{ marginBottom: 16 }}
+                        message="Aucun objectif n'a encore été défini par votre responsable. Les indicateurs ci-dessous reflètent votre activité du mois."
+                    />
+                )}
                 {stats.total === 0 ? (
                     <Empty description="Aucune intervention ce mois-ci" />
                 ) : (
@@ -91,10 +131,10 @@ export default function Objectifs({ technicienId }: ObjectifsProps) {
                                 <Statistic
                                     title="Interventions terminées"
                                     value={stats.done}
-                                    suffix={`/ ${stats.total}`}
+                                    suffix={interventionsSuffix}
                                     prefix={<CheckCircleOutlined />}
                                 />
-                                <Progress percent={stats.completionPct} status="active" />
+                                <Progress percent={interventionsPct} status="active" />
                             </Card>
                         </Col>
                         <Col xs={24} sm={8}>
@@ -102,13 +142,11 @@ export default function Objectifs({ technicienId }: ObjectifsProps) {
                                 <Statistic
                                     title="Heures réalisées"
                                     value={stats.heuresRealisees}
-                                    suffix="h"
+                                    suffix={cibleHeures ? `/ ${cibleHeures} h` : 'h'}
                                     prefix={<ClockCircleOutlined />}
                                 />
-                                <Progress percent={stats.heuresPct} />
-                                <div style={{ fontSize: 12, color: '#999', marginTop: 4 }}>
-                                    Estimé : {stats.heuresEstimees} h
-                                </div>
+                                <Progress percent={heuresPct} />
+                                <div style={{ fontSize: 12, color: '#999', marginTop: 4 }}>{heuresHint}</div>
                             </Card>
                         </Col>
                         <Col xs={24} sm={8}>


### PR DESCRIPTION
## Contexte

Closes #395

Ajout d'une section **« Mes objectifs »** sur l'UI technicien, avec des **cibles mensuelles configurables par le manager**.

## Solution

### Backend
- `TechnicienEntity` : deux nouveaux champs `cibleInterventions` (nb/mois) et `cibleHeures` (h/mois). Schéma auto-mis à jour par Hibernate (`schema-management.strategy=update`).
- `TechnicienResource` : mapping des cibles dans la mise à jour (le manager les édite via `PUT /techniciens/{id}`).
- `TechnicienPortalResource` : nouvel endpoint `GET /technicien-portal/techniciens/{id}/objectif` pour que le portail technicien lise ses cibles (toujours à jour, même si modifiées en cours de session).

### chantier-ui (manager)
- Fiche technicien : section « Objectifs mensuels » avec deux champs (cible interventions / mois, cible heures / mois).

### technicien-ui (technicien, lecture seule)
- Composant `objectifs.tsx` réutilisé en desktop (menu « Mes objectifs ») et mobile (onglet « Objectifs »).
- Indicateurs du mois courant calculés depuis les tâches (`/technicien-portal/.../taches`) :
  - **Interventions terminées** : réalisé / cible + barre de progression
  - **Heures réalisées** : réalisé / cible (rappel de la cible)
  - **Taux de complétion** du mois
- Si aucune cible n'est définie, l'interface retombe proprement sur l'activité du mois (réalisé / total, vs estimé) avec un message d'information.

## Vérification

- Backend : `mvn -pl backend -am compile` → OK
- `CI=true npm run build` (technicien-ui) → **Compiled successfully**
- `CI=true npm run build` (chantier-ui) → OK

## Plan de test

- [x] En tant que manager (chantier-ui), éditer un technicien et définir cible interventions / heures
- [x] En tant que technicien (desktop), ouvrir « Mes objectifs » → progression affichée vers les cibles
- [x] Vérifier que les compteurs correspondent aux tâches du mois
- [x] Sans cible définie → message d'information + indicateurs d'activité du mois
- [x] Sur mobile, vérifier l'onglet « Objectifs »