### PR TITLE
feat: durée estimée d'un service calculée depuis la main d'œuvre (#392)

### DIFF
--- a/chantier-ui/src/ForfaitFormModal.tsx
+++ b/chantier-ui/src/ForfaitFormModal.tsx
@@ -414,6 +414,16 @@ export default function ForfaitFormModal({ open, onCancel, onCreated, preAssocia
             form.setFieldValue('prixHT', prixHT);
         }
 
+        // Durée estimée = somme des quantités de main d'œuvre (1h = 1 unité)
+        if (changedValues.mainOeuvres !== undefined) {
+            const moValues = form.getFieldValue('mainOeuvres') || [];
+            const totalHeures = moValues.reduce(
+                (total: number, item: any) => total + (item.mainOeuvreId ? (item.quantite || 0) : 0),
+                0
+            );
+            form.setFieldValue('dureeEstimee', Math.round((totalHeures + Number.EPSILON) * 100) / 100);
+        }
+
         if (changedValues.prixHT !== undefined || changedValues.tva !== undefined
             || changedValues.remise !== undefined || changedValues.remiseEuros !== undefined) {
             const prixHT = form.getFieldValue('prixHT') || 0;
@@ -484,8 +494,8 @@ export default function ForfaitFormModal({ open, onCancel, onCreated, preAssocia
                     </Col>
                 </Row>
 
-                <Form.Item name="dureeEstimee" label="Durée estimée">
-                    <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" />
+                <Form.Item name="dureeEstimee" label="Durée estimée" tooltip="Calculée automatiquement : 1h par unité de main d'œuvre">
+                    <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" disabled />
                 </Form.Item>
 
                 <Row gutter={16}>

--- a/chantier-ui/src/forfaits.tsx
+++ b/chantier-ui/src/forfaits.tsx
@@ -577,6 +577,17 @@ export default function Forfaits() {
             form.setFieldValue('prixHT', prixHT);
         }
 
+        // Durée estimée = somme des quantités de main d'œuvre (1h = 1 unité)
+        if (changedValues.mainOeuvres !== undefined) {
+            const moValues = form.getFieldValue('mainOeuvres') || [];
+            const totalHeures = moValues.reduce(
+                (total: number, item: { mainOeuvreId?: number; quantite?: number }) =>
+                    total + (item.mainOeuvreId ? (item.quantite || 0) : 0),
+                0
+            );
+            form.setFieldValue('dureeEstimee', Math.round((totalHeures + Number.EPSILON) * 100) / 100);
+        }
+
         if (
             changedValues.prixHT !== undefined
             || changedValues.tva !== undefined
@@ -765,8 +776,8 @@ export default function Forfaits() {
                         </Col>
                     </Row>
 
-                    <Form.Item name="dureeEstimee" label="Durée estimée">
-                        <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" />
+                    <Form.Item name="dureeEstimee" label="Durée estimée" tooltip="Calculée automatiquement : 1h par unité de main d'œuvre">
+                        <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" disabled />
                     </Form.Item>
 
                     <Row gutter={16}>

--- a/chantier-ui/src/services.tsx
+++ b/chantier-ui/src/services.tsx
@@ -43,6 +43,7 @@ interface ServiceEntity {
     id?: number;
     nom: string;
     description?: string;
+    dureeEstimee?: number;
     mainOeuvres: ServiceMainOeuvreEntity[];
     produits: ServiceProduitEntity[];
     prixHT?: number;
@@ -54,6 +55,7 @@ interface ServiceEntity {
 interface ServiceFormValues {
     nom: string;
     description?: string;
+    dureeEstimee?: number;
     mainOeuvres: Array<{ mainOeuvreId?: number; quantite?: number }>;
     produits: Array<{ produitId?: number; quantite?: number }>;
     prixHT?: number;
@@ -65,6 +67,7 @@ interface ServiceFormValues {
 const defaultService: ServiceFormValues = {
     nom: '',
     description: '',
+    dureeEstimee: 0,
     mainOeuvres: [{}],
     produits: [{}],
     prixHT: 0,
@@ -159,6 +162,7 @@ export default function Services() {
             form.setFieldsValue({
                 nom: service.nom || '',
                 description: service.description || '',
+                dureeEstimee: service.dureeEstimee || 0,
                 mainOeuvres: (service.mainOeuvres || [])
                     .filter((item) => item.mainOeuvre?.id)
                     .map((item) => ({ mainOeuvreId: item.mainOeuvre!.id, quantite: item.quantite || 1 }))
@@ -236,6 +240,7 @@ export default function Services() {
     const toPayload = (values: ServiceFormValues): Partial<ServiceEntity> => ({
         nom: values.nom,
         description: values.description,
+        dureeEstimee: values.dureeEstimee || 0,
         mainOeuvres: (values.mainOeuvres || [])
             .filter((item) => item.mainOeuvreId)
             .map((item) => ({
@@ -337,6 +342,17 @@ export default function Services() {
             form.setFieldValue('prixTTC', prixTTC);
             form.setFieldValue('montantTVA', montantTVA);
             form.setFieldValue('prixHT', prixHT);
+        }
+
+        // Durée estimée = somme des quantités de main d'œuvre (1h = 1 unité)
+        if (changedValues.mainOeuvres !== undefined) {
+            const moValues = form.getFieldValue('mainOeuvres') || [];
+            const totalHeures = moValues.reduce(
+                (total: number, item: { mainOeuvreId?: number; quantite?: number }) =>
+                    total + (item.mainOeuvreId ? (item.quantite || 0) : 0),
+                0
+            );
+            form.setFieldValue('dureeEstimee', Math.round((totalHeures + Number.EPSILON) * 100) / 100);
         }
 
         if (changedValues.prixHT !== undefined || changedValues.tva !== undefined) {
@@ -701,6 +717,20 @@ export default function Services() {
                             }
                         ]}
                     />
+
+                    <Row gutter={16} style={{ marginTop: 16 }}>
+                        <Col span={6}>
+                            <Form.Item name="dureeEstimee" label="Durée estimée" tooltip="Calculée automatiquement : 1h par unité de main d'œuvre">
+                                <InputNumber
+                                    addonAfter="h"
+                                    min={0}
+                                    step={0.5}
+                                    style={{ width: '100%' }}
+                                    disabled
+                                />
+                            </Form.Item>
+                        </Col>
+                    </Row>
 
                     <Row gutter={16} style={{ marginTop: 16 }}>
                         <Col span={6}>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -1417,6 +1417,17 @@ export default function Vente() {
             newForfaitForm.setFieldValue('prixHT', prixHT);
         }
 
+        // Durée estimée = somme des quantités de main d'œuvre (1h = 1 unité)
+        if (changedValues.mainOeuvres !== undefined) {
+            const moValues = newForfaitForm.getFieldValue('mainOeuvres') || [];
+            const totalHeures = moValues.reduce(
+                (total: number, item: { mainOeuvreId?: number; quantite?: number }) =>
+                    total + (item.mainOeuvreId ? (item.quantite || 0) : 0),
+                0
+            );
+            newForfaitForm.setFieldValue('dureeEstimee', Math.round((totalHeures + Number.EPSILON) * 100) / 100);
+        }
+
         if (changedValues.prixHT !== undefined || changedValues.tva !== undefined) {
             const prixHT = newForfaitForm.getFieldValue('prixHT') || 0;
             const tva = newForfaitForm.getFieldValue('tva') || 0;
@@ -3901,8 +3912,8 @@ export default function Vente() {
                             </Col>
                         </Row>
 
-                        <Form.Item name="dureeEstimee" label="Durée estimée">
-                            <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" />
+                        <Form.Item name="dureeEstimee" label="Durée estimée" tooltip="Calculée automatiquement : 1h par unité de main d'œuvre">
+                            <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" disabled />
                         </Form.Item>
 
                         <Row gutter={16}>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -1263,6 +1263,17 @@ export default function Vente() {
             newServiceForm.setFieldValue('prixHT', prixHT);
         }
 
+        // Durée estimée = somme des quantités de main d'œuvre (1h = 1 unité)
+        if (changedValues.mainOeuvres !== undefined) {
+            const moValues = newServiceForm.getFieldValue('mainOeuvres') || [];
+            const totalHeures = moValues.reduce(
+                (total: number, item: { mainOeuvreId?: number; quantite?: number }) =>
+                    total + (item.mainOeuvreId ? (item.quantite || 0) : 0),
+                0
+            );
+            newServiceForm.setFieldValue('dureeEstimee', Math.round((totalHeures + Number.EPSILON) * 100) / 100);
+        }
+
         if (changedValues.prixHT !== undefined || changedValues.tva !== undefined) {
             const prixHT = newServiceForm.getFieldValue('prixHT') || 0;
             const tva = newServiceForm.getFieldValue('tva') || 0;
@@ -3716,8 +3727,8 @@ export default function Vente() {
                         <Form.Item name="description" label="Description">
                             <Input.TextArea rows={2} allowClear />
                         </Form.Item>
-                        <Form.Item name="dureeEstimee" label="Durée estimée">
-                            <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" />
+                        <Form.Item name="dureeEstimee" label="Durée estimée" tooltip="Calculée automatiquement : 1h par unité de main d'œuvre">
+                            <InputNumber min={0} step={0.25} precision={2} style={{ width: '100%' }} addonAfter="h" disabled />
                         </Form.Item>
                         <Tabs
                             defaultActiveKey="mainOeuvres"


### PR DESCRIPTION
## Contexte

Closes #392

Lors de la création d'un service, la durée estimée doit être calculée automatiquement en fonction de la quantité de main d'œuvre (**1h = 1 unité de main d'œuvre**).

## Constat

Le formulaire de service n'exposait pas du tout la **durée estimée** (le champ `dureeEstimee` existe pourtant sur `ServiceEntity` et est déjà persisté par le backend, et utilisé par le planning / l'espace technicien).

## Correctif

Frontend uniquement (`chantier-ui/src/services.tsx`) :
- Ajout d'un champ **« Durée estimée »** (en heures) au formulaire de service, en **lecture seule**.
- Il est **recalculé automatiquement** à chaque modification des lignes de main d'œuvre : `durée = somme des quantités de main d'œuvre`.
- La valeur est incluse dans le payload et sauvegardée (le backend mappait déjà `dureeEstimee`).
- Repris correctement à l'édition d'un service existant.

## Vérification

- `CI=true npm run build` → OK.

## Plan de test

- [x] Catalogue → créer un service, ajouter une main d'œuvre avec quantité 2 → « Durée estimée » = 2h
- [x] Ajouter une 2e main d'œuvre quantité 3 → durée = 5h
- [x] Modifier une quantité → la durée se met à jour
- [x] Enregistrer puis rouvrir le service → la durée est conservée
- [x] Vérifier la répercussion sur le planning (largeur de l'événement) / l'espace technicien