### PR TITLE
feat: frais par défaut au niveau fournisseur

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/FournisseurEntity.java
@@ -35,4 +35,19 @@ public class FournisseurEntity extends PanacheEntity {
 
     public List<String> documents = new ArrayList<>();
 
+    @Column(columnDefinition = "double default 0")
+    public double portForfaitaireDefaut;
+
+    @Column(columnDefinition = "double default 0")
+    public double portParUniteDefaut;
+
+    @Column(columnDefinition = "integer default 1")
+    public int nombreMinACommanderDefaut = 1;
+
+    @Column(columnDefinition = "double default 0")
+    public double tauxMargeDefaut;
+
+    @Column(columnDefinition = "double default 0")
+    public double tauxMarqueDefaut;
+
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/FournisseurResource.java
@@ -82,6 +82,11 @@ public class FournisseurResource {
         entity.naf = fournisseur.naf;
         entity.connexion = fournisseur.connexion;
         entity.documents = fournisseur.documents;
+        entity.portForfaitaireDefaut = fournisseur.portForfaitaireDefaut;
+        entity.portParUniteDefaut = fournisseur.portParUniteDefaut;
+        entity.nombreMinACommanderDefaut = fournisseur.nombreMinACommanderDefaut;
+        entity.tauxMargeDefaut = fournisseur.tauxMargeDefaut;
+        entity.tauxMarqueDefaut = fournisseur.tauxMarqueDefaut;
 
         return entity;
     }

--- a/chantier-ui/src/fournisseur-produits.tsx
+++ b/chantier-ui/src/fournisseur-produits.tsx
@@ -56,6 +56,11 @@ const defaultProduitCatalogue = {
 type Fournisseur = {
   id: number;
   nom: string;
+  portForfaitaireDefaut?: number;
+  portParUniteDefaut?: number;
+  nombreMinACommanderDefaut?: number;
+  tauxMargeDefaut?: number;
+  tauxMarqueDefaut?: number;
 };
 
 type Produit = {
@@ -119,6 +124,8 @@ const FournisseurProduits = ({
   const [produitModalVisible, setProduitModalVisible] = useState(false);
   const [produitForm] = Form.useForm();
 
+  const [currentFournisseur, setCurrentFournisseur] = useState<Fournisseur | null>(null);
+
   const isProduitMode = !!produitId;
   const isFournisseurMode = !!fournisseurId;
 
@@ -173,6 +180,7 @@ const FournisseurProduits = ({
         fetchFournisseurs();
       } else {
         fetchProduits();
+        api.get(`/catalogue/fournisseurs/${fournisseurId}`).then(r => setCurrentFournisseur(r.data)).catch(() => {});
       }
     }
   }, [fournisseurId, produitId]);
@@ -225,10 +233,20 @@ const FournisseurProduits = ({
     }
   };
 
+  const defaultsFromFournisseur = (f: Fournisseur | null): Partial<FournisseurProduit> => ({
+    portForfaitaire: f?.portForfaitaireDefaut ?? 0,
+    portParUnite: f?.portParUniteDefaut ?? 0,
+    nombreMinACommander: f?.nombreMinACommanderDefaut ?? 1,
+    tauxMarge: f?.tauxMargeDefaut ?? 0,
+    tauxMarque: f?.tauxMarqueDefaut ?? 0,
+  });
+
   // Add
   const handleNew = () => {
+    const defaults = isFournisseurMode ? defaultsFromFournisseur(currentFournisseur) : {};
     setEditing({
       ...defaultFournisseurProduit,
+      ...defaults,
       fournisseur: isFournisseurMode ? { id: fournisseurId!, nom: "" } : undefined,
       produit: isProduitMode ? { id: produitId!, nom: "" } : undefined,
     });
@@ -441,13 +459,18 @@ const FournisseurProduits = ({
           initialValues={editing || defaultFournisseurProduit}
           onValuesChange={(changed, all) => {
             setFormDirty(true);
-            // Compute montantTVA et TTC dynamiquement
             if ("prixAchatHT" in changed || "tva" in changed) {
               let prixAchatHT = all.prixAchatHT ?? 0;
               let tva = all.tva ?? 20;
               let montantTVA = prixAchatHT * (tva / 100);
               let prixAchatTTC = prixAchatHT + montantTVA;
               form.setFieldsValue({ montantTVA, prixAchatTTC });
+            }
+            if ("fournisseurId" in changed && isProduitMode && !(editing && editing.id)) {
+              const selected = fournisseurs.find(f => f.id === changed.fournisseurId);
+              if (selected) {
+                form.setFieldsValue(defaultsFromFournisseur(selected));
+              }
             }
           }}
         >

--- a/chantier-ui/src/fournisseurs.tsx
+++ b/chantier-ui/src/fournisseurs.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   Form,
   Input,
+  InputNumber,
   Rate,
   Spin,
   Popconfirm,
@@ -14,6 +15,7 @@ import {
   Col,
   Card,
   Select,
+  Divider,
 } from "antd";
 import {
   EditOutlined,
@@ -49,6 +51,11 @@ type Fournisseur = {
   naf?: string;
   connexion?: string;
   documents?: string[];
+  portForfaitaireDefaut?: number;
+  portParUniteDefaut?: number;
+  nombreMinACommanderDefaut?: number;
+  tauxMargeDefaut?: number;
+  tauxMarqueDefaut?: number;
 };
 
 const defaultFournisseur: Fournisseur = {
@@ -64,6 +71,11 @@ const defaultFournisseur: Fournisseur = {
   naf: "",
   connexion: "",
   documents: [],
+  portForfaitaireDefaut: 0,
+  portParUniteDefaut: 0,
+  nombreMinACommanderDefaut: 1,
+  tauxMargeDefaut: 0,
+  tauxMarqueDefaut: 0,
 };
 
 const Fournisseurs = () => {
@@ -332,6 +344,36 @@ const Fournisseurs = () => {
             <Col span={12}>
               <Form.Item label="NAF" name="naf">
                 <Input />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Divider orientation="left" orientationMargin={0}>Frais par défaut</Divider>
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item label="Port forfaitaire par défaut (€)" name="portForfaitaireDefaut">
+                <InputNumber min={0} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="Port par unité par défaut (€)" name="portParUniteDefaut">
+                <InputNumber min={0} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={16}>
+            <Col span={8}>
+              <Form.Item label="Qte min. à commander par défaut" name="nombreMinACommanderDefaut">
+                <InputNumber min={1} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item label="Taux de marge par défaut (%)" name="tauxMargeDefaut">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item label="Taux de marque par défaut (%)" name="tauxMarqueDefaut">
+                <InputNumber min={0} max={100} style={{ width: "100%" }} />
               </Form.Item>
             </Col>
           </Row>


### PR DESCRIPTION
Fixes #201

## Changements

**Backend**
- `FournisseurEntity` : 5 nouveaux champs nullable avec défaut 0 — `portForfaitaireDefaut`, `portParUniteDefaut`, `nombreMinACommanderDefaut` (défaut 1), `tauxMargeDefaut`, `tauxMarqueDefaut`
- `FournisseurResource.update()` : copie ces champs lors de la modification

**Frontend**
- `fournisseurs.tsx` : section « Frais par défaut » dans le formulaire d'édition du fournisseur
- `fournisseur-produits.tsx` : lors de la création d'une nouvelle association fournisseur/produit, les champs de frais sont pré-remplis depuis les défauts du fournisseur et restent modifiables (surcharge possible)
  - En mode fournisseur : chargement automatique du fournisseur courant au montage du composant
  - En mode produit : pré-remplissage dès la sélection du fournisseur dans le formulaire

## Test plan
- [x] Ouvrir un fournisseur, renseigner des frais par défaut, sauvegarder
- [x] Ré-ouvrir le fournisseur → les frais par défaut sont persistés
- [x] Ajouter une nouvelle association produit → les frais sont pré-remplis depuis les défauts
- [x] Modifier les frais sur l'association → la valeur de l'association est utilisée (surcharge)
- [x] En mode produit : sélectionner un fournisseur → frais pré-remplis depuis ses défauts