### PR TITLE
feat: retirer prix public/frais et déplacer les taux vers le fournisseur (#393)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/BateauCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/BateauCatalogueEntity.java
@@ -72,14 +72,6 @@ public class BateauCatalogueEntity extends PanacheEntity {
 
     public String emplacement;
 
-    public double prixPublic;
-
-    public double frais;
-
-    public double tauxMarge;
-
-    public double tauxMarque;
-
     public double prixVenteHT;
 
     public double tva;

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurBateauEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurBateauEntity.java
@@ -27,6 +27,12 @@ public class FournisseurBateauEntity extends PanacheEntity {
     
     public int nombreMinACommander;
 
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarge;
+
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarque;
+
     public String notes;
 
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurHeliceEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurHeliceEntity.java
@@ -27,5 +27,11 @@ public class FournisseurHeliceEntity extends PanacheEntity {
     
     public int nombreMinACommander;
 
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarge;
+
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarque;
+
     public String notes;
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurMoteurEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurMoteurEntity.java
@@ -27,5 +27,11 @@ public class FournisseurMoteurEntity extends PanacheEntity {
 
     public int nombreMinACommander;
 
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarge;
+
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarque;
+
     public String notes;
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurProduitEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurProduitEntity.java
@@ -29,4 +29,10 @@ public class FournisseurProduitEntity extends PanacheEntity {
 
     public int nombreMinACommander;
 
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarge;
+
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarque;
+
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurRemorqueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurRemorqueEntity.java
@@ -27,5 +27,11 @@ public class FournisseurRemorqueEntity extends PanacheEntity {
 
     public int nombreMinACommander;
 
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarge;
+
+    @jakarta.persistence.Column(columnDefinition = "double default 0")
+    public double tauxMarque;
+
     public String notes;
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/HeliceCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/HeliceCatalogueEntity.java
@@ -43,14 +43,6 @@ public class HeliceCatalogueEntity extends PanacheEntity {
     @JsonbTransient
     public List<MoteurCatalogueEntity> moteursCompatibles = new ArrayList<>();
 
-    public double prixPublic;   
-
-    public double frais;
-
-    public double tauxMarge;
-
-    public double tauxMarque;
-
     public double prixVenteHT;
 
     public double tva;

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/MoteurCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/MoteurCatalogueEntity.java
@@ -70,14 +70,6 @@ public class MoteurCatalogueEntity extends PanacheEntity {
 
     public String emplacement;
 
-    public double prixPublic;
-
-    public double frais;
-
-    public double tauxMarge;
-
-    public double tauxMarque;
-
     public double prixVenteHT;
 
     public double tva;

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/ProduitCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/ProduitCatalogueEntity.java
@@ -40,14 +40,6 @@ public class ProduitCatalogueEntity extends PanacheEntity {
 
     public String emplacement;
 
-    public double prixPublic;
-
-    public double frais;
-
-    public double tauxMarge;
-
-    public double tauxMarque;
-
     public double prixVenteHT;
 
     public double tva;

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/RemorqueCatalogueEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/RemorqueCatalogueEntity.java
@@ -56,14 +56,6 @@ public class RemorqueCatalogueEntity extends PanacheEntity {
 
     public String emplacement;
 
-    public double prixPublic;
-
-    public double frais;
-
-    public double tauxMarge;
-
-    public double tauxMarque;
-
     public double prixVenteHT;
 
     public double tva;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/BateauCatalogueResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/BateauCatalogueResource.java
@@ -85,10 +85,6 @@ public class BateauCatalogueResource {
         entity.stock = updatedBateauCatalogue.stock;
         entity.stockAlerte = updatedBateauCatalogue.stockAlerte;
         entity.emplacement = updatedBateauCatalogue.emplacement;
-        entity.prixPublic = updatedBateauCatalogue.prixPublic;
-        entity.frais = updatedBateauCatalogue.frais;
-        entity.tauxMarge = updatedBateauCatalogue.tauxMarge;
-        entity.tauxMarque = updatedBateauCatalogue.tauxMarque;
         entity.prixVenteHT = updatedBateauCatalogue.prixVenteHT;
         entity.tva = updatedBateauCatalogue.tva;
         entity.montantTVA = updatedBateauCatalogue.montantTVA;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurBateauResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurBateauResource.java
@@ -111,6 +111,8 @@ public class FournisseurBateauResource {
         entity.portForfaitaire = updated.portForfaitaire;
         entity.portParUnite = updated.portParUnite;
         entity.nombreMinACommander = updated.nombreMinACommander;
+        entity.tauxMarge = updated.tauxMarge;
+        entity.tauxMarque = updated.tauxMarque;
         entity.notes = updated.notes;
         return entity;
     }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurHeliceResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurHeliceResource.java
@@ -136,6 +136,8 @@ public class FournisseurHeliceResource {
         entity.portForfaitaire = updated.portForfaitaire;
         entity.portParUnite = updated.portParUnite;
         entity.nombreMinACommander = updated.nombreMinACommander;
+        entity.tauxMarge = updated.tauxMarge;
+        entity.tauxMarque = updated.tauxMarque;
         entity.notes = updated.notes;
         return entity;
     }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurMoteurResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurMoteurResource.java
@@ -138,6 +138,8 @@ public class FournisseurMoteurResource {
         entity.portForfaitaire = updated.portForfaitaire;
         entity.portParUnite = updated.portParUnite;
         entity.nombreMinACommander = updated.nombreMinACommander;
+        entity.tauxMarge = updated.tauxMarge;
+        entity.tauxMarque = updated.tauxMarque;
         entity.notes = updated.notes;
         return entity;
     }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurProduitResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurProduitResource.java
@@ -142,6 +142,8 @@ public class FournisseurProduitResource {
         entity.portForfaitaire = updated.portForfaitaire;
         entity.portParUnite = updated.portParUnite;
         entity.nombreMinACommander = updated.nombreMinACommander;
+        entity.tauxMarge = updated.tauxMarge;
+        entity.tauxMarque = updated.tauxMarque;
         return entity;
     }
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurRemorqueResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurRemorqueResource.java
@@ -137,6 +137,8 @@ public class FournisseurRemorqueResource {
         entity.portForfaitaire = updated.portForfaitaire;
         entity.portParUnite = updated.portParUnite;
         entity.nombreMinACommander = updated.nombreMinACommander;
+        entity.tauxMarge = updated.tauxMarge;
+        entity.tauxMarque = updated.tauxMarque;
         entity.notes = updated.notes;
         return entity;
     }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/HeliceCatalogueResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/HeliceCatalogueResource.java
@@ -114,10 +114,6 @@ public class HeliceCatalogueResource {
         entity.pales = helice.pales;
         entity.cannelures = helice.cannelures;
         entity.moteursCompatibles = helice.moteursCompatibles;
-        entity.prixPublic = helice.prixPublic;
-        entity.frais = helice.frais;
-        entity.tauxMarge = helice.tauxMarge;
-        entity.tauxMarque = helice.tauxMarque;
         entity.prixVenteHT = helice.prixVenteHT;
         entity.tva = helice.tva;
         entity.montantTVA = helice.montantTVA;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/MoteurCatalogueResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/MoteurCatalogueResource.java
@@ -82,10 +82,6 @@ public class MoteurCatalogueResource {
         entity.stock = moteur.stock;
         entity.stockAlerte = moteur.stockAlerte;
         entity.emplacement = moteur.emplacement;
-        entity.prixPublic = moteur.prixPublic;
-        entity.frais = moteur.frais;
-        entity.tauxMarge = moteur.tauxMarge;
-        entity.tauxMarque = moteur.tauxMarque;
         entity.prixVenteHT = moteur.prixVenteHT;
         entity.tva = moteur.tva;
         entity.montantTVA = moteur.montantTVA;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ProduitCatalogueResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ProduitCatalogueResource.java
@@ -162,10 +162,6 @@ public class ProduitCatalogueResource {
         entity.stock = produit.stock;
         entity.stockMini = produit.stockMini;
         entity.emplacement = produit.emplacement;
-        entity.prixPublic = produit.prixPublic;
-        entity.frais = produit.frais;
-        entity.tauxMarge = produit.tauxMarge;
-        entity.tauxMarque = produit.tauxMarque;
         entity.prixVenteHT = produit.prixVenteHT;
         entity.tva = produit.tva;
         entity.montantTVA = produit.montantTVA;

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/RemorqueCatalogResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/RemorqueCatalogResource.java
@@ -119,10 +119,6 @@ public class RemorqueCatalogResource {
         entity.stock = remorque.stock;
         entity.stockAlerte = remorque.stockAlerte;
         entity.emplacement = remorque.emplacement;
-        entity.prixPublic = remorque.prixPublic;
-        entity.frais = remorque.frais;
-        entity.tauxMarge = remorque.tauxMarge;
-        entity.tauxMarque = remorque.tauxMarque;
         entity.prixVenteHT = remorque.prixVenteHT;
         entity.tva = remorque.tva;
         entity.montantTVA = remorque.montantTVA;

--- a/backend/src/test/resources/import-test.sql
+++ b/backend/src/test/resources/import-test.sql
@@ -18,20 +18,20 @@ INSERT INTO TechnicienEntity (id, nom, prenom, email, telephone, couleur, motDeP
 INSERT INTO FournisseurEntity (id, nom, email, telephone, adresse, evaluation) VALUES (100, 'Marine Parts SA', 'contact@marineparts.com', '0400001111', '5 zone portuaire', 4.0);
 
 -- Catalogue bateaux
-INSERT INTO BateauCatalogueEntity (id, modele, marque, type, description, evaluation, anneeDebut, anneeFin, longueurExterieure, largeur, poidsVide, stock, stockAlerte, prixPublic, prixVenteHT, tva, montantTVA, prixVenteTTC, frais, tauxMarge, tauxMarque, longueurCoque, hauteur, tirantAir, tirantEau, poidsMoteurMax, chargeMax, reservoirEau, reservoirCarburant, nombrePassagersMax) VALUES (100, 'Quicksilver 505', 'Quicksilver', 'Open', 'Bateau open polyvalent', 4.0, 2024, 2024, 5.05, 2.10, 650, 3, 1, 25000.0, 22000.0, 20.0, 4400.0, 26400.0, 500.0, 10.0, 9.0, 4.80, 1.50, 2.0, 0.5, 200.0, 800.0, 50.0, 100.0, 6);
+INSERT INTO BateauCatalogueEntity (id, modele, marque, type, description, evaluation, anneeDebut, anneeFin, longueurExterieure, largeur, poidsVide, stock, stockAlerte, prixVenteHT, tva, montantTVA, prixVenteTTC, longueurCoque, hauteur, tirantAir, tirantEau, poidsMoteurMax, chargeMax, reservoirEau, reservoirCarburant, nombrePassagersMax) VALUES (100, 'Quicksilver 505', 'Quicksilver', 'Open', 'Bateau open polyvalent', 4.0, 2024, 2024, 5.05, 2.10, 650, 3, 1, 22000.0, 20.0, 4400.0, 26400.0, 4.80, 1.50, 2.0, 0.5, 200.0, 800.0, 50.0, 100.0, 6);
 
 -- Catalogue moteurs (all primitive fields included)
-INSERT INTO MoteurCatalogueEntity (id, modele, marque, type, description, anneeDebut, anneeFin, puissanceCv, puissanceKw, arbre, cylindres, cylindree, evaluation, stock, stockAlerte, prixPublic, frais, tauxMarge, tauxMarque, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Mercury 115 EFI', 'Mercury', 'Hors-bord', 'Moteur 4 temps', NULL, NULL, 115, 85, 0, 4, 2100, 0, 5, 1, 12000.0, 0, 0, 0, 10000.0, 20.0, 2000.0, 12000.0);
+INSERT INTO MoteurCatalogueEntity (id, modele, marque, type, description, anneeDebut, anneeFin, puissanceCv, puissanceKw, arbre, cylindres, cylindree, evaluation, stock, stockAlerte, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Mercury 115 EFI', 'Mercury', 'Hors-bord', 'Moteur 4 temps', NULL, NULL, 115, 85, 0, 4, 2100, 0, 5, 1, 10000.0, 20.0, 2000.0, 12000.0);
 
 -- Catalogue helices (all primitive fields included)
-INSERT INTO HeliceCatalogueEntity (id, modele, marque, description, diametre, pales, cannelures, evaluation, prixPublic, frais, tauxMarge, tauxMarque, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Vengeance 14x19', 'Mercury', 'Helice inox', 14, 3, 15, 0, 350.0, 0, 0, 0, 300.0, 20.0, 60.0, 360.0);
+INSERT INTO HeliceCatalogueEntity (id, modele, marque, description, diametre, pales, cannelures, evaluation, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Vengeance 14x19', 'Mercury', 'Helice inox', 14, 3, 15, 0, 300.0, 20.0, 60.0, 360.0);
 
 -- Catalogue remorques (all primitive fields included)
-INSERT INTO RemorqueCatalogueEntity (id, modele, marque, description, evaluation, ptac, chargeAVide, chargeUtile, longueur, largeur, longueurMaxBateau, largeurMaxBateau, stock, stockAlerte, prixPublic, frais, tauxMarge, tauxMarque, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Sun Way 500', 'Sun Way', 'Remorque routiere', 0, 750, 200, 550, 600, 200, 500, 200, 2, 1, 2500.0, 0, 0, 0, 2000.0, 20.0, 400.0, 2400.0);
+INSERT INTO RemorqueCatalogueEntity (id, modele, marque, description, evaluation, ptac, chargeAVide, chargeUtile, longueur, largeur, longueurMaxBateau, largeurMaxBateau, stock, stockAlerte, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Sun Way 500', 'Sun Way', 'Remorque routiere', 0, 750, 200, 550, 600, 200, 500, 200, 2, 1, 2000.0, 20.0, 400.0, 2400.0);
 
 -- Catalogue produits (all primitive fields included)
-INSERT INTO ProduitCatalogueEntity (id, nom, marque, categorie, description, evaluation, stock, stockMini, prixPublic, frais, tauxMarge, tauxMarque, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Huile moteur 4T', 'Motul', 'Entretien', 'Huile marine 4 temps', 0, 50, 10, 25.0, 0, 0, 0, 20.0, 20.0, 4.0, 24.0);
-INSERT INTO ProduitCatalogueEntity (id, nom, marque, categorie, description, evaluation, stock, stockMini, prixPublic, frais, tauxMarge, tauxMarque, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (101, 'Filtre a huile', 'Mercury', 'Entretien', 'Filtre compatible Mercury', 0, 2, 5, 15.0, 0, 0, 0, 12.0, 20.0, 2.4, 14.4);
+INSERT INTO ProduitCatalogueEntity (id, nom, marque, categorie, description, evaluation, stock, stockMini, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (100, 'Huile moteur 4T', 'Motul', 'Entretien', 'Huile marine 4 temps', 0, 50, 10, 20.0, 20.0, 4.0, 24.0);
+INSERT INTO ProduitCatalogueEntity (id, nom, marque, categorie, description, evaluation, stock, stockMini, prixVenteHT, tva, montantTVA, prixVenteTTC) VALUES (101, 'Filtre a huile', 'Mercury', 'Entretien', 'Filtre compatible Mercury', 0, 2, 5, 12.0, 20.0, 2.4, 14.4);
 
 -- Main d'oeuvres (all primitive fields included)
 INSERT INTO MainOeuvreEntity (id, reference, nom, description, prixHT, tva, montantTVA, prixTTC) VALUES (100, 'MO-001', 'Revision annuelle', 'Revision complete moteur', 150.0, 20.0, 30.0, 180.0);

--- a/chantier-ui/src/ForfaitFormModal.tsx
+++ b/chantier-ui/src/ForfaitFormModal.tsx
@@ -33,10 +33,6 @@ interface ProduitCatalogueEntity {
     stock?: number;
     stockMini?: number;
     emplacement?: string;
-    prixPublic?: number;
-    frais?: number;
-    tauxMarge?: number;
-    tauxMarque?: number;
     prixVenteHT?: number;
     tva?: number;
     montantTVA?: number;
@@ -57,7 +53,6 @@ interface MainOeuvreEntity {
 const defaultNewProduit = {
     nom: '', marque: '', categorie: '', ref: '', refs: [], images: [], description: '',
     evaluation: 0, stock: 0, stockMini: 0, emplacement: '',
-    prixPublic: 0, frais: 0, tauxMarge: 0, tauxMarque: 0,
     prixVenteHT: 0, tva: 20, montantTVA: 0, prixVenteTTC: 0,
 };
 
@@ -768,14 +763,6 @@ export default function ForfaitFormModal({ open, onCancel, onCreated, preAssocia
                         <Col span={12}><Form.Item name="stockMini" label="Stock minimal d'alerte"><InputNumber min={0} step={1} style={{ width: '100%' }} /></Form.Item></Col>
                     </Row>
                     <Form.Item name="emplacement" label="Emplacement"><Input /></Form.Item>
-                    <Row gutter={16}>
-                        <Col span={12}><Form.Item name="prixPublic" label="Prix public"><InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" /></Form.Item></Col>
-                        <Col span={12}><Form.Item name="frais" label="Frais"><InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" /></Form.Item></Col>
-                    </Row>
-                    <Row gutter={16}>
-                        <Col span={12}><Form.Item name="tauxMarge" label="Taux de marge (%)"><InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" /></Form.Item></Col>
-                        <Col span={12}><Form.Item name="tauxMarque" label="Taux de marque (%)"><InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" /></Form.Item></Col>
-                    </Row>
                     <Row gutter={16}>
                         <Col span={12}><Form.Item name="prixVenteHT" label="Prix de vente HT"><InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" /></Form.Item></Col>
                         <Col span={12}><Form.Item name="tva" label="TVA (%)"><InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" /></Form.Item></Col>

--- a/chantier-ui/src/catalogue-bateaux.tsx
+++ b/chantier-ui/src/catalogue-bateaux.tsx
@@ -77,10 +77,6 @@ const defaultBateau: BateauCatalogueEntity = {
     montantTVA: 0,
     prixVenteTTC: 0,
     prixVenteHT: 0,
-    tauxMarge: 0,
-    tauxMarque: 0,
-    prixPublic: 0,
-    frais: 0,
     stock: 0,
     stockAlerte: 0,
     emplacement: '',
@@ -573,30 +569,6 @@ const CatalogueBateaux: React.FC = () => {
                                 <Col span={12}>
                                     <Form.Item name="emplacement" label="Emplacement">
                                         <TextArea rows={3} placeholder="Emplacement du stock bateau" allowClear={true} />
-                                    </Form.Item>
-                                </Col>
-                            </Row>
-                            <Row gutter={16}>
-                                <Col span={12}>
-                                    <Form.Item name="prixPublic" label="Prix public">
-                                        <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-                                    </Form.Item>
-                                </Col>
-                                <Col span={12}>
-                                    <Form.Item name="frais" label="Frais">
-                                        <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-                                    </Form.Item>
-                                </Col>
-                            </Row>
-                            <Row gutter={16}>
-                                <Col span={12}>
-                                    <Form.Item name="tauxMarge" label="Taux de marge">
-                                        <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                                    </Form.Item>
-                                </Col>
-                                <Col span={12}>
-                                    <Form.Item name="tauxMarque" label="Taux de marque">
-                                        <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
                                     </Form.Item>
                                 </Col>
                             </Row>

--- a/chantier-ui/src/catalogue-helices.tsx
+++ b/chantier-ui/src/catalogue-helices.tsx
@@ -33,10 +33,6 @@ interface HeliceCatalogueEntity {
     anneeDebut?: number;
     anneeFin?: number;
     moteursCompatibles?: MoteurCatalogueEntity[];
-    prixPublic?: number;
-    frais?: number;
-    tauxMarge?: number;
-    tauxMarque?: number;
     prixVenteHT?: number;
     tva?: number;
     montantTVA?: number;
@@ -57,10 +53,6 @@ const defaultHelice: HeliceCatalogueEntity = {
     anneeDebut: new Date().getFullYear(),
     anneeFin: new Date().getFullYear(),
     moteursCompatibles: [],
-    prixPublic: 0,
-    frais: 0,
-    tauxMarge: 0,
-    tauxMarque: 0,
     prixVenteHT: 0,
     tva: 20,
     montantTVA: 0,
@@ -503,30 +495,6 @@ const HeliceCatalogueView: React.FC = () => {
                                     ))}
                                 </Select>
                             </Form.Item>
-                            <Row gutter={16}>
-                                <Col span={12}>
-                                    <Form.Item name="prixPublic" label="Prix Public">
-                                        <InputNumber min={0} step={0.01} addonAfter="€" style={{ width: '100%' }} />
-                                    </Form.Item>
-                                </Col>
-                                <Col span={12}>
-                                    <Form.Item name="frais" label="Frais">
-                                        <InputNumber min={0} step={0.01} addonAfter="€" style={{ width: '100%' }} />
-                                    </Form.Item>
-                                </Col>
-                            </Row>
-                            <Row gutter={16}>
-                                <Col span={12}>
-                                    <Form.Item name="tauxMarge" label="Taux Marge">
-                                        <InputNumber min={0} max={100} step={0.01} addonAfter="%" style={{ width: '100%' }} />
-                                    </Form.Item>
-                                </Col>
-                                <Col span={12}>
-                                    <Form.Item name="tauxMarque" label="Taux Marque">
-                                        <InputNumber min={0} max={100} step={0.01} addonAfter="%" style={{ width: '100%' }} />
-                                    </Form.Item>
-                                </Col>
-                            </Row>
                             <Row gutter={16}>
                                 <Col span={12}>
                                     <Form.Item name="prixVenteHT" label="Prix Vente HT">

--- a/chantier-ui/src/catalogue-moteurs.tsx
+++ b/chantier-ui/src/catalogue-moteurs.tsx
@@ -47,10 +47,6 @@ interface Moteur {
   stock: number;
   stockAlerte: number;
   emplacement: string;
-  prixPublic: number;
-  frais: number;
-  tauxMarge: number;
-  tauxMarque: number;
   prixVenteHT: number;
   tva: number;
   montantTVA: number;
@@ -81,10 +77,6 @@ const defaultMoteur: Moteur = {
   stock: 0,
   stockAlerte: 0,
   emplacement: '',
-  prixPublic: 0,
-  frais: 0,
-  tauxMarge: 0,
-  tauxMarque: 0,
   prixVenteHT: 0,
   tva: 20,
   montantTVA: 0,
@@ -601,30 +593,6 @@ const MoteurCatalogue = () => {
               <Form.Item name="emplacement" label="Emplacement">
                 <Input />
               </Form.Item>
-              <Row gutter={16}>
-                <Col span={12}>
-                  <Form.Item name="prixPublic" label="Prix public">
-                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€"/>
-                  </Form.Item>
-                </Col>
-                <Col span={12}>
-                  <Form.Item name="frais" label="Frais">
-                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€"/>
-                  </Form.Item>
-                </Col>
-              </Row>
-              <Row gutter={16}>
-                <Col span={12}>
-                  <Form.Item name="tauxMarge" label="Taux de marge">
-                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                  </Form.Item>
-                </Col>
-                <Col span={12}>
-                  <Form.Item name="tauxMarque" label="Taux de marque">
-                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                  </Form.Item>
-                </Col>
-              </Row>
               <Row gutter={16}>
                 <Col span={12}>
                   <Form.Item name="prixVenteHT" label="Prix de vente HT">

--- a/chantier-ui/src/catalogue-produits.tsx
+++ b/chantier-ui/src/catalogue-produits.tsx
@@ -26,10 +26,6 @@ interface ProduitCatalogueEntity {
     stock?: number;
     stockMini?: number;
     emplacement?: string;
-    prixPublic?: number;
-    frais?: number;
-    tauxMarge?: number;
-    tauxMarque?: number;
     prixVenteHT?: number;
     tva?: number;
     montantTVA?: number;
@@ -51,10 +47,6 @@ const defaultProduit: ProduitCatalogueEntity = {
     stock: 0,
     stockMini: 0,
     emplacement: '',
-    prixPublic: 0,
-    frais: 0,
-    tauxMarge: 0,
-    tauxMarque: 0,
     prixVenteHT: 0,
     tva: 20,
     montantTVA: 0,
@@ -415,30 +407,6 @@ const CatalogueProduits: React.FC = () => {
                                 <Form.Item name="emplacement" label="Emplacement">
                                     <Input />
                                 </Form.Item>
-                                <Row gutter={16}>
-                                    <Col span={12}>
-                                        <Form.Item name="prixPublic" label="Prix public">
-                                            <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€"/>
-                                        </Form.Item>
-                                    </Col>
-                                    <Col span={12}>
-                                        <Form.Item name="frais" label="Frais">
-                                            <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€"/>
-                                        </Form.Item>
-                                    </Col>
-                                </Row>
-                                <Row gutter={16}>
-                                    <Col span={12}>
-                                        <Form.Item name="tauxMarge" label="Taux de marge (%)">
-                                            <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                                        </Form.Item>
-                                    </Col>
-                                    <Col span={12}>
-                                        <Form.Item name="tauxMarque" label="Taux de marque (%)">
-                                            <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                                        </Form.Item>
-                                    </Col>
-                                </Row>
                                 <Row gutter={16}>
                                     <Col span={12}>
                                         <Form.Item name="prixVenteHT" label="Prix de vente HT">

--- a/chantier-ui/src/catalogue-remorques.tsx
+++ b/chantier-ui/src/catalogue-remorques.tsx
@@ -49,10 +49,6 @@ const defaultRemorque = {
   stock: 0,
   stockAlerte: 0,
   emplacement: "",
-  prixPublic: 0,
-  frais: 0,
-  tauxMarge: 0,
-  tauxMarque: 0,
   prixVenteHT: 0,
   tva: 20,
   montantTVA: 0,
@@ -491,30 +487,6 @@ const RemorqueCatalogue: React.FC = () => {
             <Col span={12}>
               <Form.Item name="stockAlerte" label="Stock alerte">
                 <InputNumber min={0} style={{ width: "100%" }} />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} style={{ width: "100%" }} step={100} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} style={{ width: "100%" }} step={10} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} max={100} style={{ width: "100%" }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} max={100} style={{ width: "100%" }} addonAfter="%" />
               </Form.Item>
             </Col>
           </Row>

--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -902,30 +902,6 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
           </Row>
           <Row gutter={16}>
             <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
               <Form.Item name="prixVenteHT" label="Prix de vente HT">
                 <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
               </Form.Item>
@@ -1122,30 +1098,6 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
           <Form.Item name="emplacement" label="Emplacement">
             <Input />
           </Form.Item>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-          </Row>
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item name="prixVenteHT" label="Prix de vente HT">

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -719,30 +719,6 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
           </Form.Item>
           <Row gutter={16}>
             <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
               <Form.Item name="prixVenteHT" label="Prix de vente HT">
                 <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
               </Form.Item>

--- a/chantier-ui/src/clients-remorques.tsx
+++ b/chantier-ui/src/clients-remorques.tsx
@@ -665,30 +665,6 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
           </Row>
           <Row gutter={16}>
             <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} style={{ width: "100%" }} step={100} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} style={{ width: "100%" }} step={10} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} max={100} style={{ width: "100%" }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} max={100} style={{ width: "100%" }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
               <Form.Item name="prixVenteHT" label="Prix Vente HT">
                 <InputNumber min={0} style={{ width: "100%" }} step={100} addonAfter="€" />
               </Form.Item>

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -77,10 +77,6 @@ interface ProduitCatalogueEntity {
     stock?: number;
     stockMini?: number;
     emplacement?: string;
-    prixPublic?: number;
-    frais?: number;
-    tauxMarge?: number;
-    tauxMarque?: number;
     prixVenteHT?: number;
     tva?: number;
     montantTVA?: number;
@@ -128,10 +124,6 @@ const defaultNewProduit = {
     stock: 0,
     stockMini: 0,
     emplacement: '',
-    prixPublic: 0,
-    frais: 0,
-    tauxMarge: 0,
-    tauxMarque: 0,
     prixVenteHT: 0,
     tva: 20,
     montantTVA: 0,
@@ -2053,30 +2045,6 @@ export default function Comptoir() {
                         <Form.Item name="emplacement" label="Emplacement">
                             <Input />
                         </Form.Item>
-                        <Row gutter={16}>
-                            <Col span={12}>
-                                <Form.Item name="prixPublic" label="Prix public">
-                                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-                                </Form.Item>
-                            </Col>
-                            <Col span={12}>
-                                <Form.Item name="frais" label="Frais">
-                                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-                                </Form.Item>
-                            </Col>
-                        </Row>
-                        <Row gutter={16}>
-                            <Col span={12}>
-                                <Form.Item name="tauxMarge" label="Taux de marge (%)">
-                                    <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                                </Form.Item>
-                            </Col>
-                            <Col span={12}>
-                                <Form.Item name="tauxMarque" label="Taux de marque (%)">
-                                    <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                                </Form.Item>
-                            </Col>
-                        </Row>
                         <Row gutter={16}>
                             <Col span={12}>
                                 <Form.Item name="prixVenteHT" label="Prix de vente HT">

--- a/chantier-ui/src/forfaits.tsx
+++ b/chantier-ui/src/forfaits.tsx
@@ -47,10 +47,6 @@ interface ProduitCatalogueEntity {
     stock?: number;
     stockMini?: number;
     emplacement?: string;
-    prixPublic?: number;
-    frais?: number;
-    tauxMarge?: number;
-    tauxMarque?: number;
     prixVenteHT?: number;
     tva?: number;
     montantTVA?: number;
@@ -72,7 +68,6 @@ interface MainOeuvreEntity {
 const defaultNewProduit = {
     nom: '', marque: '', categorie: '', ref: '', refs: [], images: [], description: '',
     evaluation: 0, stock: 0, stockMini: 0, emplacement: '',
-    prixPublic: 0, frais: 0, tauxMarge: 0, tauxMarque: 0,
     prixVenteHT: 0, tva: 20, montantTVA: 0, prixVenteTTC: 0,
 };
 
@@ -1083,14 +1078,6 @@ export default function Forfaits() {
                             <Col span={12}><Form.Item name="stockMini" label="Stock minimal d'alerte"><InputNumber min={0} step={1} style={{ width: '100%' }} /></Form.Item></Col>
                         </Row>
                         <Form.Item name="emplacement" label="Emplacement"><Input /></Form.Item>
-                        <Row gutter={16}>
-                            <Col span={12}><Form.Item name="prixPublic" label="Prix public"><InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" /></Form.Item></Col>
-                            <Col span={12}><Form.Item name="frais" label="Frais"><InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" /></Form.Item></Col>
-                        </Row>
-                        <Row gutter={16}>
-                            <Col span={12}><Form.Item name="tauxMarge" label="Taux de marge (%)"><InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" /></Form.Item></Col>
-                            <Col span={12}><Form.Item name="tauxMarque" label="Taux de marque (%)"><InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" /></Form.Item></Col>
-                        </Row>
                         <Row gutter={16}>
                             <Col span={12}><Form.Item name="prixVenteHT" label="Prix de vente HT"><InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" /></Form.Item></Col>
                             <Col span={12}><Form.Item name="tva" label="TVA (%)"><InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" /></Form.Item></Col>

--- a/chantier-ui/src/fournisseur-bateaux.tsx
+++ b/chantier-ui/src/fournisseur-bateaux.tsx
@@ -59,10 +59,6 @@ const defaultBateauCatalogue = {
   montantTVA: 0,
   prixVenteTTC: 0,
   prixVenteHT: 0,
-  tauxMarge: 0,
-  tauxMarque: 0,
-  prixPublic: 0,
-  frais: 0,
   stock: 0,
   stockAlerte: 0,
   emplacement: '',
@@ -92,6 +88,8 @@ type FournisseurBateau = {
   portForfaitaire?: number;
   portParUnite?: number;
   nombreMinACommander?: number;
+  tauxMarge?: number;
+  tauxMarque?: number;
   notes?: string;
 }
 
@@ -103,6 +101,8 @@ const defaultFournisseurBateau: Partial<FournisseurBateau> = {
   portForfaitaire: 0,
   portParUnite: 0,
   nombreMinACommander: 1,
+  tauxMarge: 0,
+  tauxMarque: 0,
   notes: "",
 };
 
@@ -510,6 +510,18 @@ const FournisseurBateaux = ({ fournisseurId, bateauId }: { fournisseurId?: numbe
           </Row>
           <Row gutter={8}>
             <Col span={12}>
+              <Form.Item label="Taux de marge (%)" name="tauxMarge">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="Taux de marque (%)" name="tauxMarque">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={8}>
+            <Col span={12}>
               <Form.Item label="Port forfaitaire (€)" name="portForfaitaire">
                 <InputNumber min={0} style={{ width: "100%" }} />
               </Form.Item>
@@ -779,30 +791,6 @@ const FournisseurBateaux = ({ fournisseurId, bateauId }: { fournisseurId?: numbe
             <Col span={12}>
               <Form.Item name="emplacement" label="Emplacement">
                 <Input.TextArea rows={3} placeholder="Emplacement du stock bateau" allowClear={true} />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
               </Form.Item>
             </Col>
           </Row>

--- a/chantier-ui/src/fournisseur-helices.tsx
+++ b/chantier-ui/src/fournisseur-helices.tsx
@@ -43,10 +43,6 @@ const defaultHeliceCatalogue = {
   pales: 0,
   cannelures: 0,
   moteursCompatibles: [],
-  prixPublic: 0,
-  frais: 0,
-  tauxMarge: 0,
-  tauxMarque: 0,
   prixVenteHT: 0,
   tva: 20,
   montantTVA: 0,
@@ -75,6 +71,8 @@ type FournisseurHelice = {
   portForfaitaire?: number;
   portParUnite?: number;
   nombreMinACommander?: number;
+  tauxMarge?: number;
+  tauxMarque?: number;
   notes?: string;
 };
 
@@ -86,6 +84,8 @@ const defaultFournisseurHelice: Partial<FournisseurHelice> = {
   portForfaitaire: 0,
   portParUnite: 0,
   nombreMinACommander: 1,
+  tauxMarge: 0,
+  tauxMarque: 0,
   notes: "",
 };
 
@@ -539,6 +539,18 @@ const FournisseurHelices = ({
           </Row>
           <Row gutter={8}>
             <Col span={12}>
+              <Form.Item label="Taux de marge (%)" name="tauxMarge">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="Taux de marque (%)" name="tauxMarque">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={8}>
+            <Col span={12}>
               <Form.Item label="Port forfaitaire (€)" name="portForfaitaire">
                 <InputNumber min={0} style={{ width: "100%" }} />
               </Form.Item>
@@ -711,30 +723,6 @@ const FournisseurHelices = ({
           <Form.Item name="cannelures" label="Cannelures">
             <InputNumber min={0} style={{ width: '100%' }} />
           </Form.Item>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix Public">
-                <InputNumber min={0} step={0.01} addonAfter="€" style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} step={0.01} addonAfter="€" style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux Marge">
-                <InputNumber min={0} max={100} step={0.01} addonAfter="%" style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux Marque">
-                <InputNumber min={0} max={100} step={0.01} addonAfter="%" style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-          </Row>
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item name="prixVenteHT" label="Prix Vente HT">

--- a/chantier-ui/src/fournisseur-moteurs.tsx
+++ b/chantier-ui/src/fournisseur-moteurs.tsx
@@ -53,10 +53,6 @@ const defaultMoteurCatalogue = {
   stock: 0,
   stockAlerte: 0,
   emplacement: '',
-  prixPublic: 0,
-  frais: 0,
-  tauxMarge: 0,
-  tauxMarque: 0,
   prixVenteHT: 0,
   tva: 20,
   montantTVA: 0,
@@ -85,6 +81,8 @@ type FournisseurMoteur = {
   portForfaitaire?: number;
   portParUnite?: number;
   nombreMinACommander?: number;
+  tauxMarge?: number;
+  tauxMarque?: number;
   notes?: string;
 };
 
@@ -96,6 +94,8 @@ const defaultFournisseurMoteur: Partial<FournisseurMoteur> = {
   portForfaitaire: 0,
   portParUnite: 0,
   nombreMinACommander: 1,
+  tauxMarge: 0,
+  tauxMarque: 0,
   notes: "",
 };
 
@@ -599,6 +599,18 @@ const FournisseurMoteurs = ({
 
           <Row gutter={8}>
             <Col span={12}>
+              <Form.Item label="Taux de marge (%)" name="tauxMarge">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="Taux de marque (%)" name="tauxMarque">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={8}>
+            <Col span={12}>
               <Form.Item label="Port forfaitaire (€)" name="portForfaitaire">
                 <InputNumber min={0} style={{ width: "100%" }} />
               </Form.Item>
@@ -846,30 +858,6 @@ const FournisseurMoteurs = ({
           <Form.Item name="emplacement" label="Emplacement">
             <Input />
           </Form.Item>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-          </Row>
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item name="prixVenteHT" label="Prix de vente HT">

--- a/chantier-ui/src/fournisseur-produits.tsx
+++ b/chantier-ui/src/fournisseur-produits.tsx
@@ -47,10 +47,6 @@ const defaultProduitCatalogue = {
   stock: 0,
   stockMini: 0,
   emplacement: '',
-  prixPublic: 0,
-  frais: 0,
-  tauxMarge: 0,
-  tauxMarque: 0,
   prixVenteHT: 0,
   tva: 20,
   montantTVA: 0,
@@ -80,6 +76,8 @@ type FournisseurProduit = {
   portForfaitaire?: number;
   portParUnite?: number;
   nombreMinACommander?: number;
+  tauxMarge?: number;
+  tauxMarque?: number;
   delaiLivraison?: string;
   referenceFournisseur?: string;
   notes?: string;
@@ -93,6 +91,8 @@ const defaultFournisseurProduit: Partial<FournisseurProduit> = {
   portForfaitaire: 0,
   portParUnite: 0,
   nombreMinACommander: 1,
+  tauxMarge: 0,
+  tauxMarque: 0,
   delaiLivraison: "",
   referenceFournisseur: "",
   notes: "",
@@ -565,6 +565,18 @@ const FournisseurProduits = ({
           </Row>
           <Row gutter={8}>
             <Col span={12}>
+              <Form.Item label="Taux de marge (%)" name="tauxMarge">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="Taux de marque (%)" name="tauxMarque">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={8}>
+            <Col span={12}>
               <Form.Item label="Port forfaitaire (€)" name="portForfaitaire">
                 <InputNumber min={0} style={{ width: "100%" }} />
               </Form.Item>
@@ -774,30 +786,6 @@ const FournisseurProduits = ({
           <Form.Item name="emplacement" label="Emplacement">
             <Input />
           </Form.Item>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge (%)">
-                <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque (%)">
-                <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-          </Row>
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item name="prixVenteHT" label="Prix de vente HT">

--- a/chantier-ui/src/fournisseur-remorques.tsx
+++ b/chantier-ui/src/fournisseur-remorques.tsx
@@ -57,10 +57,6 @@ const defaultRemorqueCatalogue = {
   stock: 0,
   stockAlerte: 0,
   emplacement: "",
-  prixPublic: 0,
-  frais: 0,
-  tauxMarge: 0,
-  tauxMarque: 0,
   prixVenteHT: 0,
   tva: 20,
   montantTVA: 0,
@@ -89,6 +85,8 @@ type FournisseurRemorque = {
   portForfaitaire?: number;
   portParUnite?: number;
   nombreMinACommander?: number;
+  tauxMarge?: number;
+  tauxMarque?: number;
   notes?: string;
 };
 
@@ -100,6 +98,8 @@ const defaultFournisseurRemorque: Partial<FournisseurRemorque> = {
   portForfaitaire: 0,
   portParUnite: 0,
   nombreMinACommander: 1,
+  tauxMarge: 0,
+  tauxMarque: 0,
   notes: "",
 };
 
@@ -531,6 +531,18 @@ const FournisseurRemorques = ({
           </Row>
           <Row gutter={8}>
             <Col span={12}>
+              <Form.Item label="Taux de marge (%)" name="tauxMarge">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="Taux de marque (%)" name="tauxMarque">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={8}>
+            <Col span={12}>
               <Form.Item label="Port forfaitaire (€)" name="portForfaitaire">
                 <InputNumber min={0} style={{ width: "100%" }} />
               </Form.Item>
@@ -761,30 +773,6 @@ const FournisseurRemorques = ({
             <Col span={12}>
               <Form.Item name="stockAlerte" label="Stock alerte">
                 <InputNumber min={0} style={{ width: "100%" }} />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="prixPublic" label="Prix public">
-                <InputNumber min={0} style={{ width: "100%" }} step={100} addonAfter="€" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="frais" label="Frais">
-                <InputNumber min={0} style={{ width: "100%" }} step={10} addonAfter="€" />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item name="tauxMarge" label="Taux de marge">
-                <InputNumber min={0} max={100} style={{ width: "100%" }} addonAfter="%" />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item name="tauxMarque" label="Taux de marque">
-                <InputNumber min={0} max={100} style={{ width: "100%" }} addonAfter="%" />
               </Form.Item>
             </Col>
           </Row>

--- a/chantier-ui/src/services.tsx
+++ b/chantier-ui/src/services.tsx
@@ -80,7 +80,6 @@ const defaultNewMainOeuvre = {
 const defaultNewProduit = {
     nom: '', marque: '', categorie: '', ref: '', refs: [], images: [], description: '',
     evaluation: 0, stock: 0, stockMini: 0, emplacement: '',
-    prixPublic: 0, frais: 0, tauxMarge: 0, tauxMarque: 0,
     prixVenteHT: 0, tva: 20, montantTVA: 0, prixVenteTTC: 0,
 };
 

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -176,10 +176,6 @@ interface ProduitCatalogueEntity {
     stock?: number;
     stockMini?: number;
     emplacement?: string;
-    prixPublic?: number;
-    frais?: number;
-    tauxMarge?: number;
-    tauxMarque?: number;
     prixVenteHT?: number;
     tva?: number;
     montantTVA?: number;
@@ -228,10 +224,6 @@ const defaultNewProduit = {
     stock: 0,
     stockMini: 0,
     emplacement: '',
-    prixPublic: 0,
-    frais: 0,
-    tauxMarge: 0,
-    tauxMarque: 0,
     prixVenteHT: 0,
     tva: 20,
     montantTVA: 0,
@@ -3647,30 +3639,6 @@ export default function Vente() {
                         <Form.Item name="emplacement" label="Emplacement">
                             <Input />
                         </Form.Item>
-                        <Row gutter={16}>
-                            <Col span={12}>
-                                <Form.Item name="prixPublic" label="Prix public">
-                                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-                                </Form.Item>
-                            </Col>
-                            <Col span={12}>
-                                <Form.Item name="frais" label="Frais">
-                                    <InputNumber min={0} step={0.01} style={{ width: '100%' }} addonAfter="€" />
-                                </Form.Item>
-                            </Col>
-                        </Row>
-                        <Row gutter={16}>
-                            <Col span={12}>
-                                <Form.Item name="tauxMarge" label="Taux de marge (%)">
-                                    <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                                </Form.Item>
-                            </Col>
-                            <Col span={12}>
-                                <Form.Item name="tauxMarque" label="Taux de marque (%)">
-                                    <InputNumber min={0} max={100} step={0.01} style={{ width: '100%' }} addonAfter="%" />
-                                </Form.Item>
-                            </Col>
-                        </Row>
                         <Row gutter={16}>
                             <Col span={12}>
                                 <Form.Item name="prixVenteHT" label="Prix de vente HT">


### PR DESCRIPTION
## Contexte

Closes #393

Pour un article, supprimer les champs **prix public** et **frais**, et déplacer **taux de marge** / **taux de marque** vers le **fournisseur**. Appliqué aux 5 types : produit, bateau, moteur, hélice, remorque.

## Modifications

### Backend
- **5 entités catalogue** (`ProduitCatalogueEntity`, `BateauCatalogueEntity`, `MoteurCatalogueEntity`, `HeliceCatalogueEntity`, `RemorqueCatalogueEntity`) : suppression de `prixPublic`, `frais`, `tauxMarge`, `tauxMarque`.
- **5 resources catalogue** : suppression du mapping de ces champs.
- **5 entités fournisseur** (`FournisseurProduitEntity`, `FournisseurBateauEntity`, …) : ajout de `tauxMarge`, `tauxMarque` (`default 0`).
- **5 resources fournisseur** : mapping de `tauxMarge`/`tauxMarque`.
- `import-test.sql` : colonnes retirées des INSERT catalogue.

### Frontend
- **5 formulaires catalogue** : suppression des 4 champs.
- **5 formulaires fournisseur** : suppression des champs sur le formulaire d'article intégré + ajout de **taux de marge / taux de marque** sur le formulaire d'association fournisseur.
- **Formulaires de création rapide** d'articles (comptoir, prestation, clients bateaux/moteurs/remorques, forfaits, services, ForfaitFormModal) : suppression des 4 champs.

Le prix de vente HT/TTC reste saisi directement — aucun calcul ne dépendait des champs retirés.

## Vérification
- Backend : compile + **284/284 tests OK**.
- `CI=true npm run build` (chantier-ui) : OK.

## Plan de test
- [x] Créer/éditer un produit (et bateau/moteur/hélice/remorque) → plus de « prix public », « frais », « taux de marge », « taux de marque »
- [x] Associer un fournisseur à un article → champs « taux de marge » et « taux de marque » disponibles et persistés
- [x] Vérifier la création rapide d'un article depuis le comptoir / une prestation