### PR TITLE
feat: boutons « Ajouter Forfait » / « Ajouter Service » sur une prestation (#391)

### DIFF
--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -3224,7 +3224,7 @@ export default function Vente() {
                                                     </Space>
                                                     );
                                                 })}
-                                                <Space style={{ marginTop: -12, marginBottom: 16 }}>
+                                                <Space style={{ marginTop: -12, marginBottom: 16, marginLeft: 16 }}>
                                                     <Button icon={<PlusOutlined />} onClick={() => openNewForfaitModal(findOrCreateEmptyLineIndex())}>
                                                         Ajouter Forfait
                                                     </Button>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -3224,7 +3224,7 @@ export default function Vente() {
                                                     </Space>
                                                     );
                                                 })}
-                                                <Space style={{ marginTop: 8 }}>
+                                                <Space style={{ marginTop: -4 }}>
                                                     <Button icon={<PlusOutlined />} onClick={() => openNewForfaitModal(findOrCreateEmptyLineIndex())}>
                                                         Ajouter Forfait
                                                     </Button>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -1054,6 +1054,19 @@ export default function Vente() {
         setNewProduitModalVisible(true);
     };
 
+    // Renvoie l'index de la premiere ligne vide (sans type ni article), en en creant une si besoin.
+    // Utilise par les boutons « Ajouter Forfait » / « Ajouter Service » sous la liste des lignes.
+    const findOrCreateEmptyLineIndex = (): number => {
+        const currentLines: LigneUnifiee[] = form.getFieldValue('lignes') || [];
+        const emptyIndex = currentLines.findIndex((l) => !l?.type && !l?.itemId);
+        if (emptyIndex >= 0) {
+            return emptyIndex;
+        }
+        const updated = [...currentLines, { quantite: 1 }];
+        form.setFieldValue('lignes', updated);
+        return updated.length - 1;
+    };
+
     const handleNewProduitSave = async () => {
         try {
             const values = await newProduitForm.validateFields();
@@ -3191,18 +3204,7 @@ export default function Vente() {
                                                             </>
                                                         )}
                                                         {isEmptyLine ? (
-                                                            <Dropdown
-                                                                menu={{
-                                                                    items: [
-                                                                        { key: 'forfait', label: 'Forfait', onClick: () => openNewForfaitModal(field.name) },
-                                                                        { key: 'service', label: 'Service', onClick: () => openNewServiceModal(field.name) },
-                                                                        { key: 'produit', label: 'Produit', onClick: () => openNewProduitModal(field.name) },
-                                                                    ],
-                                                                }}
-                                                                trigger={['click']}
-                                                            >
-                                                                <Button icon={<PlusOutlined />} title="Créer..." />
-                                                            </Dropdown>
+                                                            <Button icon={<PlusOutlined />} title="Créer un produit" onClick={() => openNewProduitModal(field.name)} />
                                                         ) : (
                                                             <>
                                                                 {lineType === 'service' && itemId && (
@@ -3222,6 +3224,14 @@ export default function Vente() {
                                                     </Space>
                                                     );
                                                 })}
+                                                <Space style={{ marginTop: 8 }}>
+                                                    <Button icon={<PlusOutlined />} onClick={() => openNewForfaitModal(findOrCreateEmptyLineIndex())}>
+                                                        Ajouter Forfait
+                                                    </Button>
+                                                    <Button icon={<PlusOutlined />} onClick={() => openNewServiceModal(findOrCreateEmptyLineIndex())}>
+                                                        Ajouter Service
+                                                    </Button>
+                                                </Space>
                                             </>
                                         )}
                                     </Form.List>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -3224,7 +3224,7 @@ export default function Vente() {
                                                     </Space>
                                                     );
                                                 })}
-                                                <Space style={{ marginTop: -4 }}>
+                                                <Space style={{ marginTop: -12, marginBottom: 16 }}>
                                                     <Button icon={<PlusOutlined />} onClick={() => openNewForfaitModal(findOrCreateEmptyLineIndex())}>
                                                         Ajouter Forfait
                                                     </Button>


### PR DESCRIPTION
Closes #391

## Changements (formulaire de prestation / vente)

- Le bouton **« + »** au bout d'une ligne de vente ne crée désormais **qu'un produit** (`Créer un produit`), au lieu d'un menu déroulant Forfait/Service/Produit.
- Ajout de deux boutons **« Ajouter Forfait »** et **« Ajouter Service »** sous la liste des lignes, qui ouvrent respectivement les modales de création de forfait et de service.

Ces deux actions (création de forfait / service) qui étaient auparavant dans le menu déroulant de chaque ligne sont donc déplacées sous la liste ; la création cible la première ligne vide (ou en crée une).

Le comptoir crée déjà exclusivement des produits via son bouton « + », aucun changement nécessaire de ce côté.

## Vérification
- `CI=true npm run build` OK (seuls les warnings source-map @antv habituels).
- Vérification runtime non effectuée : la session chantier-ui a expiré (écran de login) et je ne peux pas saisir d'identifiants.