### PR TITLE
feat: technicien peut voir et s'affecter les tâches non assignées

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
@@ -604,6 +604,95 @@ public class TechnicienPortalResource {
         return PlanningItemWithVente.fromService(vs, parentVente);
     }
 
+    public static class SelfAssignRequest {
+        public Long technicienId;
+        public String datePlanification;
+    }
+
+    @GET
+    @Path("/taches-non-affectees")
+    public List<PlanningItemWithVente> getNonAffectees() {
+        List<VenteEntity> ventes = VenteEntity.listAll();
+        List<PlanningItemWithVente> result = new ArrayList<>();
+        for (VenteEntity vente : ventes) {
+            if (vente.venteForfaits != null) {
+                for (VenteForfaitEntity vf : vente.venteForfaits) {
+                    if ((vf.techniciens == null || vf.techniciens.isEmpty())
+                            && vf.status == VenteForfaitEntity.Status.EN_ATTENTE) {
+                        result.add(PlanningItemWithVente.fromForfait(vf, vente));
+                    }
+                }
+            }
+            if (vente.venteServices != null) {
+                for (VenteServiceEntity vs : vente.venteServices) {
+                    if ((vs.techniciens == null || vs.techniciens.isEmpty())
+                            && vs.status == VenteServiceEntity.Status.EN_ATTENTE) {
+                        result.add(PlanningItemWithVente.fromService(vs, vente));
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    @POST
+    @Path("/forfaits/{itemId}/s-affecter")
+    @Transactional
+    public PlanningItemWithVente sAffecterForfait(@PathParam("itemId") long itemId, SelfAssignRequest request) {
+        VenteForfaitEntity vf = VenteForfaitEntity.findById(itemId);
+        if (vf == null) {
+            throw new WebApplicationException("Element non trouve", Response.Status.NOT_FOUND);
+        }
+        TechnicienEntity technicien = TechnicienEntity.findById(request.technicienId);
+        if (technicien == null) {
+            throw new WebApplicationException("Technicien non trouve", Response.Status.NOT_FOUND);
+        }
+        if (vf.techniciens == null) {
+            vf.techniciens = new ArrayList<>();
+        }
+        if (vf.techniciens.stream().noneMatch(t -> t.id.equals(request.technicienId))) {
+            vf.techniciens.add(technicien);
+        }
+        if (request.datePlanification != null && !request.datePlanification.isBlank()) {
+            String dateStr = request.datePlanification.length() > 10
+                    ? request.datePlanification.substring(0, 10)
+                    : request.datePlanification;
+            vf.datePlanification = java.sql.Timestamp.valueOf(java.time.LocalDate.parse(dateStr).atStartOfDay());
+        }
+        vf.status = VenteForfaitEntity.Status.PLANIFIEE;
+        VenteEntity parentVente = venteParenteForfait(itemId);
+        return PlanningItemWithVente.fromForfait(vf, parentVente != null ? parentVente : new VenteEntity());
+    }
+
+    @POST
+    @Path("/services/{itemId}/s-affecter")
+    @Transactional
+    public PlanningItemWithVente sAffecterService(@PathParam("itemId") long itemId, SelfAssignRequest request) {
+        VenteServiceEntity vs = VenteServiceEntity.findById(itemId);
+        if (vs == null) {
+            throw new WebApplicationException("Element non trouve", Response.Status.NOT_FOUND);
+        }
+        TechnicienEntity technicien = TechnicienEntity.findById(request.technicienId);
+        if (technicien == null) {
+            throw new WebApplicationException("Technicien non trouve", Response.Status.NOT_FOUND);
+        }
+        if (vs.techniciens == null) {
+            vs.techniciens = new ArrayList<>();
+        }
+        if (vs.techniciens.stream().noneMatch(t -> t.id.equals(request.technicienId))) {
+            vs.techniciens.add(technicien);
+        }
+        if (request.datePlanification != null && !request.datePlanification.isBlank()) {
+            String dateStr = request.datePlanification.length() > 10
+                    ? request.datePlanification.substring(0, 10)
+                    : request.datePlanification;
+            vs.datePlanification = java.sql.Timestamp.valueOf(java.time.LocalDate.parse(dateStr).atStartOfDay());
+        }
+        vs.status = VenteServiceEntity.Status.PLANIFIEE;
+        VenteEntity parentVente = venteParenteService(itemId);
+        return PlanningItemWithVente.fromService(vs, parentVente != null ? parentVente : new VenteEntity());
+    }
+
     private static VenteEntity venteParenteForfait(long forfaitId) {
         List<VenteEntity> ventes = VenteEntity.list("SELECT v FROM VenteEntity v JOIN v.venteForfaits vf WHERE vf.id = ?1", forfaitId);
         return ventes.isEmpty() ? null : ventes.get(0);

--- a/technicien-ui/src/planning.tsx
+++ b/technicien-ui/src/planning.tsx
@@ -18,7 +18,7 @@ import {
     Tag,
     message,
 } from 'antd';
-import { CheckCircleOutlined, ClockCircleOutlined, DeleteOutlined, EditOutlined, ExclamationCircleOutlined, FileOutlined, PictureOutlined, PlusOutlined, ReloadOutlined, ShoppingOutlined } from '@ant-design/icons';
+import { CalendarOutlined, CheckCircleOutlined, ClockCircleOutlined, DeleteOutlined, EditOutlined, ExclamationCircleOutlined, FileOutlined, PictureOutlined, PlusOutlined, ReloadOutlined, ShoppingOutlined, UserAddOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import api from './api.ts';
 import ImageUpload from './ImageUpload.tsx';
@@ -131,6 +131,12 @@ export default function Planning({ technicienId }: PlanningProps) {
     const [selectedProduitId, setSelectedProduitId] = useState<number | undefined>(undefined);
     const [addQuantite, setAddQuantite] = useState(1);
 
+    const [nonAffectees, setNonAffectees] = useState<PlanningItem[]>([]);
+    const [loadingNonAffectees, setLoadingNonAffectees] = useState(false);
+    const [selfAssignItem, setSelfAssignItem] = useState<PlanningItem | null>(null);
+    const [selfAssignDate, setSelfAssignDate] = useState<any>(null);
+    const [selfAssigning, setSelfAssigning] = useState(false);
+
     const fetchItems = async () => {
         setLoading(true);
         try {
@@ -143,8 +149,21 @@ export default function Planning({ technicienId }: PlanningProps) {
         }
     };
 
+    const fetchNonAffectees = async () => {
+        setLoadingNonAffectees(true);
+        try {
+            const res = await api.get('/technicien-portal/taches-non-affectees');
+            setNonAffectees(res.data || []);
+        } catch {
+            message.error('Erreur lors du chargement des taches disponibles');
+        } finally {
+            setLoadingNonAffectees(false);
+        }
+    };
+
     useEffect(() => {
         fetchItems();
+        fetchNonAffectees();
     }, [technicienId]);
 
     const filteredItems = filterStatus
@@ -505,6 +524,76 @@ export default function Planning({ technicienId }: PlanningProps) {
         },
     ];
 
+    const handleSelfAssign = async () => {
+        if (!selfAssignItem) return;
+        setSelfAssigning(true);
+        try {
+            const endpoint = selfAssignItem.itemType === 'forfait'
+                ? `/technicien-portal/forfaits/${selfAssignItem.itemId}/s-affecter`
+                : `/technicien-portal/services/${selfAssignItem.itemId}/s-affecter`;
+            await api.post(endpoint, {
+                technicienId,
+                datePlanification: selfAssignDate ? selfAssignDate.format('YYYY-MM-DD') : undefined,
+            });
+            message.success('Tache affectee et planifiee');
+            setSelfAssignItem(null);
+            setSelfAssignDate(null);
+            fetchItems();
+            fetchNonAffectees();
+        } catch {
+            message.error("Erreur lors de l'affectation");
+        } finally {
+            setSelfAssigning(false);
+        }
+    };
+
+    const nonAffecteesColumns = [
+        {
+            title: 'Opération',
+            key: 'nom',
+            render: (_: unknown, record: PlanningItem) => (
+                <Space>
+                    <Tag color={record.itemType === 'forfait' ? 'blue' : 'purple'}>
+                        {record.itemType === 'forfait' ? 'Forfait' : 'Service'}
+                    </Tag>
+                    {record.itemNom}
+                </Space>
+            ),
+        },
+        {
+            title: 'Client',
+            dataIndex: 'clientNom',
+            key: 'clientNom',
+            render: (val: string) => val || '-',
+        },
+        {
+            title: 'Bateau',
+            dataIndex: 'bateauNom',
+            key: 'bateauNom',
+            render: (val: string) => val || '-',
+        },
+        {
+            title: 'Durée estimée',
+            dataIndex: 'dureeEstimee',
+            key: 'dureeEstimee',
+            render: (val: number) => val ? `${val}h` : '-',
+        },
+        {
+            title: 'Action',
+            key: 'action',
+            render: (_: unknown, record: PlanningItem) => (
+                <Button
+                    size="small"
+                    type="primary"
+                    icon={<UserAddOutlined />}
+                    onClick={() => { setSelfAssignItem(record); setSelfAssignDate(null); }}
+                >
+                    S'affecter
+                </Button>
+            ),
+        },
+    ];
+
     return (
         <div>
             <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
@@ -565,6 +654,65 @@ export default function Planning({ technicienId }: PlanningProps) {
                     bordered
                 />
             </Card>
+
+            <Card
+                title={
+                    <Space>
+                        <CalendarOutlined />
+                        Taches disponibles (non affectees)
+                        <Tag>{nonAffectees.length}</Tag>
+                    </Space>
+                }
+                style={{ marginTop: 16 }}
+                extra={<Button icon={<ReloadOutlined />} size="small" onClick={fetchNonAffectees} />}
+            >
+                {nonAffectees.length === 0 ? (
+                    <Empty description="Aucune tache disponible" />
+                ) : (
+                    <Table
+                        rowKey="itemId"
+                        dataSource={nonAffectees}
+                        columns={nonAffecteesColumns}
+                        loading={loadingNonAffectees}
+                        pagination={{ pageSize: 10 }}
+                        bordered
+                    />
+                )}
+            </Card>
+
+            <Modal
+                open={!!selfAssignItem}
+                title="S'affecter cette tache"
+                onCancel={() => { setSelfAssignItem(null); setSelfAssignDate(null); }}
+                onOk={handleSelfAssign}
+                okText="Confirmer"
+                cancelText="Annuler"
+                confirmLoading={selfAssigning}
+                destroyOnHidden
+            >
+                {selfAssignItem && (
+                    <div style={{ marginBottom: 16 }}>
+                        <p>
+                            <strong>{selfAssignItem.itemNom}</strong>
+                            {selfAssignItem.clientNom && <> — {selfAssignItem.clientNom}</>}
+                            {selfAssignItem.bateauNom && <> ({selfAssignItem.bateauNom})</>}
+                        </p>
+                        <p style={{ color: '#888', fontSize: 13 }}>
+                            En confirmant, vous vous affectez cette tache et son statut passe a <strong>Planifiee</strong>.
+                        </p>
+                    </div>
+                )}
+                <Form layout="vertical">
+                    <Form.Item label="Date de planification (optionnel)">
+                        <DatePicker
+                            style={{ width: '100%' }}
+                            value={selfAssignDate}
+                            onChange={(date) => setSelfAssignDate(date)}
+                            placeholder="Choisir une date"
+                        />
+                    </Form.Item>
+                </Form>
+            </Modal>
 
             <Modal
                 open={addProduitVisible}


### PR DESCRIPTION
Fixes #167

## Changements

**Backend — `TechnicienPortalResource.java`**

- `GET /technicien-portal/taches-non-affectees` — retourne tous les forfaits/services en statut `EN_ATTENTE` sans aucun technicien assigné (toutes prestations confondues)
- `POST /technicien-portal/forfaits/{itemId}/s-affecter` — corps `{ technicienId, datePlanification? }` : ajoute le technicien à la liste, passe le statut à `PLANIFIEE`, fixe `datePlanification` si fournie
- `POST /technicien-portal/services/{itemId}/s-affecter` — même comportement pour les services

**Frontend — `planning.tsx`**

- Nouvelle card **« Tâches disponibles (non affectées) »** sous les tâches existantes, avec compteur et bouton de rafraîchissement
- Table : Opération (type + nom), Client, Bateau, Durée estimée, bouton « S'affecter »
- Modale de confirmation avec DatePicker optionnel pour choisir une date de planification
- Après confirmation : la tâche disparaît des disponibles et apparaît dans « Toutes mes tâches » avec statut Planifiée

## Test plan
- [x] Créer une prestation avec un forfait/service en statut EN_ATTENTE sans technicien
- [x] Ouvrir le portail technicien → card « Tâches disponibles » visible avec la tâche
- [x] Cliquer « S'affecter » → choisir une date → Confirmer
- [x] La tâche n'apparaît plus dans les disponibles et est présente dans le planning du technicien avec statut Planifiée
- [x] Sans date de planification : la tâche passe quand même en Planifiée