### PR TITLE
feat: permettre au client de gérer ses photos et documents (#124)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
@@ -209,4 +209,58 @@ public class ClientPortalResource {
     public List<AnnonceEntity> getClientAnnonces(@PathParam("id") long id) {
         return AnnonceEntity.list("client.id = ?1", id);
     }
+
+    public static class MediasRequest {
+        public List<String> images;
+        public List<String> documents;
+    }
+
+    @PUT
+    @Path("/clients/{clientId}/bateaux/{bateauId}/medias")
+    @Transactional
+    public Response updateBateauMedias(@PathParam("clientId") long clientId, @PathParam("bateauId") long bateauId, MediasRequest request) {
+        BateauClientEntity entity = BateauClientEntity.findById(bateauId);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Bateau non trouve.").build();
+        }
+        boolean belongs = entity.proprietaires.stream().anyMatch(p -> p.id == clientId);
+        if (!belongs) {
+            return Response.status(Response.Status.FORBIDDEN).entity("Acces interdit.").build();
+        }
+        if (request.images != null) entity.images = request.images;
+        if (request.documents != null) entity.documents = request.documents;
+        return Response.noContent().build();
+    }
+
+    @PUT
+    @Path("/clients/{clientId}/moteurs/{moteurId}/medias")
+    @Transactional
+    public Response updateMoteurMedias(@PathParam("clientId") long clientId, @PathParam("moteurId") long moteurId, MediasRequest request) {
+        MoteurClientEntity entity = MoteurClientEntity.findById(moteurId);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Moteur non trouve.").build();
+        }
+        if (entity.proprietaire == null || entity.proprietaire.id != clientId) {
+            return Response.status(Response.Status.FORBIDDEN).entity("Acces interdit.").build();
+        }
+        if (request.images != null) entity.images = request.images;
+        if (request.documents != null) entity.documents = request.documents;
+        return Response.noContent().build();
+    }
+
+    @PUT
+    @Path("/clients/{clientId}/remorques/{remorqueId}/medias")
+    @Transactional
+    public Response updateRemorqueMedias(@PathParam("clientId") long clientId, @PathParam("remorqueId") long remorqueId, MediasRequest request) {
+        RemorqueClientEntity entity = RemorqueClientEntity.findById(remorqueId);
+        if (entity == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Remorque non trouvee.").build();
+        }
+        if (entity.proprietaire == null || entity.proprietaire.id != clientId) {
+            return Response.status(Response.Status.FORBIDDEN).entity("Acces interdit.").build();
+        }
+        if (request.images != null) entity.images = request.images;
+        if (request.documents != null) entity.documents = request.documents;
+        return Response.noContent().build();
+    }
 }

