### PR TITLE
fix: placer la table des tâches à planifier sous le planning (#400)

### DIFF
--- a/chantier-ui/src/planning.tsx
+++ b/chantier-ui/src/planning.tsx
@@ -1154,6 +1154,42 @@ export default function Planning() {
                 </Col>
             </Row>
 
+            <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+                <Col span={24}>
+                    <Card
+                        title="A planifier (en attente)"
+                        size="small"
+                        bodyStyle={{ padding: pendingItems.length ? 12 : 24 }}
+                    >
+                        {pendingItems.length ? (
+                            <Table
+                                rowKey="key"
+                                loading={loading}
+                                dataSource={pendingItems}
+                                columns={pendingColumns}
+                                pagination={{ pageSize: 6 }}
+                                bordered
+                                onRow={(record) => ({
+                                    draggable: true,
+                                    style: { cursor: 'grab' },
+                                    onDragStart: (e) => {
+                                        draggedRowRef.current = record;
+                                        e.dataTransfer.effectAllowed = 'move';
+                                        e.dataTransfer.setData('text/plain', record.key);
+                                    },
+                                    onDragEnd: () => {
+                                        draggedRowRef.current = null;
+                                        setDragOverDay(null);
+                                    }
+                                })}
+                            />
+                        ) : (
+                            <Empty description="Aucun element en attente." />
+                        )}
+                    </Card>
+                </Col>
+            </Row>
+
             {lateItems.length > 0 && (
                 <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
                     <Col span={24}>
@@ -1217,42 +1253,6 @@ export default function Planning() {
                             />
                         ) : (
                             <Empty description="Aucun element planifie pour cette date." />
-                        )}
-                    </Card>
-                </Col>
-            </Row>
-
-            <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
-                <Col span={24}>
-                    <Card
-                        title="A planifier (en attente)"
-                        size="small"
-                        bodyStyle={{ padding: pendingItems.length ? 12 : 24 }}
-                    >
-                        {pendingItems.length ? (
-                            <Table
-                                rowKey="key"
-                                loading={loading}
-                                dataSource={pendingItems}
-                                columns={pendingColumns}
-                                pagination={{ pageSize: 6 }}
-                                bordered
-                                onRow={(record) => ({
-                                    draggable: true,
-                                    style: { cursor: 'grab' },
-                                    onDragStart: (e) => {
-                                        draggedRowRef.current = record;
-                                        e.dataTransfer.effectAllowed = 'move';
-                                        e.dataTransfer.setData('text/plain', record.key);
-                                    },
-                                    onDragEnd: () => {
-                                        draggedRowRef.current = null;
-                                        setDragOverDay(null);
-                                    }
-                                })}
-                            />
-                        ) : (
-                            <Empty description="Aucun element en attente." />
                         )}
                     </Card>
                 </Col>


### PR DESCRIPTION
## Contexte

Closes #400

Sur la vue planning, la table « A planifier (en attente) » — la **source** du glisser-déposer — était affichée tout en bas, sous les tableaux « En retard », « En cours » et « Planifié ». Elle était donc éloignée de la grille du planning (la **cible** du dépôt), ce qui compliquait le drag & drop (obligé de scroller).

## Correctif

La table « A planifier (en attente) » est déplacée **directement sous la grille du planning**, pour que la source et la cible du glisser-déposer soient visibles ensemble.

Frontend uniquement (`chantier-ui/src/planning.tsx`) — simple relocalisation du bloc, aucune logique modifiée.

Nouvel ordre des sections : Planning (grille) → **A planifier** → En retard → En cours → Planifié → Terminées.

## Vérification

- `CI=true npm run build` → OK (diff net ~0, le bloc est seulement déplacé).

## Plan de test

- [x] Ouvrir Atelier → Planning
- [x] Vérifier que la table « A planifier » est juste sous la grille hebdomadaire
- [x] Glisser une tâche depuis la table vers un créneau du planning → le drop fonctionne