### PR TITLE
feat: historique des 5 dernières opérations par client/bateau/moteur/remorque (#409)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/VenteResource.java
@@ -317,7 +317,11 @@ public class VenteResource {
     public List<VenteEntity> search(
             @QueryParam("status") String status,
             @QueryParam("clientId") Long clientId,
-            @QueryParam("comptoir") Boolean comptoir
+            @QueryParam("bateauId") Long bateauId,
+            @QueryParam("moteurId") Long moteurId,
+            @QueryParam("remorqueId") Long remorqueId,
+            @QueryParam("comptoir") Boolean comptoir,
+            @QueryParam("limit") Integer limit
     ) {
         VenteEntity.Status parsedStatus = parseStatus(status);
         StringBuilder query = new StringBuilder();
@@ -330,14 +334,33 @@ public class VenteResource {
             query.append(query.length() == 0 ? "" : " and ").append("client.id = ?").append(params.size() + 1);
             params.add(clientId);
         }
+        if (bateauId != null) {
+            query.append(query.length() == 0 ? "" : " and ").append("bateau.id = ?").append(params.size() + 1);
+            params.add(bateauId);
+        }
+        if (moteurId != null) {
+            query.append(query.length() == 0 ? "" : " and ").append("moteur.id = ?").append(params.size() + 1);
+            params.add(moteurId);
+        }
+        if (remorqueId != null) {
+            query.append(query.length() == 0 ? "" : " and ").append("remorque.id = ?").append(params.size() + 1);
+            params.add(remorqueId);
+        }
         if (comptoir != null) {
             query.append(query.length() == 0 ? "" : " and ").append("comptoir = ?").append(params.size() + 1);
             params.add(comptoir);
         }
+        io.quarkus.panache.common.Sort sort = io.quarkus.panache.common.Sort.by("date").descending();
+        List<VenteEntity> results;
         if (query.length() == 0) {
-            return VenteEntity.listAll();
+            results = VenteEntity.listAll(sort);
+        } else {
+            results = VenteEntity.list(query.toString(), sort, params.toArray());
         }
-        return VenteEntity.list(query.toString(), params.toArray());
+        if (limit != null && limit > 0 && results.size() > limit) {
+            return results.subList(0, limit);
+        }
+        return results;
     }
 
     @POST

--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -19,6 +19,7 @@ import {
   Col,
   DatePicker,
   Checkbox,
+  Divider,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -35,6 +36,7 @@ import DocumentUpload from './DocumentUpload.tsx';
 import dayjs from "dayjs";
 import LocationPicker from "./LocationPicker.tsx";
 import { useNavigation } from './navigation-context.tsx';
+import HistoriqueOperations from './historique-operations.tsx';
 
 const { Option } = Select;
 const { Search } = Input;
@@ -707,6 +709,12 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
             />
           </Form.Item>
         </Form>
+        {editing && editing.id && (
+          <>
+            <Divider />
+            <HistoriqueOperations bateauId={editing.id} />
+          </>
+        )}
       </Modal>
       <Modal
         open={catalogueModalVisible}

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -19,6 +19,7 @@ import {
   Col,
   DatePicker,
   Checkbox,
+  Divider,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -33,6 +34,7 @@ import ImageUpload from './ImageUpload.tsx';
 import DocumentUpload from './DocumentUpload.tsx';
 import dayjs from "dayjs";
 import { useNavigation } from './navigation-context.tsx';
+import HistoriqueOperations from './historique-operations.tsx';
 
 const { Option } = Select;
 const { Search } = Input;
@@ -541,6 +543,12 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
             <DocumentUpload />
           </Form.Item>
         </Form>
+        {editing && editing.id && (
+          <>
+            <Divider />
+            <HistoriqueOperations moteurId={editing.id} />
+          </>
+        )}
       </Modal>
       <Modal
         open={catalogueModalVisible}

--- a/chantier-ui/src/clients-remorques.tsx
+++ b/chantier-ui/src/clients-remorques.tsx
@@ -18,6 +18,7 @@ import {
   Col,
   DatePicker,
   Checkbox,
+  Divider,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -32,6 +33,7 @@ import ImageUpload from './ImageUpload.tsx';
 import DocumentUpload from './DocumentUpload.tsx';
 import dayjs from "dayjs";
 import { useNavigation } from './navigation-context.tsx';
+import HistoriqueOperations from './historique-operations.tsx';
 
 const { Option } = Select;
 const { Search } = Input;
@@ -506,6 +508,12 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
             </Space.Compact>
           </Form.Item>
         </Form>
+        {editing && editing.id && (
+          <>
+            <Divider />
+            <HistoriqueOperations remorqueId={editing.id} />
+          </>
+        )}
       </Modal>
       <Modal
         open={catalogueModalVisible}

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -40,6 +40,7 @@ import ClientsMoteurs from "./clients-moteurs.tsx";
 import RemorquesClients from "./clients-remorques.tsx";
 import DocumentUpload from "./DocumentUpload.tsx";
 import { useNavigation } from "./navigation-context.tsx";
+import HistoriqueOperations from "./historique-operations.tsx";
 
 const { Option } = Select;
 const { Search } = Input;
@@ -574,6 +575,8 @@ function Clients() {
             <ClientsMoteurs clientId={editing.id} />
             <Divider />
             <RemorquesClients clientId={editing.id} />
+            <Divider />
+            <HistoriqueOperations clientId={editing.id} />
           </>
         )}
       </Modal>

--- a/chantier-ui/src/historique-operations.tsx
+++ b/chantier-ui/src/historique-operations.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Table, Card, Space, Tag, Empty, message } from "antd";
-import { HistoryOutlined } from "@ant-design/icons";
+import { Table, Card, Space, Tag, Tooltip, Empty, message } from "antd";
+import { HistoryOutlined, WarningOutlined } from "@ant-design/icons";
 import api from "./api.ts";
 
 interface Operation {
@@ -11,10 +11,37 @@ interface Operation {
   type: "forfait" | "service";
   venteId: number;
   date?: string;
+  status?: string;
+  incidentDate?: string;
+  incidentDetails?: string;
 }
+
+const STATUS_LABEL: Record<string, string> = {
+  EN_ATTENTE: "En attente",
+  PLANIFIEE: "Planifiée",
+  EN_COURS: "En cours",
+  TERMINEE: "Terminée",
+  INCIDENT: "Incident",
+  ANNULEE: "Annulée",
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  EN_ATTENTE: "default",
+  PLANIFIEE: "blue",
+  EN_COURS: "processing",
+  TERMINEE: "success",
+  INCIDENT: "error",
+  ANNULEE: "warning",
+};
 
 const formatEuro = (value?: number) =>
   `${(value ?? 0).toLocaleString("fr-FR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €`;
+
+const formatDate = (value?: string) => {
+  if (!value) return "";
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? value : d.toLocaleDateString("fr-FR");
+};
 
 interface Props {
   clientId?: number;
@@ -57,6 +84,9 @@ function HistoriqueOperations({ clientId, bateauId, moteurId, remorqueId }: Prop
               type: "forfait",
               venteId: vente.id,
               date: vente.date,
+              status: vf.status ?? undefined,
+              incidentDate: vf.incidentDate ?? undefined,
+              incidentDetails: vf.incidentDetails ?? undefined,
             });
           }
           for (const vs of vente.venteServices ?? []) {
@@ -71,6 +101,9 @@ function HistoriqueOperations({ clientId, bateauId, moteurId, remorqueId }: Prop
               type: "service",
               venteId: vente.id,
               date: vente.date,
+              status: vs.status ?? undefined,
+              incidentDate: vs.incidentDate ?? undefined,
+              incidentDetails: vs.incidentDetails ?? undefined,
             });
           }
         }
@@ -99,6 +132,36 @@ function HistoriqueOperations({ clientId, bateauId, moteurId, remorqueId }: Prop
           {nom}
         </Space>
       ),
+    },
+    {
+      title: "Statut",
+      dataIndex: "status",
+      width: 120,
+      render: (v: string) =>
+        v ? (
+          <Tag color={STATUS_COLOR[v] ?? "default"}>{STATUS_LABEL[v] ?? v}</Tag>
+        ) : (
+          "—"
+        ),
+    },
+    {
+      title: "Incident",
+      key: "incident",
+      width: 90,
+      render: (_: unknown, r: Operation) => {
+        if (!r.incidentDate && !r.incidentDetails) return "—";
+        const label = r.incidentDate ? formatDate(r.incidentDate) : "Oui";
+        const tooltipContent = r.incidentDetails
+          ? `${label} — ${r.incidentDetails}`
+          : label;
+        return (
+          <Tooltip title={tooltipContent}>
+            <Tag icon={<WarningOutlined />} color="error" style={{ cursor: "help" }}>
+              {label}
+            </Tag>
+          </Tooltip>
+        );
+      },
     },
     {
       title: "Prix TTC",

--- a/chantier-ui/src/historique-operations.tsx
+++ b/chantier-ui/src/historique-operations.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from "react";
+import { Table, Card, Space, Tag, Empty, message } from "antd";
+import { HistoryOutlined } from "@ant-design/icons";
+import api from "./api.ts";
+
+interface Operation {
+  key: string;
+  nom: string;
+  prixTTC: number;
+  techniciens: string;
+  type: "forfait" | "service";
+  venteId: number;
+  date?: string;
+}
+
+const formatEuro = (value?: number) =>
+  `${(value ?? 0).toLocaleString("fr-FR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €`;
+
+interface Props {
+  clientId?: number;
+  bateauId?: number;
+  moteurId?: number;
+  remorqueId?: number;
+}
+
+function HistoriqueOperations({ clientId, bateauId, moteurId, remorqueId }: Props) {
+  const [operations, setOperations] = useState<Operation[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams({ limit: "5" });
+    if (clientId) params.set("clientId", String(clientId));
+    if (bateauId) params.set("bateauId", String(bateauId));
+    if (moteurId) params.set("moteurId", String(moteurId));
+    if (remorqueId) params.set("remorqueId", String(remorqueId));
+
+    if (!clientId && !bateauId && !moteurId && !remorqueId) return;
+
+    let cancelled = false;
+    setLoading(true);
+    api
+      .get(`/ventes/search?${params.toString()}`)
+      .then((res) => {
+        if (cancelled) return;
+        const ventes: any[] = Array.isArray(res.data) ? res.data : [];
+        const ops: Operation[] = [];
+        for (const vente of ventes) {
+          for (const vf of vente.venteForfaits ?? []) {
+            ops.push({
+              key: `f-${vente.id}-${vf.id ?? ops.length}`,
+              nom: vf.forfait?.nom ?? "(Sans nom)",
+              prixTTC: vf.forfait?.prixTTC ?? 0,
+              techniciens: (vf.techniciens ?? [])
+                .map((t: any) => `${t.prenom ?? ""} ${t.nom ?? ""}`.trim())
+                .filter(Boolean)
+                .join(", ") || "—",
+              type: "forfait",
+              venteId: vente.id,
+              date: vente.date,
+            });
+          }
+          for (const vs of vente.venteServices ?? []) {
+            ops.push({
+              key: `s-${vente.id}-${vs.id ?? ops.length}`,
+              nom: vs.service?.nom ?? "(Sans nom)",
+              prixTTC: vs.service?.prixTTC ?? 0,
+              techniciens: (vs.techniciens ?? [])
+                .map((t: any) => `${t.prenom ?? ""} ${t.nom ?? ""}`.trim())
+                .filter(Boolean)
+                .join(", ") || "—",
+              type: "service",
+              venteId: vente.id,
+              date: vente.date,
+            });
+          }
+        }
+        setOperations(ops.slice(0, 5));
+      })
+      .catch(() => {
+        if (!cancelled) message.error("Erreur lors du chargement de l'historique");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId, bateauId, moteurId, remorqueId]);
+
+  const columns = [
+    {
+      title: "Opération",
+      dataIndex: "nom",
+      render: (nom: string, r: Operation) => (
+        <Space>
+          <Tag color={r.type === "forfait" ? "purple" : "geekblue"}>
+            {r.type === "forfait" ? "Forfait" : "Service"}
+          </Tag>
+          {nom}
+        </Space>
+      ),
+    },
+    {
+      title: "Prix TTC",
+      dataIndex: "prixTTC",
+      align: "right" as const,
+      width: 110,
+      render: (v: number) => formatEuro(v),
+    },
+    {
+      title: "Technicien(s)",
+      dataIndex: "techniciens",
+    },
+    {
+      title: "Prestation",
+      dataIndex: "venteId",
+      width: 100,
+      render: (v: number) => `#${v}`,
+    },
+  ];
+
+  return (
+    <Card
+      size="small"
+      title={<Space><HistoryOutlined /> Historique (5 dernières opérations)</Space>}
+      styles={{ body: { padding: operations.length === 0 && !loading ? 24 : 0 } }}
+    >
+      <Table
+        rowKey="key"
+        size="small"
+        loading={loading}
+        dataSource={operations}
+        columns={columns}
+        pagination={false}
+        locale={{
+          emptyText: (
+            <Empty
+              description="Aucune opération enregistrée"
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          ),
+        }}
+      />
+    </Card>
+  );
+}
+
+export default HistoriqueOperations;


### PR DESCRIPTION
## Contexte

Closes #409

## Changement

### Backend — `VenteResource.search`
- Nouveaux `@QueryParam` : `bateauId`, `moteurId`, `remorqueId` (en plus du `clientId` existant).
- Nouveau `@QueryParam limit` : tronque la liste retournée (utilisé ici avec `limit=5`).
- Tri par `date DESC` ajouté (via `Sort.by("date").descending()`) afin de retourner les ventes les plus récentes en premier.

### Frontend — nouveau composant `historique-operations.tsx`
- Accepte l'un des props `clientId` / `bateauId` / `moteurId` / `remorqueId`.
- Charge les 5 dernières ventes via `/ventes/search?…&limit=5`, puis extrait et aplatit tous les forfaits et services de chaque vente.
- Affiche un tableau en lecture seule : type (Forfait / Service), nom, prix TTC, technicien(s), numéro de prestation.

### Intégration dans les 4 vues
| Fichier | Prop passé |
|---|---|
| `clients.tsx` | `clientId` |
| `clients-bateaux.tsx` | `bateauId` |
| `clients-moteurs.tsx` | `moteurId` |
| `clients-remorques.tsx` | `remorqueId` |

La section « Historique » est ajoutée en bas du modal, séparée par un `Divider`.

## Tests
- Backend compile (`mvn compile`) OK.
- Build front (`react-scripts build`) OK, aucun warning sur les fichiers modifiés.