### PR TITLE
feat: accès aux prestations depuis la fiche client/bateau/moteur/remorque (#119)

### DIFF
--- a/chantier-ui/src/PrestationsList.tsx
+++ b/chantier-ui/src/PrestationsList.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import { Table, Tag, Spin, Button, message } from 'antd';
+import { EyeOutlined, PlusCircleOutlined } from '@ant-design/icons';
+import api from './api.ts';
+import { useNavigation } from './navigation-context.tsx';
+
+interface Vente {
+    id: number;
+    reference?: string;
+    dateDevis?: string;
+    status: string;
+    montantTTC: number;
+    client?: { id: number; prenom?: string; nom?: string };
+}
+
+interface PrestationsListProps {
+    clientId?: number;
+    bateauId?: number;
+    moteurId?: number;
+    remorqueId?: number;
+}
+
+const statusColor: Record<string, string> = {
+    DEVIS: 'default',
+    FACTURE_EN_ATTENTE: 'orange',
+    FACTURE_PRETE: 'blue',
+    FACTURE_PAYEE: 'green',
+};
+
+const statusLabel: Record<string, string> = {
+    DEVIS: 'Devis / OR',
+    FACTURE_EN_ATTENTE: 'Facture en attente',
+    FACTURE_PRETE: 'Facture prête',
+    FACTURE_PAYEE: 'Facture payée',
+};
+
+export default function PrestationsList({ clientId, bateauId, moteurId, remorqueId }: PrestationsListProps) {
+    const [ventes, setVentes] = useState<Vente[]>([]);
+    const [loading, setLoading] = useState(false);
+    const { navigate } = useNavigation();
+
+    useEffect(() => {
+        if (!clientId && !bateauId && !moteurId && !remorqueId) return;
+        const params = new URLSearchParams();
+        if (clientId) params.append('clientId', String(clientId));
+        if (bateauId) params.append('bateauId', String(bateauId));
+        if (moteurId) params.append('moteurId', String(moteurId));
+        if (remorqueId) params.append('remorqueId', String(remorqueId));
+        setLoading(true);
+        api.get(`/ventes/search?${params.toString()}`)
+            .then((res) => setVentes(res.data || []))
+            .catch(() => message.error('Erreur lors du chargement des prestations'))
+            .finally(() => setLoading(false));
+    }, [clientId, bateauId, moteurId, remorqueId]);
+
+    const columns = [
+        {
+            title: 'Référence',
+            dataIndex: 'reference',
+            key: 'reference',
+            render: (v: string) => v || '-',
+        },
+        {
+            title: 'Date',
+            dataIndex: 'dateDevis',
+            key: 'dateDevis',
+            render: (v: string) => v ? new Date(v).toLocaleDateString('fr-FR') : '-',
+        },
+        {
+            title: 'Statut',
+            dataIndex: 'status',
+            key: 'status',
+            render: (s: string) => <Tag color={statusColor[s] || 'default'}>{statusLabel[s] || s}</Tag>,
+        },
+        {
+            title: 'Montant TTC',
+            dataIndex: 'montantTTC',
+            key: 'montantTTC',
+            align: 'right' as const,
+            render: (v: number) =>
+                v != null
+                    ? v.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' €'
+                    : '-',
+        },
+        {
+            title: '',
+            key: 'actions',
+            width: 60,
+            render: (_: unknown, record: Vente) => (
+                <Button
+                    size="small"
+                    icon={<EyeOutlined />}
+                    onClick={() => navigate('/prestations', { clientId: record.client?.id })}
+                    title="Voir les prestations"
+                />
+            ),
+        },
+    ];
+
+    return (
+        <div>
+            <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'flex-end' }}>
+                <Button
+                    type="primary"
+                    size="small"
+                    icon={<PlusCircleOutlined />}
+                    onClick={() => navigate('/prestations', { clientId })}
+                >
+                    Créer une prestation
+                </Button>
+            </div>
+            <Spin spinning={loading}>
+                <Table
+                    rowKey="id"
+                    dataSource={ventes}
+                    columns={columns}
+                    size="small"
+                    pagination={{ pageSize: 5, hideOnSinglePage: true }}
+                    locale={{ emptyText: 'Aucune prestation' }}
+                />
+            </Spin>
+        </div>
+    );
+}

