### PR TITLE
fix: corriger l'erreur lors de la création d'un incident sur une intervention (#418)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
@@ -413,7 +413,7 @@ public class TechnicienPortalResource {
         }
         if ("INCIDENT".equals(request.status)) {
             if (request.incidentDate != null && !request.incidentDate.isBlank()) {
-                vf.incidentDate = Date.valueOf(request.incidentDate);
+                vf.incidentDate = Date.valueOf(request.incidentDate.length() > 10 ? request.incidentDate.substring(0, 10) : request.incidentDate);
             }
             vf.incidentDetails = request.incidentDetails;
         }
@@ -485,7 +485,7 @@ public class TechnicienPortalResource {
         }
         if ("INCIDENT".equals(request.status)) {
             if (request.incidentDate != null && !request.incidentDate.isBlank()) {
-                vs.incidentDate = Date.valueOf(request.incidentDate);
+                vs.incidentDate = Date.valueOf(request.incidentDate.length() > 10 ? request.incidentDate.substring(0, 10) : request.incidentDate);
             }
             vs.incidentDetails = request.incidentDetails;
         }

--- a/technicien-ui/src/planning.tsx
+++ b/technicien-ui/src/planning.tsx
@@ -760,7 +760,7 @@ export default function Planning({ technicienId }: PlanningProps) {
                                         label="Date de l'incident"
                                         rules={[{ required: true, message: "La date de l'incident est requise" }]}
                                     >
-                                        <DatePicker showTime style={{ width: '100%' }} />
+                                        <DatePicker style={{ width: '100%' }} />
                                     </Form.Item>
                                     <Form.Item
                                         name="incidentDetails"


### PR DESCRIPTION
## Contexte

Closes #418

## Cause

Le `DatePicker` de la section incident avait `showTime`, ce qui faisait envoyer la date au format `YYYY-MM-DDTHH:mm:ss` (ex : `2026-07-04T09:30:00`). Le backend appelait `Date.valueOf(string)` qui n'accepte que le format `yyyy-MM-dd` strict — d'où une `IllegalArgumentException` remontant en 500 côté client.

## Fix

**Backend** (`TechnicienPortalResource`) — tronque la chaîne aux 10 premiers caractères avant `Date.valueOf` sur les deux méthodes (`updateForfaitItem` et `updateServiceItem`). Ainsi, tout format contenant une heure est toléré sans casser les envois déjà conformes.

**Frontend** (`technicien-ui/src/planning.tsx`) — retire `showTime` du `DatePicker` de l'incident. Le champ backend est `java.sql.Date` (date seule), l'heure n'a pas de sens ici.