### PR TITLE
feat: afficher les avoirs d'un client sur sa fiche (#411)

### DIFF
--- a/chantier-ui/src/clients-avoirs.tsx
+++ b/chantier-ui/src/clients-avoirs.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from "react";
+import { Table, Card, Space, Tag, Empty, message } from "antd";
+import { RollbackOutlined } from "@ant-design/icons";
+import api from "./api.ts";
+
+interface Avoir {
+  id?: number;
+  status?: string;
+  montantTTC?: number;
+  dateCreation?: string;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  BROUILLON: "Brouillon",
+  EMIS: "Émis",
+  REMBOURSE: "Remboursé",
+  ANNULE: "Annulé",
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  BROUILLON: "default",
+  EMIS: "blue",
+  REMBOURSE: "green",
+  ANNULE: "red",
+};
+
+const formatEuro = (value?: number) =>
+  `${(value ?? 0).toLocaleString("fr-FR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €`;
+
+const formatDate = (value?: string) => {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString("fr-FR");
+};
+
+function ClientsAvoirs({ clientId }: { clientId: number }) {
+  const [avoirs, setAvoirs] = useState<Avoir[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!clientId) return;
+    let cancelled = false;
+    setLoading(true);
+    api
+      .get(`/avoirs/search?clientId=${clientId}`)
+      .then((res) => {
+        if (!cancelled) setAvoirs(Array.isArray(res.data) ? res.data : []);
+      })
+      .catch(() => {
+        if (!cancelled) message.error("Erreur lors du chargement des avoirs");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId]);
+
+  const columns = [
+    {
+      title: "#",
+      dataIndex: "id",
+      width: 70,
+      sorter: (a: Avoir, b: Avoir) => (a.id || 0) - (b.id || 0),
+      render: (v: number) => `#${v}`,
+    },
+    {
+      title: "Prix",
+      dataIndex: "montantTTC",
+      align: "right" as const,
+      sorter: (a: Avoir, b: Avoir) => (a.montantTTC || 0) - (b.montantTTC || 0),
+      render: (v: number) => formatEuro(v),
+    },
+    {
+      title: "Date de création",
+      dataIndex: "dateCreation",
+      sorter: (a: Avoir, b: Avoir) => (a.dateCreation || "").localeCompare(b.dateCreation || ""),
+      render: (v: string) => formatDate(v),
+    },
+    {
+      title: "Statut",
+      dataIndex: "status",
+      width: 130,
+      sorter: (a: Avoir, b: Avoir) => (a.status || "").localeCompare(b.status || ""),
+      render: (v: string) => <Tag color={STATUS_COLOR[v] ?? "default"}>{STATUS_LABEL[v] ?? v}</Tag>,
+    },
+  ];
+
+  return (
+    <Card
+      size="small"
+      title={<Space><RollbackOutlined /> Avoirs</Space>}
+      styles={{ body: { padding: avoirs.length === 0 && !loading ? 24 : 0 } }}
+    >
+      <Table
+        rowKey="id"
+        size="small"
+        loading={loading}
+        dataSource={avoirs}
+        columns={columns}
+        pagination={false}
+        locale={{ emptyText: <Empty description="Aucun avoir pour ce client" image={Empty.PRESENTED_IMAGE_SIMPLE} /> }}
+      />
+    </Card>
+  );
+}
+
+export default ClientsAvoirs;

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -38,6 +38,7 @@ import api from "./api.ts";
 import BateauxClients from "./clients-bateaux.tsx";
 import ClientsMoteurs from "./clients-moteurs.tsx";
 import RemorquesClients from "./clients-remorques.tsx";
+import ClientsAvoirs from "./clients-avoirs.tsx";
 import DocumentUpload from "./DocumentUpload.tsx";
 import { useNavigation } from "./navigation-context.tsx";
 import HistoriqueOperations from "./historique-operations.tsx";
@@ -577,6 +578,8 @@ function Clients() {
             <RemorquesClients clientId={editing.id} />
             <Divider />
             <HistoriqueOperations clientId={editing.id} />
+            <Divider />
+            <ClientsAvoirs clientId={editing.id} />
           </>
         )}
       </Modal>


### PR DESCRIPTION
## Contexte

Closes #411

## Changement

### Nouveau composant `clients-avoirs.tsx`
- Charge les avoirs du client via `/avoirs/search?clientId=…` (endpoint existant, aucune modification backend).
- Affiche un tableau en lecture seule avec : numéro, prix TTC, date de création, statut.
- Annulation du fetch si le composant est démonté avant la réponse.

### `clients.tsx`
- Import de `ClientsAvoirs`.
- Section ajoutée en bas du modal client, après l'historique des opérations, séparée par un `Divider`.

## Tests
- Build `react-scripts build` OK, aucun warning sur les fichiers modifiés.

> Rebasée sur `main` : conflit résolu dans `clients.tsx` en conservant à la fois `HistoriqueOperations` (#417) et `ClientsAvoirs`.