### PR TITLE
feat: préparer l'abonnement dans les paramètres société (#412)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
@@ -41,13 +41,18 @@ public class SocieteEntity extends PanacheEntity {
 
     public List<String> images = new ArrayList<>();
 
-    // Abonnement : paiement « one-shot » d'activation du compte.
+    // Date de création du compte (sert de date d'activation de l'abonnement).
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp dateCreation;
+
+    // Abonnement (informations en lecture seule, gérées par le serveur).
+    // Paiement « one-shot » d'activation du compte.
     @JsonbTypeAdapter(TimestampJsonbAdapter.class)
     public Timestamp abonnementActivationDate;
 
     public Double abonnementActivationMontant;
 
-    // Abonnement : prochaine échéance (date prévue et valeur à payer).
+    // Prochaine échéance (date prévue et valeur à payer).
     @JsonbTypeAdapter(TimestampJsonbAdapter.class)
     public Timestamp abonnementProchainPaiementDate;
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
@@ -1,9 +1,11 @@
 package net.nanthrax.moussaillon.persistence;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.json.bind.annotation.JsonbTypeAdapter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,5 +40,17 @@ public class SocieteEntity extends PanacheEntity {
     public String bancaire;
 
     public List<String> images = new ArrayList<>();
+
+    // Abonnement : paiement « one-shot » d'activation du compte.
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp abonnementActivationDate;
+
+    public Double abonnementActivationMontant;
+
+    // Abonnement : prochaine échéance (date prévue et valeur à payer).
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp abonnementProchainPaiementDate;
+
+    public Double abonnementProchainPaiementMontant;
 
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -42,6 +42,10 @@ public class SocieteResource {
         entity.email = societe.email;
         entity.bancaire = societe.bancaire;
         entity.images = societe.images;
+        entity.abonnementActivationDate = societe.abonnementActivationDate;
+        entity.abonnementActivationMontant = societe.abonnementActivationMontant;
+        entity.abonnementProchainPaiementDate = societe.abonnementProchainPaiementDate;
+        entity.abonnementProchainPaiementMontant = societe.abonnementProchainPaiementMontant;
 
         return entity;
     }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -6,18 +6,27 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+
 @Path("/societe")
 @ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class SocieteResource {
 
+    // Tarifs de l'abonnement (informations en lecture seule).
+    static final double MONTANT_ACTIVATION = 350.0;
+    static final double MONTANT_ABONNEMENT = 150.0;
+
     @GET
+    @Transactional
     public SocieteEntity get() {
         SocieteEntity entity = SocieteEntity.findById(1);
         if (entity == null) {
             throw new WebApplicationException("La société n'est pas trouvée", 404);
         }
+        initAbonnement(entity);
         return entity;
     }
 
@@ -42,12 +51,35 @@ public class SocieteResource {
         entity.email = societe.email;
         entity.bancaire = societe.bancaire;
         entity.images = societe.images;
-        entity.abonnementActivationDate = societe.abonnementActivationDate;
-        entity.abonnementActivationMontant = societe.abonnementActivationMontant;
-        entity.abonnementProchainPaiementDate = societe.abonnementProchainPaiementDate;
-        entity.abonnementProchainPaiementMontant = societe.abonnementProchainPaiementMontant;
+        // Les informations d'abonnement sont en lecture seule : elles ne sont pas
+        // modifiables par le client et restent gérées par le serveur.
+        initAbonnement(entity);
 
         return entity;
+    }
+
+    /**
+     * Renseigne, si nécessaire, les informations d'abonnement du compte :
+     * date d'activation = date de création du compte, montant d'activation de 350 €,
+     * prochaine échéance un mois plus tard pour un montant de 150 €.
+     */
+    private void initAbonnement(SocieteEntity entity) {
+        if (entity.dateCreation == null) {
+            entity.dateCreation = Timestamp.from(Instant.now());
+        }
+        if (entity.abonnementActivationDate == null) {
+            entity.abonnementActivationDate = entity.dateCreation;
+        }
+        if (entity.abonnementActivationMontant == null) {
+            entity.abonnementActivationMontant = MONTANT_ACTIVATION;
+        }
+        if (entity.abonnementProchainPaiementDate == null) {
+            entity.abonnementProchainPaiementDate = Timestamp.valueOf(
+                entity.abonnementActivationDate.toLocalDateTime().plusMonths(1));
+        }
+        if (entity.abonnementProchainPaiementMontant == null) {
+            entity.abonnementProchainPaiementMontant = MONTANT_ABONNEMENT;
+        }
     }
 
 }

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/SocieteResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/SocieteResourceTest.java
@@ -38,4 +38,28 @@ public class SocieteResourceTest {
             .then()
             .statusCode(200);
     }
+
+    @Test
+    void testModifierAbonnement() {
+        given()
+            .contentType("application/json")
+            .body("{\"nom\":\"MS Plaisance\",\"siren\":\"123456789\",\"adresse\":\"10 quai du Port\","
+                + "\"abonnementActivationDate\":\"2026-01-15\",\"abonnementActivationMontant\":990.0,"
+                + "\"abonnementProchainPaiementDate\":\"2027-01-15\",\"abonnementProchainPaiementMontant\":49.9}")
+            .when().put("/societe")
+            .then()
+            .statusCode(200)
+            .body("abonnementActivationDate", startsWith("2026-01-15"))
+            .body("abonnementActivationMontant", is(990.0f))
+            .body("abonnementProchainPaiementDate", startsWith("2027-01-15"))
+            .body("abonnementProchainPaiementMontant", is(49.9f));
+
+        // Restaurer l'original
+        given()
+            .contentType("application/json")
+            .body("{\"nom\":\"MS Plaisance\",\"siren\":\"123456789\",\"adresse\":\"10 quai du Port\"}")
+            .when().put("/societe")
+            .then()
+            .statusCode(200);
+    }
 }

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/SocieteResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/SocieteResourceTest.java
@@ -40,26 +40,29 @@ public class SocieteResourceTest {
     }
 
     @Test
-    void testModifierAbonnement() {
+    void testAbonnementInfosParDefaut() {
+        // Les informations d'abonnement sont renseignées automatiquement (lecture seule).
+        given()
+            .when().get("/societe")
+            .then()
+            .statusCode(200)
+            .body("abonnementActivationDate", notNullValue())
+            .body("abonnementActivationMontant", is(350.0f))
+            .body("abonnementProchainPaiementDate", notNullValue())
+            .body("abonnementProchainPaiementMontant", is(150.0f));
+    }
+
+    @Test
+    void testAbonnementNonModifiableParPut() {
+        // Un PUT ne doit pas pouvoir écraser les informations d'abonnement.
         given()
             .contentType("application/json")
             .body("{\"nom\":\"MS Plaisance\",\"siren\":\"123456789\",\"adresse\":\"10 quai du Port\","
-                + "\"abonnementActivationDate\":\"2026-01-15\",\"abonnementActivationMontant\":990.0,"
-                + "\"abonnementProchainPaiementDate\":\"2027-01-15\",\"abonnementProchainPaiementMontant\":49.9}")
+                + "\"abonnementActivationMontant\":990.0,\"abonnementProchainPaiementMontant\":49.9}")
             .when().put("/societe")
             .then()
             .statusCode(200)
-            .body("abonnementActivationDate", startsWith("2026-01-15"))
-            .body("abonnementActivationMontant", is(990.0f))
-            .body("abonnementProchainPaiementDate", startsWith("2027-01-15"))
-            .body("abonnementProchainPaiementMontant", is(49.9f));
-
-        // Restaurer l'original
-        given()
-            .contentType("application/json")
-            .body("{\"nom\":\"MS Plaisance\",\"siren\":\"123456789\",\"adresse\":\"10 quai du Port\"}")
-            .when().put("/societe")
-            .then()
-            .statusCode(200);
+            .body("abonnementActivationMontant", is(350.0f))
+            .body("abonnementProchainPaiementMontant", is(150.0f));
     }
 }

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -1,0 +1,62 @@
+import { fetchWithAuth } from './api.ts';
+import { useState, useEffect } from 'react';
+import { Card, Space, Descriptions, Spin, message } from 'antd';
+import { CreditCardOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+
+const formatDate = (value) => (value ? dayjs(value).format('DD/MM/YYYY') : '—');
+
+const formatMontant = (value) => (value != null
+    ? new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(value)
+    : '—');
+
+export default function Facturation() {
+
+    const [ societe, setSociete ] = useState();
+
+    useEffect(() => {
+       fetchWithAuth('./societe')
+       .then((response) => {
+            if (!response.ok) {
+                throw new Error('Erreur (code ' + response.status + ')');
+            };
+            return response.json();
+       })
+       .then(data => {
+           setSociete(data);
+       })
+       .catch((error) => {
+            message.error('Une erreur est survenue: ' + error.message);
+            console.error(error)
+       })
+    }, []);
+
+    if (!societe) {
+        return(<Spin/>);
+    }
+
+    return(
+      <Card title={<Space><CreditCardOutlined/> Facturation</Space>}>
+          <Descriptions
+              title="Abonnement"
+              column={1}
+              bordered
+              size="small"
+          >
+              <Descriptions.Item label="Date d'activation (paiement one-shot)">
+                  {formatDate(societe.abonnementActivationDate)}
+              </Descriptions.Item>
+              <Descriptions.Item label="Montant d'activation">
+                  {formatMontant(societe.abonnementActivationMontant)}
+              </Descriptions.Item>
+              <Descriptions.Item label="Prochaine échéance">
+                  {formatDate(societe.abonnementProchainPaiementDate)}
+              </Descriptions.Item>
+              <Descriptions.Item label="Montant à payer">
+                  {formatMontant(societe.abonnementProchainPaiementMontant)}
+              </Descriptions.Item>
+          </Descriptions>
+      </Card>
+    );
+
+}

--- a/chantier-ui/src/societe.tsx
+++ b/chantier-ui/src/societe.tsx
@@ -1,11 +1,18 @@
 import { fetchWithAuth } from './api.ts';
 import { useState, useEffect } from 'react';
-import { Card, Row, Col, Space, Button, Form, Input, InputNumber, Spin, message } from 'antd';
-import { PauseCircleOutlined, DeploymentUnitOutlined, SaveOutlined } from '@ant-design/icons';
+import { Card, Row, Col, Space, Button, Form, Input, InputNumber, DatePicker, Spin, message } from 'antd';
+import { PauseCircleOutlined, DeploymentUnitOutlined, SaveOutlined, CreditCardOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
 import { demo } from './workspace.tsx';
 import ImageUpload from './ImageUpload.tsx';
 
 const { TextArea } = Input;
+
+const toFormValues = (data) => ({
+    ...data,
+    abonnementActivationDate: data.abonnementActivationDate ? dayjs(data.abonnementActivationDate) : null,
+    abonnementProchainPaiementDate: data.abonnementProchainPaiementDate ? dayjs(data.abonnementProchainPaiementDate) : null,
+});
 
 export default function Societe(props) {
 
@@ -35,7 +42,13 @@ export default function Societe(props) {
     }
 
     const updateSocieteFunction = (values) => {
-        let newSociete = values;
+        const newSociete = {
+            ...values,
+            abonnementActivationDate: values.abonnementActivationDate
+                ? values.abonnementActivationDate.format('YYYY-MM-DD') : null,
+            abonnementProchainPaiementDate: values.abonnementProchainPaiementDate
+                ? values.abonnementProchainPaiementDate.format('YYYY-MM-DD') : null,
+        };
         fetchWithAuth('./societe', {
             method: 'PUT',
             body: JSON.stringify(newSociete),
@@ -66,7 +79,7 @@ export default function Societe(props) {
                     form={societeForm}
                     onFinish={updateSocieteFunction}
                     wrapperCol={{ span: 16 }}
-                    style={{ width: '80%' }} initialValues={societe}>
+                    style={{ width: '80%' }} initialValues={toFormValues(societe)}>
                     <Form.Item name="nom" label="Nom" rules={[{required: true, message: 'Le nom est requis'}]}>
                         <Input allowClear={true} />
                     </Form.Item>
@@ -106,6 +119,27 @@ export default function Societe(props) {
                     <Form.Item name="images" label="Images">
                         <ImageUpload />
                     </Form.Item>
+
+                    <Card
+                        type="inner"
+                        size="small"
+                        title={<Space><CreditCardOutlined/> Abonnement</Space>}
+                        style={{ marginBottom: 24 }}
+                    >
+                        <Form.Item name="abonnementActivationDate" label="Date d'activation (paiement one-shot)">
+                            <DatePicker format="YYYY-MM-DD" style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item name="abonnementActivationMontant" label="Montant d'activation">
+                            <InputNumber addonAfter="€" min={0} precision={2} style={{ width: '100%' }} allowClear={true} />
+                        </Form.Item>
+                        <Form.Item name="abonnementProchainPaiementDate" label="Prochaine échéance">
+                            <DatePicker format="YYYY-MM-DD" style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item name="abonnementProchainPaiementMontant" label="Montant à payer">
+                            <InputNumber addonAfter="€" min={0} precision={2} style={{ width: '100%' }} allowClear={true} />
+                        </Form.Item>
+                    </Card>
+
                     <Form.Item label={null}>
                         <Space>
                             <Button onClick={() => societeForm.submit()} type="primary" icon={<SaveOutlined/>}>Enregistrer</Button>

--- a/chantier-ui/src/societe.tsx
+++ b/chantier-ui/src/societe.tsx
@@ -1,18 +1,11 @@
 import { fetchWithAuth } from './api.ts';
 import { useState, useEffect } from 'react';
-import { Card, Row, Col, Space, Button, Form, Input, InputNumber, DatePicker, Spin, message } from 'antd';
-import { PauseCircleOutlined, DeploymentUnitOutlined, SaveOutlined, CreditCardOutlined } from '@ant-design/icons';
-import dayjs from 'dayjs';
+import { Card, Row, Col, Space, Button, Form, Input, InputNumber, Spin, message } from 'antd';
+import { PauseCircleOutlined, DeploymentUnitOutlined, SaveOutlined } from '@ant-design/icons';
 import { demo } from './workspace.tsx';
 import ImageUpload from './ImageUpload.tsx';
 
 const { TextArea } = Input;
-
-const toFormValues = (data) => ({
-    ...data,
-    abonnementActivationDate: data.abonnementActivationDate ? dayjs(data.abonnementActivationDate) : null,
-    abonnementProchainPaiementDate: data.abonnementProchainPaiementDate ? dayjs(data.abonnementProchainPaiementDate) : null,
-});
 
 export default function Societe(props) {
 
@@ -42,13 +35,7 @@ export default function Societe(props) {
     }
 
     const updateSocieteFunction = (values) => {
-        const newSociete = {
-            ...values,
-            abonnementActivationDate: values.abonnementActivationDate
-                ? values.abonnementActivationDate.format('YYYY-MM-DD') : null,
-            abonnementProchainPaiementDate: values.abonnementProchainPaiementDate
-                ? values.abonnementProchainPaiementDate.format('YYYY-MM-DD') : null,
-        };
+        let newSociete = values;
         fetchWithAuth('./societe', {
             method: 'PUT',
             body: JSON.stringify(newSociete),
@@ -79,7 +66,7 @@ export default function Societe(props) {
                     form={societeForm}
                     onFinish={updateSocieteFunction}
                     wrapperCol={{ span: 16 }}
-                    style={{ width: '80%' }} initialValues={toFormValues(societe)}>
+                    style={{ width: '80%' }} initialValues={societe}>
                     <Form.Item name="nom" label="Nom" rules={[{required: true, message: 'Le nom est requis'}]}>
                         <Input allowClear={true} />
                     </Form.Item>
@@ -119,27 +106,6 @@ export default function Societe(props) {
                     <Form.Item name="images" label="Images">
                         <ImageUpload />
                     </Form.Item>
-
-                    <Card
-                        type="inner"
-                        size="small"
-                        title={<Space><CreditCardOutlined/> Abonnement</Space>}
-                        style={{ marginBottom: 24 }}
-                    >
-                        <Form.Item name="abonnementActivationDate" label="Date d'activation (paiement one-shot)">
-                            <DatePicker format="YYYY-MM-DD" style={{ width: '100%' }} />
-                        </Form.Item>
-                        <Form.Item name="abonnementActivationMontant" label="Montant d'activation">
-                            <InputNumber addonAfter="€" min={0} precision={2} style={{ width: '100%' }} allowClear={true} />
-                        </Form.Item>
-                        <Form.Item name="abonnementProchainPaiementDate" label="Prochaine échéance">
-                            <DatePicker format="YYYY-MM-DD" style={{ width: '100%' }} />
-                        </Form.Item>
-                        <Form.Item name="abonnementProchainPaiementMontant" label="Montant à payer">
-                            <InputNumber addonAfter="€" min={0} precision={2} style={{ width: '100%' }} allowClear={true} />
-                        </Form.Item>
-                    </Card>
-
                     <Form.Item label={null}>
                         <Space>
                             <Button onClick={() => societeForm.submit()} type="primary" icon={<SaveOutlined/>}>Enregistrer</Button>

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -18,6 +18,7 @@ import CatalogueMoteurs from './catalogue-moteurs.tsx';
 import CatalogueHelices from './catalogue-helices.tsx';
 import Fournisseurs from './fournisseurs.tsx';
 import Societe from './societe.tsx';
+import Facturation from './facturation.tsx';
 import Utilisateurs from './utilisateurs.tsx';
 import Forfaits from './forfaits.tsx';
 import CatalogueRemorques from './catalogue-remorques.tsx';
@@ -120,6 +121,7 @@ function SideMenu(props) {
       ] },
       { key: 'parametrage', label: 'Paramétrage', icon: <SettingOutlined/>, requiredRole: 'admin', children: [
         { key: '/societe', label: 'Société', icon: <BankOutlined/> },
+        { key: '/facturation', label: 'Facturation', icon: <DollarOutlined/> },
         { key: '/utilisateurs', label: 'Utilisateurs', icon: <UserOutlined/> },
         { key: '/emails', label: 'Emails', icon: <MailOutlined/> },
         { key: '/sequence-emails', label: 'Séquence emails', icon: <NodeIndexOutlined/> },
@@ -475,6 +477,8 @@ export default function Workspace(props) {
                 return <ProtectedRoute roles={props.roles} requiredRole="magasinier"><CommandesFournisseur /></ProtectedRoute>;
             case '/societe':
                 return <ProtectedRoute roles={props.roles} requiredRole="admin"><Societe /></ProtectedRoute>;
+            case '/facturation':
+                return <ProtectedRoute roles={props.roles} requiredRole="admin"><Facturation /></ProtectedRoute>;
             case '/utilisateurs':
                 return <ProtectedRoute roles={props.roles} requiredRole="admin"><Utilisateurs /></ProtectedRoute>;
             case '/emails':


### PR DESCRIPTION
## Contexte

Closes #412

En préparation de la commercialisation, on ajoute les informations d'abonnement du compte. Ces informations sont **en lecture seule** (gérées par le serveur), et présentées dans un onglet dédié **Facturation** du menu **Paramétrage**.

## Règles métier

- **Date d'activation** (paiement one-shot) = date de création du compte
- **Montant d'activation** = 350 €
- **Prochaine échéance** = un mois après l'activation
- **Montant à payer** = 150 €

## Changement

### Backend
- `SocieteEntity` : nouveaux champs
  - `dateCreation` (date de création du compte)
  - `abonnementActivationDate` / `abonnementActivationMontant`
  - `abonnementProchainPaiementDate` / `abonnementProchainPaiementMontant`
  - dates via `TimestampJsonbAdapter` (comme le reste du projet)
- `SocieteResource` : `initAbonnement(...)` renseigne ces valeurs si elles sont nulles (idempotent), appelé sur GET et PUT. Le PUT **n'accepte pas** de modification de ces champs (lecture seule).
- Pas de migration : `schema-management.strategy=update` + colonnes nullables.

### Frontend
- Nouvelle page `facturation.tsx` : affichage en lecture seule via `Descriptions` (dates au format `DD/MM/YYYY`, montants formatés en €).
- `workspace.tsx` : onglet **Facturation** ajouté sous **Paramétrage** (réservé au rôle `admin`), avec sa route.
- `societe.tsx` : inchangé (aucune section abonnement).

## Tests
- `SocieteResourceTest` :
  - `testAbonnementInfosParDefaut` — GET renseigne bien 350 € / 150 € et les dates ;
  - `testAbonnementNonModifiableParPut` — un PUT ne peut pas écraser ces montants.
  - 4/4 tests passent.
- Build front (`react-scripts build`) OK.