--- a/client-ui/src/DocumentUpload.tsx
+++ b/client-ui/src/DocumentUpload.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { Upload, message, Button, List, Input, Space } from 'antd';
+import { DeleteOutlined, InboxOutlined, FileOutlined, FilePdfOutlined, FileWordOutlined, FileExcelOutlined, DownloadOutlined, LinkOutlined } from '@ant-design/icons';
+import type { UploadProps } from 'antd';
+import api from './api.ts';
+
+const { Dragger } = Upload;
+
+interface DocumentUploadProps {
+    value?: string[];
+    onChange?: (urls: string[]) => void;
+}
+
+const parseDocument = (entry: string) => {
+    const pipeIndex = entry.indexOf('|');
+    if (pipeIndex > 0) {
+        return { name: entry.substring(0, pipeIndex), url: entry.substring(pipeIndex + 1) };
+    }
+    const parts = entry.split('/');
+    return { name: parts[parts.length - 1], url: entry };
+};
+
+const getFileIcon = (name: string) => {
+    const lower = name.toLowerCase();
+    if (lower.endsWith('.pdf')) return <FilePdfOutlined style={{ color: '#ff4d4f' }} />;
+    if (lower.endsWith('.doc') || lower.endsWith('.docx')) return <FileWordOutlined style={{ color: '#1677ff' }} />;
+    if (lower.endsWith('.xls') || lower.endsWith('.xlsx')) return <FileExcelOutlined style={{ color: '#52c41a' }} />;
+    return <FileOutlined />;
+};
+
+const DocumentUpload: React.FC<DocumentUploadProps> = ({ value = [], onChange }) => {
+    const [urlInput, setUrlInput] = useState('');
+
+    const triggerChange = (urls: string[]) => {
+        onChange?.(urls);
+    };
+
+    const handleDownload = async (url: string) => {
+        try {
+            const res = await api.get(url, { responseType: 'blob' });
+            const blob = new Blob([res.data], { type: res.headers['content-type'] });
+            const blobUrl = window.URL.createObjectURL(blob);
+            window.open(blobUrl, '_blank');
+        } catch {
+            message.error("Erreur lors du téléchargement du document");
+        }
+    };
+
+    const handleUpload: UploadProps['customRequest'] = async (options) => {
+        const { file, onSuccess, onError } = options;
+        const formData = new FormData();
+        formData.append('files', file as File);
+        try {
+            const res = await api.post('/documents', formData, {
+                headers: { 'Content-Type': 'multipart/form-data' },
+            });
+            const urls: string[] = res.data;
+            if (urls.length > 0) {
+                triggerChange([...value, ...urls]);
+            }
+            onSuccess?.(res.data);
+        } catch (err) {
+            message.error("Erreur lors de l'upload du document");
+            onError?.(err as Error);
+        }
+    };
+
+    const handleRemove = (index: number) => {
+        const newUrls = value.filter((_, i) => i !== index);
+        triggerChange(newUrls);
+    };
+
+    return (
+        <div>
+            {value.length > 0 && (
+                <List
+                    size="small"
+                    style={{ marginBottom: 12 }}
+                    dataSource={value}
+                    renderItem={(entry, index) => {
+                        const doc = parseDocument(entry);
+                        return (
+                            <List.Item
+                                actions={[
+                                    <Button
+                                        type="link"
+                                        size="small"
+                                        icon={<DownloadOutlined />}
+                                        onClick={() => handleDownload(doc.url)}
+                                    />,
+                                    <Button
+                                        type="text"
+                                        size="small"
+                                        danger
+                                        icon={<DeleteOutlined />}
+                                        onClick={() => handleRemove(index)}
+                                    />,
+                                ]}
+                            >
+                                <List.Item.Meta
+                                    avatar={getFileIcon(doc.name)}
+                                    title={doc.name}
+                                />
+                            </List.Item>
+                        );
+                    }}
+                />
+            )}
+            <Dragger
+                multiple
+                showUploadList={false}
+                customRequest={handleUpload}
+                accept=".pdf,.doc,.docx,.xls,.xlsx,.odt,.ods,.txt,.csv"
+            >
+                <p className="ant-upload-drag-icon">
+                    <InboxOutlined />
+                </p>
+                <p className="ant-upload-text">Cliquer ou glisser-déposer des documents ici</p>
+                <p className="ant-upload-hint">Formats acceptés : PDF, DOC, DOCX, XLS, XLSX, ODT, ODS, TXT, CSV</p>
+            </Dragger>
+            <Space.Compact style={{ width: '100%', marginTop: 8 }}>
+                <Input
+                    prefix={<LinkOutlined />}
+                    placeholder="Ou ajouter une URL de document"
+                    value={urlInput}
+                    onChange={(e) => setUrlInput(e.target.value)}
+                    onPressEnter={() => {
+                        const trimmed = urlInput.trim();
+                        if (trimmed) {
+                            triggerChange([...value, trimmed]);
+                            setUrlInput('');
+                        }
+                    }}
+                />
+                <Button onClick={() => {
+                    const trimmed = urlInput.trim();
+                    if (trimmed) {
+                        triggerChange([...value, trimmed]);
+                        setUrlInput('');
+                    }
+                }}>Ajouter</Button>
+            </Space.Compact>
+        </div>
+    );
+};
+
+export default DocumentUpload;

--- a/client-ui/src/mes-bateaux.tsx
+++ b/client-ui/src/mes-bateaux.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Table, Tag, Spin, message, Checkbox, Button, Space, Image } from 'antd';
+import { Card, Table, Tag, Spin, message, Checkbox, Button, Image, Divider, Typography } from 'antd';
 import { PictureOutlined, TagsOutlined } from '@ant-design/icons';
 import api from './api.ts';
