### PR TITLE
fix: permettre de cliquer sur une ligne de remorque pour accéder à ses paramètres (#419)

### DIFF
--- a/chantier-ui/src/clients-remorques.tsx
+++ b/chantier-ui/src/clients-remorques.tsx
@@ -405,6 +405,13 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
           dataSource={remorques}
           bordered
           pagination={{ pageSize: 10 }}
+          onRow={(record) => ({
+            onClick: (e) => {
+              if ((e.target as HTMLElement).closest('button, .ant-btn, [role="button"]')) return;
+              handleEdit(record);
+            },
+            style: { cursor: 'pointer' },
+          })}
         />
       </Spin>
       <Modal


### PR DESCRIPTION
## Contexte

Closes #419

## Cause

La `Table` des remorques (`clients-remorques.tsx`) n'avait pas de prop `onRow`, contrairement aux tables bateaux et moteurs qui utilisent ce pattern depuis l'origine.

## Fix

Ajout du même `onRow` que bateaux/moteurs :
- clic sur la ligne → `handleEdit(record)`
- les clics sur les boutons d'action sont ignorés via `.closest('button, .ant-btn, [role="button"]')`
- curseur `pointer` sur les lignes