--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -20,6 +20,7 @@ import {
   DatePicker,
   Checkbox,
   Divider,
+  Tabs,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -38,6 +39,7 @@ import dayjs from "dayjs";
 import LocationPicker from "./LocationPicker.tsx";
 import { useNavigation } from './navigation-context.tsx';
 import HistoriqueOperations from './historique-operations.tsx';
+import PrestationsList from './PrestationsList.tsx';
 
 const { Option } = Select;
 const { Search } = Input;
@@ -671,7 +673,20 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         {editing && editing.id && (
           <>
             <Divider />
-            <HistoriqueOperations bateauId={editing.id} />
+            <Tabs
+              items={[
+                {
+                  key: 'prestations',
+                  label: 'Prestations',
+                  children: <PrestationsList bateauId={editing.id} />,
+                },
+                {
+                  key: 'historique',
+                  label: 'Historique',
+                  children: <HistoriqueOperations bateauId={editing.id} />,
+                },
+              ]}
+            />
           </>
         )}
       </Modal>

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -4,6 +4,8 @@ import {
   Button,
   Modal,
   Form,
+  Divider,
+  Tabs,
   Input,
   InputNumber,
   Select,
@@ -19,7 +21,6 @@ import {
   Col,
   DatePicker,
   Checkbox,
-  Divider,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -36,6 +37,7 @@ import DocumentUpload from './DocumentUpload.tsx';
 import dayjs from "dayjs";
 import { useNavigation } from './navigation-context.tsx';
 import HistoriqueOperations from './historique-operations.tsx';
+import PrestationsList from './PrestationsList.tsx';
 
 const { Option } = Select;
 const { Search } = Input;
@@ -519,7 +521,20 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         {editing && editing.id && (
           <>
             <Divider />
-            <HistoriqueOperations moteurId={editing.id} />
+            <Tabs
+              items={[
+                {
+                  key: 'prestations',
+                  label: 'Prestations',
+                  children: <PrestationsList moteurId={editing.id} />,
+                },
+                {
+                  key: 'historique',
+                  label: 'Historique',
+                  children: <HistoriqueOperations moteurId={editing.id} />,
+                },
+              ]}
+            />
           </>
         )}
       </Modal>

--- a/chantier-ui/src/clients-remorques.tsx
+++ b/chantier-ui/src/clients-remorques.tsx
@@ -19,6 +19,7 @@ import {
   DatePicker,
   Checkbox,
   Divider,
+  Tabs,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -34,6 +35,7 @@ import DocumentUpload from './DocumentUpload.tsx';
 import dayjs from "dayjs";
 import { useNavigation } from './navigation-context.tsx';
 import HistoriqueOperations from './historique-operations.tsx';
+import PrestationsList from './PrestationsList.tsx';
 
 const { Option } = Select;
 const { Search } = Input;
@@ -470,7 +472,20 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
         {editing && editing.id && (
           <>
             <Divider />
-            <HistoriqueOperations remorqueId={editing.id} />
+            <Tabs
+              items={[
+                {
+                  key: 'prestations',
+                  label: 'Prestations',
+                  children: <PrestationsList remorqueId={editing.id} />,
+                },
+                {
+                  key: 'historique',
+                  label: 'Historique',
+                  children: <HistoriqueOperations remorqueId={editing.id} />,
+                },
+              ]}
+            />
           </>
         )}
       </Modal>

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -17,6 +17,7 @@ import {
   Col,
   Checkbox,
   Alert,
+  Tabs,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -32,7 +33,6 @@ import {
   ShopOutlined,
   GlobalOutlined,
   PhoneOutlined,
-  ToolOutlined,
 } from "@ant-design/icons";
 import api from "./api.ts";
 import BateauxClients from "./clients-bateaux.tsx";
@@ -40,7 +40,7 @@ import ClientsMoteurs from "./clients-moteurs.tsx";
 import RemorquesClients from "./clients-remorques.tsx";
 import ClientsAvoirs from "./clients-avoirs.tsx";
 import DocumentUpload from "./DocumentUpload.tsx";
-import { useNavigation } from "./navigation-context.tsx";
+import PrestationsList from "./PrestationsList.tsx";
 import HistoriqueOperations from "./historique-operations.tsx";
 
 const { Option } = Select;
@@ -105,7 +105,6 @@ const canalAcquisitionOptions = [
 ];
 
 function Clients() {
-  const { navigate } = useNavigation();
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
@@ -559,27 +558,38 @@ function Clients() {
         {editing && editing.id && (
           <>
             <Divider />
-            <Button
-              type="primary"
-              icon={<ToolOutlined />}
-              onClick={() => {
-                setModalVisible(false);
-                navigate('/prestations', { clientId: editing.id });
-              }}
-            >
-              Créer une prestation
-            </Button>
-            <Divider />
-            {/* Affiche la liste des bateaux pour ce client */}
-            <BateauxClients clientId={editing.id} />
-            <Divider />
-            <ClientsMoteurs clientId={editing.id} />
-            <Divider />
-            <RemorquesClients clientId={editing.id} />
-            <Divider />
-            <HistoriqueOperations clientId={editing.id} />
-            <Divider />
-            <ClientsAvoirs clientId={editing.id} />
+            <Tabs
+              items={[
+                {
+                  key: 'vehicules',
+                  label: 'Véhicules',
+                  children: (
+                    <>
+                      <BateauxClients clientId={editing.id} />
+                      <Divider />
+                      <ClientsMoteurs clientId={editing.id} />
+                      <Divider />
+                      <RemorquesClients clientId={editing.id} />
+                    </>
+                  ),
+                },
+                {
+                  key: 'prestations',
+                  label: 'Prestations',
+                  children: <PrestationsList clientId={editing.id} />,
+                },
+                {
+                  key: 'historique',
+                  label: 'Historique',
+                  children: <HistoriqueOperations clientId={editing.id} />,
+                },
+                {
+                  key: 'avoirs',
+                  label: 'Avoirs',
+                  children: <ClientsAvoirs clientId={editing.id} />,
+                },
+              ]}
+            />
           </>
         )}
       </Modal>


### PR DESCRIPTION
Closes #119

## Résumé

- Ajout des query params `bateauId`, `moteurId`, `remorqueId` dans `GET /ventes/search` (en plus du `clientId` existant)
- Nouveau composant `PrestationsList.tsx` : table compacte (référence, date, statut coloré, montant TTC, bouton «Voir») avec bouton «Créer une prestation»
- **Fiche client** : section en bas du modal organisée en deux onglets — **Véhicules** (bateaux/moteurs/remorques existants) et **Prestations**
- **Fiche bateau / moteur / remorque** : onglet **Prestations** affiché en bas du modal lors de l'édition d'un véhicule existant

## Plan de test

- [x] Ouvrir la fiche d'un client existant → les onglets «Véhicules» et «Prestations» s'affichent
- [x] Onglet Prestations client → liste les ventes du client (statuts colorés, montants)
- [x] Bouton «Créer une prestation» navigue vers /prestations avec le clientId pré-rempli
- [x] Ouvrir la fiche d'un bateau existant → onglet Prestations visible en bas
- [x] Onglet Prestations bateau → liste uniquement les ventes liées à ce bateau
- [x] Tester de même pour un moteur et une remorque
- [x] Vérifier que la sauvegarde du formulaire (Enregistrer) fonctionne toujours depuis n'importe quel onglet actif