+import ImageUpload from './ImageUpload.tsx';
+import DocumentUpload from './DocumentUpload.tsx';
 
 interface BateauClientEntity {
     id: number;
@@ -13,6 +15,7 @@ interface BateauClientEntity {
     dateFinDeGuarantie?: string;
     localisation?: string;
     images?: string[];
+    documents?: string[];
     modele?: { id: number; nom?: string; marque?: string };
     moteurs?: Array<{ id: number; nom?: string; marque?: string }>;
     equipements?: string[];
@@ -34,6 +37,9 @@ export default function MesBateaux({ clientId, onCreateAnnonce }: MesBateauxProp
     const [bateaux, setBateaux] = useState<BateauClientEntity[]>([]);
     const [loading, setLoading] = useState(false);
     const [selectedImages, setSelectedImages] = useState<Record<number, Set<string>>>({});
+    const [draftImages, setDraftImages] = useState<Record<number, string[]>>({});
+    const [draftDocuments, setDraftDocuments] = useState<Record<number, string[]>>({});
+    const [savingMedias, setSavingMedias] = useState<Record<number, boolean>>({});
 
     useEffect(() => {
         setLoading(true);
@@ -67,6 +73,22 @@ export default function MesBateaux({ clientId, onCreateAnnonce }: MesBateauxProp
             return;
         }
         onCreateAnnonce?.(Array.from(selected), bateau.id);
+    };
+
+    const handleSaveMedias = async (bateauId: number) => {
+        setSavingMedias((prev) => ({ ...prev, [bateauId]: true }));
+        const bateau = bateaux.find((b) => b.id === bateauId);
+        const images = draftImages[bateauId] ?? bateau?.images ?? [];
+        const documents = draftDocuments[bateauId] ?? bateau?.documents ?? [];
+        try {
+            await api.put(`/portal/clients/${clientId}/bateaux/${bateauId}/medias`, { images, documents });
+            setBateaux((prev) => prev.map((b) => b.id === bateauId ? { ...b, images, documents } : b));
+            message.success('Médias sauvegardés');
+        } catch {
+            message.error('Erreur lors de la sauvegarde des médias');
+        } finally {
+            setSavingMedias((prev) => ({ ...prev, [bateauId]: false }));
+        }
     };
 
     const columns = [
@@ -126,69 +148,96 @@ export default function MesBateaux({ clientId, onCreateAnnonce }: MesBateauxProp
     ];
 
     const expandedRowRender = (record: BateauClientEntity) => {
-        const images = record.images || [];
-        if (images.length === 0) {
-            return <p style={{ color: '#999', fontStyle: 'italic' }}>Aucune image disponible</p>;
-        }
+        const savedImages = record.images || [];
         const selected = selectedImages[record.id] || new Set();
-        const allSelected = images.every((img) => selected.has(img));
+        const allSelected = savedImages.length > 0 && savedImages.every((img) => selected.has(img));
 
         return (
             <div>
-                <div style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Checkbox
-                        checked={allSelected}
-                        indeterminate={selected.size > 0 && !allSelected}
-                        onChange={() => toggleAll(record.id, images)}
-                    >
-                        Tout selectionner ({selected.size}/{images.length})
-                    </Checkbox>
-                    {onCreateAnnonce && (
-                        <Button
-                            type="primary"
-                            icon={<TagsOutlined />}
-                            disabled={selected.size === 0}
-                            onClick={() => handleCreateAnnonce(record)}
-                        >
-                            Creer une annonce avec {selected.size > 0 ? `${selected.size} photo(s)` : 'les photos'}
-                        </Button>
-                    )}
+                <Typography.Text strong>Photos</Typography.Text>
+                <div style={{ marginTop: 8 }}>
+                    <ImageUpload
+                        value={draftImages[record.id] ?? record.images ?? []}
+                        onChange={(urls) => setDraftImages((prev) => ({ ...prev, [record.id]: urls }))}
+                    />
                 </div>
-                <Image.PreviewGroup>
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                        {images.map((url, i) => (
-                            <div
-                                key={i}
-                                onClick={(e) => {
-                                    if (!(e.target as HTMLElement).closest('.ant-image-mask')) {
-                                        toggleImage(record.id, url);
-                                    }
-                                }}
-                                style={{
-                                    position: 'relative',
-                                    cursor: 'pointer',
-                                    border: selected.has(url) ? '3px solid #1890ff' : '3px solid transparent',
-                                    borderRadius: 8,
-                                    overflow: 'hidden',
-                                }}
+
+                <Divider style={{ margin: '12px 0' }} />
+                <Typography.Text strong>Documents</Typography.Text>
+                <div style={{ marginTop: 8 }}>
+                    <DocumentUpload
+                        value={draftDocuments[record.id] ?? record.documents ?? []}
+                        onChange={(urls) => setDraftDocuments((prev) => ({ ...prev, [record.id]: urls }))}
+                    />
+                </div>
+
+                <div style={{ marginTop: 12, display: 'flex', justifyContent: 'flex-end' }}>
+                    <Button
+                        type="primary"
+                        loading={savingMedias[record.id]}
+                        onClick={() => handleSaveMedias(record.id)}
+                    >
+                        Sauvegarder les modifications
+                    </Button>
+                </div>
+
+                {onCreateAnnonce && savedImages.length > 0 && (
+                    <>
+                        <Divider>Créer une annonce</Divider>
+                        <div style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <Checkbox
+                                checked={allSelected}
+                                indeterminate={selected.size > 0 && !allSelected}
+                                onChange={() => toggleAll(record.id, savedImages)}
                             >
-                                <Image
-                                    width={120}
-                                    height={120}
-                                    src={url}
-                                    style={{ objectFit: 'cover', display: 'block' }}
-                                    preview={{ mask: 'Agrandir' }}
-                                />
-                                <Checkbox
-                                    checked={selected.has(url)}
-                                    onChange={() => toggleImage(record.id, url)}
-                                    onClick={(e) => e.stopPropagation()}
-                                    style={{ position: 'absolute', top: 4, left: 4, zIndex: 1 }}
-                                />
+                                Tout selectionner ({selected.size}/{savedImages.length})
+                            </Checkbox>
+                            <Button
+                                type="primary"
+                                icon={<TagsOutlined />}
+                                disabled={selected.size === 0}
+                                onClick={() => handleCreateAnnonce(record)}
+                            >
+                                Creer une annonce avec {selected.size > 0 ? `${selected.size} photo(s)` : 'les photos'}
+                            </Button>
+                        </div>
+                        <Image.PreviewGroup>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                                {savedImages.map((url, i) => (
+                                    <div
+                                        key={i}
+                                        onClick={(e) => {
+                                            if (!(e.target as HTMLElement).closest('.ant-image-mask')) {
+                                                toggleImage(record.id, url);
+                                            }
+                                        }}
+                                        style={{
+                                            position: 'relative',
+                                            cursor: 'pointer',
+                                            border: selected.has(url) ? '3px solid #1890ff' : '3px solid transparent',
+                                            borderRadius: 8,
+                                            overflow: 'hidden',
+                                        }}
+                                    >
+                                        <Image
+                                            width={120}
+                                            height={120}
+                                            src={url}
+                                            style={{ objectFit: 'cover', display: 'block' }}
+                                            preview={{ mask: 'Agrandir' }}
+                                        />
+                                        <Checkbox
+                                            checked={selected.has(url)}
+                                            onChange={() => toggleImage(record.id, url)}
+                                            onClick={(e) => e.stopPropagation()}
+                                            style={{ position: 'absolute', top: 4, left: 4, zIndex: 1 }}
+                                        />
+                                    </div>
+                                ))}
                             </div>
-                        ))}
-                    </div>
-                </Image.PreviewGroup>
+                        </Image.PreviewGroup>
+                    </>
+                )}
             </div>
         );
     };
@@ -204,7 +253,7 @@ export default function MesBateaux({ clientId, onCreateAnnonce }: MesBateauxProp
                     bordered
                     expandable={{
                         expandedRowRender,
-                        rowExpandable: (record) => (record.images || []).length > 0,
+                        rowExpandable: () => true,
                     }}
                 />
             </Spin>

--- a/client-ui/src/mes-moteurs.tsx
+++ b/client-ui/src/mes-moteurs.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Table, Tag, Spin, message, Checkbox, Button, Image } from 'antd';
+import { Card, Table, Tag, Spin, message, Checkbox, Button, Image, Divider, Typography } from 'antd';
 import { PictureOutlined, TagsOutlined } from '@ant-design/icons';
 import api from './api.ts';
+import ImageUpload from './ImageUpload.tsx';
+import DocumentUpload from './DocumentUpload.tsx';
 
 interface MoteurClientEntity {
     id: number;
@@ -10,6 +12,7 @@ interface MoteurClientEntity {
     dateAchat?: string;
     dateFinDeGuarantie?: string;
     images?: string[];
+    documents?: string[];
     modele?: { id: number; nom?: string; marque?: string };
 }
 
@@ -29,6 +32,9 @@ export default function MesMoteurs({ clientId, onCreateAnnonce }: MesMoteursProp
     const [moteurs, setMoteurs] = useState<MoteurClientEntity[]>([]);
     const [loading, setLoading] = useState(false);
     const [selectedImages, setSelectedImages] = useState<Record<number, Set<string>>>({});
+    const [draftImages, setDraftImages] = useState<Record<number, string[]>>({});
+    const [draftDocuments, setDraftDocuments] = useState<Record<number, string[]>>({});
+    const [savingMedias, setSavingMedias] = useState<Record<number, boolean>>({});
 
     useEffect(() => {
         setLoading(true);
@@ -62,6 +68,22 @@ export default function MesMoteurs({ clientId, onCreateAnnonce }: MesMoteursProp
             return;
         }
         onCreateAnnonce?.(Array.from(selected));
+    };
+
+    const handleSaveMedias = async (moteurId: number) => {
+        setSavingMedias((prev) => ({ ...prev, [moteurId]: true }));
+        const moteur = moteurs.find((m) => m.id === moteurId);
+        const images = draftImages[moteurId] ?? moteur?.images ?? [];
+        const documents = draftDocuments[moteurId] ?? moteur?.documents ?? [];
+        try {
+            await api.put(`/portal/clients/${clientId}/moteurs/${moteurId}/medias`, { images, documents });
+            setMoteurs((prev) => prev.map((m) => m.id === moteurId ? { ...m, images, documents } : m));
+            message.success('Médias sauvegardés');
+        } catch {
+            message.error('Erreur lors de la sauvegarde des médias');
+        } finally {
+            setSavingMedias((prev) => ({ ...prev, [moteurId]: false }));
+        }
     };
 
     const columns = [
@@ -108,69 +130,96 @@ export default function MesMoteurs({ clientId, onCreateAnnonce }: MesMoteursProp
     ];
 
     const expandedRowRender = (record: MoteurClientEntity) => {
-        const images = record.images || [];
-        if (images.length === 0) {
-            return <p style={{ color: '#999', fontStyle: 'italic' }}>Aucune image disponible</p>;
-        }
+        const savedImages = record.images || [];
         const selected = selectedImages[record.id] || new Set();
-        const allSelected = images.every((img) => selected.has(img));
+        const allSelected = savedImages.length > 0 && savedImages.every((img) => selected.has(img));
 
         return (
             <div>
-                <div style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Checkbox
-                        checked={allSelected}
-                        indeterminate={selected.size > 0 && !allSelected}
-                        onChange={() => toggleAll(record.id, images)}
-                    >
-                        Tout selectionner ({selected.size}/{images.length})
-                    </Checkbox>
-                    {onCreateAnnonce && (
-                        <Button
-                            type="primary"
-                            icon={<TagsOutlined />}
-                            disabled={selected.size === 0}
-                            onClick={() => handleCreateAnnonce(record)}
-                        >
-                            Creer une annonce avec {selected.size > 0 ? `${selected.size} photo(s)` : 'les photos'}
-                        </Button>
-                    )}
+                <Typography.Text strong>Photos</Typography.Text>
+                <div style={{ marginTop: 8 }}>
+                    <ImageUpload
+                        value={draftImages[record.id] ?? record.images ?? []}
+                        onChange={(urls) => setDraftImages((prev) => ({ ...prev, [record.id]: urls }))}
+                    />
                 </div>
-                <Image.PreviewGroup>
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                        {images.map((url, i) => (
-                            <div
-                                key={i}
-                                onClick={(e) => {
-                                    if (!(e.target as HTMLElement).closest('.ant-image-mask')) {
-                                        toggleImage(record.id, url);
-                                    }
-                                }}
-                                style={{
-                                    position: 'relative',
-                                    cursor: 'pointer',
-                                    border: selected.has(url) ? '3px solid #1890ff' : '3px solid transparent',
-                                    borderRadius: 8,
-                                    overflow: 'hidden',
-                                }}
+
+                <Divider style={{ margin: '12px 0' }} />
+                <Typography.Text strong>Documents</Typography.Text>
+                <div style={{ marginTop: 8 }}>
+                    <DocumentUpload
+                        value={draftDocuments[record.id] ?? record.documents ?? []}
+                        onChange={(urls) => setDraftDocuments((prev) => ({ ...prev, [record.id]: urls }))}
+                    />
+                </div>
+
+                <div style={{ marginTop: 12, display: 'flex', justifyContent: 'flex-end' }}>
+                    <Button
+                        type="primary"
+                        loading={savingMedias[record.id]}
+                        onClick={() => handleSaveMedias(record.id)}
+                    >
+                        Sauvegarder les modifications
+                    </Button>
+                </div>
+
+                {onCreateAnnonce && savedImages.length > 0 && (
+                    <>
+                        <Divider>Créer une annonce</Divider>
+                        <div style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <Checkbox
+                                checked={allSelected}
+                                indeterminate={selected.size > 0 && !allSelected}
+                                onChange={() => toggleAll(record.id, savedImages)}
                             >
-                                <Image
-                                    width={120}
-                                    height={120}
-                                    src={url}
-                                    style={{ objectFit: 'cover', display: 'block' }}
-                                    preview={{ mask: 'Agrandir' }}
-                                />
-                                <Checkbox
-                                    checked={selected.has(url)}
-                                    onChange={() => toggleImage(record.id, url)}
-                                    onClick={(e) => e.stopPropagation()}
-                                    style={{ position: 'absolute', top: 4, left: 4, zIndex: 1 }}
-                                />
+                                Tout selectionner ({selected.size}/{savedImages.length})
+                            </Checkbox>
+                            <Button
+                                type="primary"
+                                icon={<TagsOutlined />}
+                                disabled={selected.size === 0}
+                                onClick={() => handleCreateAnnonce(record)}
+                            >
+                                Creer une annonce avec {selected.size > 0 ? `${selected.size} photo(s)` : 'les photos'}
+                            </Button>
+                        </div>
+                        <Image.PreviewGroup>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                                {savedImages.map((url, i) => (
+                                    <div
+                                        key={i}
+                                        onClick={(e) => {
+                                            if (!(e.target as HTMLElement).closest('.ant-image-mask')) {
+                                                toggleImage(record.id, url);
+                                            }
+                                        }}
+                                        style={{
+                                            position: 'relative',
+                                            cursor: 'pointer',
+                                            border: selected.has(url) ? '3px solid #1890ff' : '3px solid transparent',
+                                            borderRadius: 8,
+                                            overflow: 'hidden',
+                                        }}
+                                    >
+                                        <Image
+                                            width={120}
+                                            height={120}
+                                            src={url}
+                                            style={{ objectFit: 'cover', display: 'block' }}
+                                            preview={{ mask: 'Agrandir' }}
+                                        />
+                                        <Checkbox
+                                            checked={selected.has(url)}
+                                            onChange={() => toggleImage(record.id, url)}
+                                            onClick={(e) => e.stopPropagation()}
+                                            style={{ position: 'absolute', top: 4, left: 4, zIndex: 1 }}
+                                        />
+                                    </div>
+                                ))}
                             </div>
-                        ))}
-                    </div>
-                </Image.PreviewGroup>
+                        </Image.PreviewGroup>
+                    </>
+                )}
             </div>
         );
     };
@@ -186,7 +235,7 @@ export default function MesMoteurs({ clientId, onCreateAnnonce }: MesMoteursProp
                     bordered
                     expandable={{
                         expandedRowRender,
-                        rowExpandable: (record) => (record.images || []).length > 0,
+                        rowExpandable: () => true,
                     }}
                 />
             </Spin>

--- a/client-ui/src/mes-remorques.tsx
+++ b/client-ui/src/mes-remorques.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Table, Tag, Spin, message, Checkbox, Button, Image } from 'antd';
+import { Card, Table, Tag, Spin, message, Checkbox, Button, Image, Divider, Typography } from 'antd';
 import { PictureOutlined, TagsOutlined } from '@ant-design/icons';
 import api from './api.ts';
+import ImageUpload from './ImageUpload.tsx';
+import DocumentUpload from './DocumentUpload.tsx';
 
 interface RemorqueClientEntity {
     id: number;
@@ -10,6 +12,7 @@ interface RemorqueClientEntity {
     dateAchat?: string;
     dateFinDeGuarantie?: string;
     images?: string[];
+    documents?: string[];
     modele?: { id: number; nom?: string; marque?: string };
 }
 
@@ -29,6 +32,9 @@ export default function MesRemorques({ clientId, onCreateAnnonce }: MesRemorques
     const [remorques, setRemorques] = useState<RemorqueClientEntity[]>([]);
     const [loading, setLoading] = useState(false);
     const [selectedImages, setSelectedImages] = useState<Record<number, Set<string>>>({});
+    const [draftImages, setDraftImages] = useState<Record<number, string[]>>({});
+    const [draftDocuments, setDraftDocuments] = useState<Record<number, string[]>>({});
+    const [savingMedias, setSavingMedias] = useState<Record<number, boolean>>({});
 
     useEffect(() => {
         setLoading(true);
@@ -62,6 +68,22 @@ export default function MesRemorques({ clientId, onCreateAnnonce }: MesRemorques
             return;
         }
         onCreateAnnonce?.(Array.from(selected));
+    };
+
+    const handleSaveMedias = async (remorqueId: number) => {
+        setSavingMedias((prev) => ({ ...prev, [remorqueId]: true }));
+        const remorque = remorques.find((r) => r.id === remorqueId);
+        const images = draftImages[remorqueId] ?? remorque?.images ?? [];
+        const documents = draftDocuments[remorqueId] ?? remorque?.documents ?? [];
+        try {
+            await api.put(`/portal/clients/${clientId}/remorques/${remorqueId}/medias`, { images, documents });
+            setRemorques((prev) => prev.map((r) => r.id === remorqueId ? { ...r, images, documents } : r));
+            message.success('Médias sauvegardés');
+        } catch {
+            message.error('Erreur lors de la sauvegarde des médias');
+        } finally {
+            setSavingMedias((prev) => ({ ...prev, [remorqueId]: false }));
+        }
     };
 
     const columns = [
@@ -108,69 +130,96 @@ export default function MesRemorques({ clientId, onCreateAnnonce }: MesRemorques
     ];
 
     const expandedRowRender = (record: RemorqueClientEntity) => {
-        const images = record.images || [];
-        if (images.length === 0) {
-            return <p style={{ color: '#999', fontStyle: 'italic' }}>Aucune image disponible</p>;
-        }
+        const savedImages = record.images || [];
         const selected = selectedImages[record.id] || new Set();
-        const allSelected = images.every((img) => selected.has(img));
+        const allSelected = savedImages.length > 0 && savedImages.every((img) => selected.has(img));
 
         return (
             <div>
-                <div style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Checkbox
-                        checked={allSelected}
-                        indeterminate={selected.size > 0 && !allSelected}
-                        onChange={() => toggleAll(record.id, images)}
-                    >
-                        Tout selectionner ({selected.size}/{images.length})
-                    </Checkbox>
-                    {onCreateAnnonce && (
-                        <Button
-                            type="primary"
-                            icon={<TagsOutlined />}
-                            disabled={selected.size === 0}
-                            onClick={() => handleCreateAnnonce(record)}
-                        >
-                            Creer une annonce avec {selected.size > 0 ? `${selected.size} photo(s)` : 'les photos'}
-                        </Button>
-                    )}
+                <Typography.Text strong>Photos</Typography.Text>
+                <div style={{ marginTop: 8 }}>
+                    <ImageUpload
+                        value={draftImages[record.id] ?? record.images ?? []}
+                        onChange={(urls) => setDraftImages((prev) => ({ ...prev, [record.id]: urls }))}
+                    />
                 </div>
-                <Image.PreviewGroup>
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                        {images.map((url, i) => (
-                            <div
-                                key={i}
-                                onClick={(e) => {
-                                    if (!(e.target as HTMLElement).closest('.ant-image-mask')) {
-                                        toggleImage(record.id, url);
-                                    }
-                                }}
-                                style={{
-                                    position: 'relative',
-                                    cursor: 'pointer',
-                                    border: selected.has(url) ? '3px solid #1890ff' : '3px solid transparent',
-                                    borderRadius: 8,
-                                    overflow: 'hidden',
-                                }}
+
+                <Divider style={{ margin: '12px 0' }} />
+                <Typography.Text strong>Documents</Typography.Text>
+                <div style={{ marginTop: 8 }}>
+                    <DocumentUpload
+                        value={draftDocuments[record.id] ?? record.documents ?? []}
+                        onChange={(urls) => setDraftDocuments((prev) => ({ ...prev, [record.id]: urls }))}
+                    />
+                </div>
+
+                <div style={{ marginTop: 12, display: 'flex', justifyContent: 'flex-end' }}>
+                    <Button
+                        type="primary"
+                        loading={savingMedias[record.id]}
+                        onClick={() => handleSaveMedias(record.id)}
+                    >
+                        Sauvegarder les modifications
+                    </Button>
+                </div>
+
+                {onCreateAnnonce && savedImages.length > 0 && (
+                    <>
+                        <Divider>Créer une annonce</Divider>
+                        <div style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <Checkbox
+                                checked={allSelected}
+                                indeterminate={selected.size > 0 && !allSelected}
+                                onChange={() => toggleAll(record.id, savedImages)}
                             >
-                                <Image
-                                    width={120}
-                                    height={120}
-                                    src={url}
-                                    style={{ objectFit: 'cover', display: 'block' }}
-                                    preview={{ mask: 'Agrandir' }}
-                                />
-                                <Checkbox
-                                    checked={selected.has(url)}
-                                    onChange={() => toggleImage(record.id, url)}
-                                    onClick={(e) => e.stopPropagation()}
-                                    style={{ position: 'absolute', top: 4, left: 4, zIndex: 1 }}
-                                />
+                                Tout selectionner ({selected.size}/{savedImages.length})
+                            </Checkbox>
+                            <Button
+                                type="primary"
+                                icon={<TagsOutlined />}
+                                disabled={selected.size === 0}
+                                onClick={() => handleCreateAnnonce(record)}
+                            >
+                                Creer une annonce avec {selected.size > 0 ? `${selected.size} photo(s)` : 'les photos'}
+                            </Button>
+                        </div>
+                        <Image.PreviewGroup>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                                {savedImages.map((url, i) => (
+                                    <div
+                                        key={i}
+                                        onClick={(e) => {
+                                            if (!(e.target as HTMLElement).closest('.ant-image-mask')) {
+                                                toggleImage(record.id, url);
+                                            }
+                                        }}
+                                        style={{
+                                            position: 'relative',
+                                            cursor: 'pointer',
+                                            border: selected.has(url) ? '3px solid #1890ff' : '3px solid transparent',
+                                            borderRadius: 8,
+                                            overflow: 'hidden',
+                                        }}
+                                    >
+                                        <Image
+                                            width={120}
+                                            height={120}
+                                            src={url}
+                                            style={{ objectFit: 'cover', display: 'block' }}
+                                            preview={{ mask: 'Agrandir' }}
+                                        />
+                                        <Checkbox
+                                            checked={selected.has(url)}
+                                            onChange={() => toggleImage(record.id, url)}
+                                            onClick={(e) => e.stopPropagation()}
+                                            style={{ position: 'absolute', top: 4, left: 4, zIndex: 1 }}
+                                        />
+                                    </div>
+                                ))}
                             </div>
-                        ))}
-                    </div>
-                </Image.PreviewGroup>
+                        </Image.PreviewGroup>
+                    </>
+                )}
             </div>
         );
     };
@@ -186,7 +235,7 @@ export default function MesRemorques({ clientId, onCreateAnnonce }: MesRemorques
                     bordered
                     expandable={{
                         expandedRowRender,
-                        rowExpandable: (record) => (record.images || []).length > 0,
+                        rowExpandable: () => true,
                     }}
                 />
             </Spin>


### PR DESCRIPTION
Closes #124

## Résumé

- Ajout de 3 endpoints `PUT /portal/clients/{clientId}/bateaux/{bateauId}/medias`, `.../moteurs/{id}/medias` et `.../remorques/{id}/medias` dans `ClientPortalResource` pour sauvegarder images et documents (vérification d'appartenance au client)
- Création de `DocumentUpload.tsx` dans `client-ui` (upload multipart vers `/documents` + gestion par URL)
- Dans `mes-bateaux.tsx`, `mes-moteurs.tsx`, `mes-remorques.tsx` : lignes toujours expandables avec sections `ImageUpload` et `DocumentUpload` éditables, bouton « Sauvegarder les modifications »
- La sélection de photos pour la création d'annonce est préservée en dessous de la section médias

## Plan de test

- [x] Ouvrir l'espace client et dérouler un bateau sans photos → zone d'upload visible
- [x] Uploader une image → la miniature apparaît, cliquer Sauvegarder → rechargement confirme la persistance
- [x] Supprimer une image existante, sauvegarder → la photo disparaît
- [x] Uploader un PDF dans la section Documents, sauvegarder → document listé avec icône PDF
- [x] Tester le même flux sur un moteur et une remorque
- [x] Vérifier que la section « Créer une annonce » reste fonctionnelle sur les bateaux ayant des photos sauvegardées
- [x] Tester qu'un client ne peut pas modifier les médias d'un véhicule ne lui appartenant pas (403)