### PR TITLE
feat: identification de produit client par photo (IA)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/AiIdentifyResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/AiIdentifyResource.java
@@ -1,0 +1,265 @@
+package net.nanthrax.moussaillon.services;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/ai/identify")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AiIdentifyResource {
+
+    private static final Logger LOG = Logger.getLogger(AiIdentifyResource.class);
+
+    @ConfigProperty(name = "ai.anthropic.api-key", defaultValue = "")
+    String anthropicApiKey;
+
+    @ConfigProperty(name = "ai.anthropic.model", defaultValue = "claude-haiku-4-5-20251001")
+    String anthropicModel;
+
+    private final Jsonb jsonb = JsonbBuilder.create();
+
+    @POST
+    public Response identify(Map<String, Object> request) {
+        List<String> images = asStringList(request.get("images"));
+        String type = asString(request.get("type"));
+
+        if (images.isEmpty()) {
+            return errorResponse(400, "INVALID_REQUEST", "Aucune image fournie");
+        }
+        if (anthropicApiKey == null || anthropicApiKey.trim().isEmpty()) {
+            return errorResponse(500, "CONFIG_ERROR", "La clé Anthropic est absente (ai.anthropic.api-key)");
+        }
+
+        try {
+            List<Map<String, Object>> contentBlocks = new ArrayList<>();
+            for (String image : images) {
+                contentBlocks.add(buildImageBlock(image));
+            }
+            Map<String, Object> textBlock = new LinkedHashMap<>();
+            textBlock.put("type", "text");
+            textBlock.put("text", buildPrompt(type));
+            contentBlocks.add(textBlock);
+
+            Map<String, Object> userMessage = new LinkedHashMap<>();
+            userMessage.put("role", "user");
+            userMessage.put("content", contentBlocks);
+
+            List<Map<String, Object>> messages = new ArrayList<>();
+            messages.add(userMessage);
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("model", anthropicModel);
+            payload.put("max_tokens", Integer.valueOf(512));
+            payload.put("system", "Tu es un expert en produits nautiques. Réponds uniquement en JSON valide, sans markdown ni explication supplémentaire.");
+            payload.put("messages", messages);
+
+            String responseBody = callAnthropicApi(payload);
+            Map<String, Object> parsed = fromJsonMap(responseBody);
+            String answer = extractAnswer(parsed);
+
+            // Strip markdown code fences if present
+            String cleaned = answer.trim();
+            if (cleaned.startsWith("```")) {
+                int firstNewline = cleaned.indexOf('\n');
+                int lastFence = cleaned.lastIndexOf("```");
+                if (firstNewline >= 0 && lastFence > firstNewline) {
+                    cleaned = cleaned.substring(firstNewline + 1, lastFence).trim();
+                }
+            }
+
+            try {
+                Map<String, Object> result = fromJsonMap(cleaned);
+                return Response.ok(result).build();
+            } catch (Exception e) {
+                Map<String, Object> fallback = new LinkedHashMap<>();
+                fallback.put("description", answer);
+                fallback.put("confidence", "faible");
+                return Response.ok(fallback).build();
+            }
+        } catch (WebApplicationException e) {
+            int status = e.getResponse() != null ? e.getResponse().getStatus() : 500;
+            LOG.errorf("AI identify error status=%d", Integer.valueOf(status));
+            return errorResponse(status, "AI_ERROR", e.getMessage());
+        } catch (Exception e) {
+            String traceId = UUID.randomUUID().toString();
+            LOG.errorf(e, "AI identify unexpected error traceId=%s", traceId);
+            return errorResponse(500, "AI_INTERNAL_ERROR", "Erreur interne [traceId=" + traceId + "]");
+        }
+    }
+
+    private Map<String, Object> buildImageBlock(String imageData) {
+        String mediaType = "image/jpeg";
+        String rawBase64 = imageData;
+
+        if (imageData.startsWith("data:")) {
+            int comma = imageData.indexOf(',');
+            if (comma > 0) {
+                String header = imageData.substring(5, comma);
+                int semi = header.indexOf(';');
+                if (semi > 0) {
+                    mediaType = header.substring(0, semi);
+                }
+                rawBase64 = imageData.substring(comma + 1);
+            }
+        }
+
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("type", "base64");
+        source.put("media_type", mediaType);
+        source.put("data", rawBase64);
+
+        Map<String, Object> block = new LinkedHashMap<>();
+        block.put("type", "image");
+        block.put("source", source);
+        return block;
+    }
+
+    private String buildPrompt(String type) {
+        String entityLabel = "produit nautique";
+        String fields;
+
+        if ("bateau".equals(type)) {
+            entityLabel = "bateau";
+            fields = "\"marque\", \"modele\", \"type\" (type de bateau, ex: Open, Semi-rigide, Voilier), \"anneeDebut\" (entier ou null), \"description\", \"confidence\" (haute/moyenne/faible)";
+        } else if ("moteur".equals(type)) {
+            entityLabel = "moteur hors-bord ou inboard";
+            fields = "\"marque\", \"modele\", \"type\" (Hors-bord/Inboard/In-Out), \"anneeDebut\" (entier ou null), \"puissanceCv\" (entier ou null), \"description\", \"confidence\" (haute/moyenne/faible)";
+        } else if ("remorque".equals(type)) {
+            entityLabel = "remorque nautique";
+            fields = "\"marque\", \"modele\", \"type\", \"anneeDebut\" (entier ou null), \"description\", \"confidence\" (haute/moyenne/faible)";
+        } else if ("helice".equals(type)) {
+            entityLabel = "hélice de bateau";
+            fields = "\"marque\", \"modele\", \"materiau\", \"pas\" (ex: 19), \"diametre\" (en pouces, ex: 14.5), \"description\", \"confidence\" (haute/moyenne/faible)";
+        } else {
+            fields = "\"marque\", \"modele\", \"type\", \"anneeDebut\" (entier ou null), \"description\", \"confidence\" (haute/moyenne/faible)";
+        }
+
+        return "À partir de cette/ces photo(s), identifie ce " + entityLabel + ". "
+                + "Réponds en JSON avec les champs : " + fields + ". "
+                + "Si un champ est inconnu, utilise null. "
+                + "Réponds uniquement avec le JSON brut, sans markdown.";
+    }
+
+    private String callAnthropicApi(Map<String, Object> payload) {
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL("https://api.anthropic.com/v1/messages").openConnection();
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("x-api-key", anthropicApiKey);
+            connection.setRequestProperty("anthropic-version", "2023-06-01");
+
+            byte[] body = jsonb.toJson(payload).getBytes(StandardCharsets.UTF_8);
+            OutputStream out = connection.getOutputStream();
+            try {
+                out.write(body);
+                out.flush();
+            } finally {
+                out.close();
+            }
+
+            int status = connection.getResponseCode();
+            String responseBody = readBody(connection, status);
+            if (status >= 400) {
+                throw new WebApplicationException("Erreur Anthropic [status=" + status + ", body=" + truncate(responseBody) + "]", 502);
+            }
+            return responseBody;
+        } catch (IOException e) {
+            throw new WebApplicationException("Erreur d'appel Anthropic: " + e.getMessage(), 502);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private String readBody(HttpURLConnection conn, int status) throws IOException {
+        InputStream is = status >= 400 ? conn.getErrorStream() : conn.getInputStream();
+        if (is == null) return "";
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+        try {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) sb.append(line);
+            return sb.toString();
+        } finally {
+            reader.close();
+        }
+    }
+
+    private String extractAnswer(Map<String, Object> response) {
+        Object contentObj = response.get("content");
+        if (!(contentObj instanceof List<?>)) return "";
+        for (Object block : (List<?>) contentObj) {
+            if (!(block instanceof Map<?, ?>)) continue;
+            Object type = ((Map<?, ?>) block).get("type");
+            if ("text".equals(type)) {
+                Object text = ((Map<?, ?>) block).get("text");
+                if (text != null) return text.toString();
+            }
+        }
+        return "";
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> fromJsonMap(String content) {
+        Object parsed = jsonb.fromJson(content, Object.class);
+        if (!(parsed instanceof Map<?, ?>)) return new LinkedHashMap<>();
+        return (Map<String, Object>) parsed;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> asStringList(Object value) {
+        List<String> result = new ArrayList<>();
+        if (!(value instanceof List<?>)) return result;
+        for (Object item : (List<?>) value) {
+            if (item != null) result.add(item.toString());
+        }
+        return result;
+    }
+
+    private String asString(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    private String truncate(String s) {
+        if (s == null) return "";
+        return s.length() <= 500 ? s : s.substring(0, 500) + "...";
+    }
+
+    private Response errorResponse(int status, String code, String message) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("error", code);
+        payload.put("message", message == null ? "" : message);
+        payload.put("status", Integer.valueOf(status));
+        return Response.status(status).entity(payload).type(MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/chantier-ui/src/ai-photo-identify.tsx
+++ b/chantier-ui/src/ai-photo-identify.tsx
@@ -1,0 +1,184 @@
+import React, { useState } from 'react';
+import { Button, Modal, Upload, message, Spin, Descriptions, Tag, Space } from 'antd';
+import { CameraOutlined, SearchOutlined } from '@ant-design/icons';
+import api from './api.ts';
+
+export type ProductType = 'bateau' | 'moteur' | 'remorque' | 'helice';
+
+export type IdentifyResult = {
+  marque?: string;
+  modele?: string;
+  type?: string;
+  anneeDebut?: number;
+  puissanceCv?: number;
+  description?: string;
+  immatriculation?: string;
+  pas?: string | number;
+  diametre?: number;
+  materiau?: string;
+  confidence?: string;
+};
+
+type Props = {
+  productType: ProductType;
+  onApply: (result: IdentifyResult) => void;
+};
+
+const CONFIDENCE_COLOR: Record<string, string> = {
+  haute: 'success',
+  moyenne: 'warning',
+  faible: 'error',
+};
+
+const PRODUCT_LABEL: Record<ProductType, string> = {
+  bateau: 'bateau',
+  moteur: 'moteur',
+  remorque: 'remorque',
+  helice: 'hélice',
+};
+
+const AiPhotoIdentify: React.FC<Props> = ({ productType, onApply }) => {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [fileList, setFileList] = useState<any[]>([]);
+  const [images, setImages] = useState<string[]>([]);
+  const [result, setResult] = useState<IdentifyResult | null>(null);
+
+  const handleBeforeUpload = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const base64 = e.target?.result as string;
+      setImages(prev => [...prev, base64]);
+    };
+    reader.readAsDataURL(file);
+    return false;
+  };
+
+  const handleRemove = (file: any) => {
+    const idx = fileList.findIndex(f => f.uid === file.uid);
+    if (idx >= 0) {
+      setImages(prev => prev.filter((_, i) => i !== idx));
+    }
+  };
+
+  const handleAnalyze = async () => {
+    if (images.length === 0) {
+      message.warning('Ajoutez au moins une photo');
+      return;
+    }
+    setLoading(true);
+    setResult(null);
+    try {
+      const res = await api.post('/ai/identify', { images, type: productType });
+      setResult(res.data);
+    } catch {
+      message.error("Erreur lors de l'identification par IA");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApply = () => {
+    if (result) {
+      onApply(result);
+      handleClose();
+    }
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setFileList([]);
+    setImages([]);
+    setResult(null);
+  };
+
+  const renderResult = () => {
+    if (!result) return null;
+    const items: { label: string; value: React.ReactNode }[] = [];
+    if (result.marque) items.push({ label: 'Marque', value: result.marque });
+    if (result.modele) items.push({ label: 'Modèle', value: result.modele });
+    if (result.type) items.push({ label: 'Type', value: result.type });
+    if (result.anneeDebut) items.push({ label: 'Année', value: result.anneeDebut });
+    if (result.puissanceCv) items.push({ label: 'Puissance (CV)', value: result.puissanceCv });
+    if (result.pas) items.push({ label: 'Pas', value: result.pas });
+    if (result.diametre) items.push({ label: 'Diamètre (po)', value: result.diametre });
+    if (result.materiau) items.push({ label: 'Matériau', value: result.materiau });
+    if (result.description) items.push({ label: 'Description', value: result.description });
+    if (result.confidence) {
+      items.push({
+        label: 'Fiabilité',
+        value: <Tag color={CONFIDENCE_COLOR[result.confidence] ?? 'default'}>{result.confidence}</Tag>,
+      });
+    }
+
+    return (
+      <div style={{ marginTop: 16 }}>
+        <Descriptions bordered size="small" column={2} title="Résultat de l'identification">
+          {items.map(item => (
+            <Descriptions.Item key={item.label} label={item.label}>
+              {item.value}
+            </Descriptions.Item>
+          ))}
+        </Descriptions>
+        <Button
+          type="primary"
+          style={{ marginTop: 12 }}
+          onClick={handleApply}
+        >
+          Appliquer au formulaire
+        </Button>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <Button icon={<CameraOutlined />} onClick={() => setOpen(true)}>
+        Identifier par photo
+      </Button>
+      <Modal
+        open={open}
+        title={`Identification du ${PRODUCT_LABEL[productType]} par photo (IA)`}
+        onCancel={handleClose}
+        footer={null}
+        width={600}
+        destroyOnHidden
+      >
+        <Spin spinning={loading}>
+          <Upload
+            multiple
+            listType="picture-card"
+            beforeUpload={handleBeforeUpload}
+            onRemove={handleRemove}
+            fileList={fileList}
+            onChange={({ fileList: fl }) => setFileList(fl)}
+            accept="image/*"
+          >
+            <div>
+              <CameraOutlined />
+              <div style={{ marginTop: 4 }}>Ajouter une photo</div>
+            </div>
+          </Upload>
+          <Space style={{ marginTop: 12 }}>
+            <Button
+              type="primary"
+              icon={<SearchOutlined />}
+              onClick={handleAnalyze}
+              disabled={images.length === 0}
+            >
+              Analyser
+            </Button>
+            {images.length > 0 && (
+              <span style={{ color: '#888', fontSize: 12 }}>
+                {images.length} photo{images.length > 1 ? 's' : ''} sélectionnée{images.length > 1 ? 's' : ''}
+              </span>
+            )}
+          </Space>
+          {renderResult()}
+        </Spin>
+      </Modal>
+    </>
+  );
+};
+
+export default AiPhotoIdentify;

--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -30,6 +30,7 @@ import {
 } from "@ant-design/icons";
 import api from "./api.ts";
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
+import AiPhotoIdentify, { IdentifyResult } from './ai-photo-identify.tsx';
 import ImageUpload from './ImageUpload.tsx';
 import DocumentUpload from './DocumentUpload.tsx';
 import dayjs from "dayjs";
@@ -375,6 +376,30 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
     }
   };
 
+  const handleAiIdentify = (result: IdentifyResult) => {
+    const updates: Record<string, any> = {};
+    if (!form.getFieldValue('name') && (result.marque || result.modele)) {
+      updates.name = [result.marque, result.modele].filter(Boolean).join(' ');
+    }
+    if (result.immatriculation && !form.getFieldValue('immatriculation')) {
+      updates.immatriculation = result.immatriculation;
+    }
+    const matching = bateauxCatalogue.find((b: any) =>
+      result.marque && result.modele &&
+      b.marque?.toLowerCase() === result.marque.toLowerCase() &&
+      b.modele?.toLowerCase() === result.modele.toLowerCase()
+    );
+    if (matching) {
+      updates.modeleId = matching.id;
+      setModeleOptions(prev => prev.some((m: any) => m.id === matching.id) ? prev : [...prev, matching]);
+      setAvailableOptions(matching.options || []);
+    }
+    if (Object.keys(updates).length > 0) {
+      form.setFieldsValue(updates);
+      setFormDirty(true);
+    }
+  };
+
   const handleModalOk = async () => {
     try {
       const values = await form.validateFields();
@@ -528,6 +553,9 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         destroyOnHidden
         width={1024}
       >
+        <div style={{ marginBottom: 12 }}>
+          <AiPhotoIdentify productType="bateau" onApply={handleAiIdentify} />
+        </div>
         <Form layout="vertical" form={form} initialValues={defaultBateau} onValuesChange={(changedValues) => {
             setFormDirty(true);
             if (changedValues.localisationGps) {

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -29,6 +29,7 @@ import {
 } from "@ant-design/icons";
 import api from "./api.ts";
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
+import AiPhotoIdentify, { IdentifyResult } from './ai-photo-identify.tsx';
 import ImageUpload from './ImageUpload.tsx';
 import DocumentUpload from './DocumentUpload.tsx';
 import dayjs from "dayjs";
@@ -300,6 +301,23 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
     }
   };
 
+  const handleAiIdentify = (result: IdentifyResult) => {
+    const updates: Record<string, any> = {};
+    const matching = catalogueMoteurs.find((m: any) =>
+      result.marque && result.modele &&
+      m.marque?.toLowerCase() === result.marque.toLowerCase() &&
+      m.modele?.toLowerCase() === result.modele.toLowerCase()
+    );
+    if (matching) {
+      updates.modeleId = matching.id;
+      setModeleOptions(prev => prev.some((m: any) => m.id === matching.id) ? prev : [...prev, matching]);
+    }
+    if (Object.keys(updates).length > 0) {
+      form.setFieldsValue(updates);
+      setFormDirty(true);
+    }
+  };
+
   const handleModalOk = async () => {
     try {
       const values = await form.validateFields();
@@ -450,6 +468,9 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         destroyOnHidden
         width={1024}
       >
+        <div style={{ marginBottom: 12 }}>
+          <AiPhotoIdentify productType="moteur" onApply={handleAiIdentify} />
+        </div>
         <Form layout="vertical" form={form} initialValues={defaultMoteur} onValuesChange={() => setFormDirty(true)}>
           <Row gutter={16}>
             <Col span={12}>


### PR DESCRIPTION
Fixes #289

## Changements

**Backend — `AiIdentifyResource.java`** (`POST /ai/identify`)
- Accepte `{ "images": ["data:image/jpeg;base64,..."], "type": "bateau|moteur|remorque|helice" }`
- Appelle l'API Anthropic (vision) avec les images en base64
- Construit un prompt spécifique au type de produit pour extraire : marque, modèle, type, année, puissance (moteur), description, niveau de fiabilité
- Retourne un JSON structuré avec les champs identifiés

**Frontend — `ai-photo-identify.tsx`** (composant réutilisable)
- Bouton « Identifier par photo »
- Modal : upload de photos (drag & drop, multi-fichiers), bouton « Analyser »
- Affichage du résultat avec badge de fiabilité (haute/moyenne/faible)
- Bouton « Appliquer au formulaire » déclenche le callback `onApply`

**`clients-bateaux.tsx`**
- Intégration d'`AiPhotoIdentify` dans le formulaire de création/édition
- `onApply` : pré-remplit `name`, `immatriculation`, et `modeleId` si le modèle est trouvé dans le catalogue

**`clients-moteurs.tsx`**
- Même intégration pour les moteurs
- `onApply` : pré-remplit `modeleId` si le modèle est trouvé dans `catalogueMoteurs`

## Test plan
- [x] Ouvrir la fiche d'un bateau → bouton « Identifier par photo » visible
- [x] Uploader une photo de bateau → analyser → le résultat s'affiche avec marque/modèle/type
- [x] Cliquer « Appliquer au formulaire » → les champs sont pré-remplis
- [x] Si la marque/modèle correspond à un modèle catalogue → `modeleId` est sélectionné automatiquement
- [x] Même test pour un moteur
- [x] Sans clé Anthropic configurée → message d'erreur explicite (500 CONFIG_ERROR)