### PR TITLE
fix: corriger l'affichage du logo (client-ui & technicien-ui)

### DIFF
--- a/client-ui/public/index.html
+++ b/client-ui/public/index.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="moussAIllon, plate-forme de gestion de chantier naval" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" href="/logo.png" />
   <title>moussAIllon</title>
 </head>
 

--- a/client-ui/public/index.html
+++ b/client-ui/public/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="moussAIllon, plate-forme de gestion de chantier naval" />
-  <link rel="icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" href="/logo.png" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.png" />
   <title>moussAIllon</title>
 </head>
 

--- a/client-ui/src/app.css
+++ b/client-ui/src/app.css
@@ -1,12 +1,13 @@
 /* ── Logo ────────────────────────────────────────── */
 .logo {
-    height: 96px;
+    height: auto;
     margin: 20px 16px 8px;
     padding-bottom: 16px;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 12px;
+    gap: 8px;
     color: #fff;
     font-size: 1.35em;
     font-weight: 600;

--- a/client-ui/src/app.css
+++ b/client-ui/src/app.css
@@ -1,6 +1,6 @@
 /* ── Logo ────────────────────────────────────────── */
 .logo {
-    height: 64px;
+    height: 96px;
     margin: 20px 16px 8px;
     padding-bottom: 16px;
     display: flex;

--- a/client-ui/src/app.tsx
+++ b/client-ui/src/app.tsx
@@ -117,7 +117,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={64} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
+                    <Image width={80} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu

--- a/client-ui/src/app.tsx
+++ b/client-ui/src/app.tsx
@@ -117,7 +117,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={40} src="./logo.png" preview={false} />
+                    <Image width={40} src="/logo.png" preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu

--- a/client-ui/src/app.tsx
+++ b/client-ui/src/app.tsx
@@ -117,7 +117,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={40} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
+                    <Image width={64} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu

--- a/client-ui/src/app.tsx
+++ b/client-ui/src/app.tsx
@@ -118,7 +118,6 @@ export default function App() {
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
                     <Image width={80} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
-                    <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu
                     theme="dark"

--- a/client-ui/src/app.tsx
+++ b/client-ui/src/app.tsx
@@ -117,7 +117,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={40} src="/logo.png" preview={false} />
+                    <Image width={40} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu

--- a/technicien-ui/public/index.html
+++ b/technicien-ui/public/index.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="moussAIllon - Espace Technicien" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" href="/logo.png" />
   <title>moussAIllon - Technicien</title>
 </head>
 

--- a/technicien-ui/public/index.html
+++ b/technicien-ui/public/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="moussAIllon - Espace Technicien" />
-  <link rel="icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" href="/logo.png" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.png" />
   <title>moussAIllon - Technicien</title>
 </head>
 

--- a/technicien-ui/src/app.css
+++ b/technicien-ui/src/app.css
@@ -1,12 +1,13 @@
 /* ── Logo ────────────────────────────────────────── */
 .logo {
-    height: 96px;
+    height: auto;
     margin: 20px 16px 8px;
     padding-bottom: 16px;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 12px;
+    gap: 8px;
     color: #fff;
     font-size: 1.35em;
     font-weight: 600;

--- a/technicien-ui/src/app.css
+++ b/technicien-ui/src/app.css
@@ -1,6 +1,6 @@
 /* ── Logo ────────────────────────────────────────── */
 .logo {
-    height: 64px;
+    height: 96px;
     margin: 20px 16px 8px;
     padding-bottom: 16px;
     display: flex;

--- a/technicien-ui/src/app.tsx
+++ b/technicien-ui/src/app.tsx
@@ -66,7 +66,6 @@ export default function App() {
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
                     <Image width={80} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
-                    <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu
                     theme="dark"

--- a/technicien-ui/src/app.tsx
+++ b/technicien-ui/src/app.tsx
@@ -65,7 +65,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={64} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
+                    <Image width={80} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu

--- a/technicien-ui/src/app.tsx
+++ b/technicien-ui/src/app.tsx
@@ -65,7 +65,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={40} src="./logo.png" preview={false} />
+                    <Image width={40} src="/logo.png" preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu

--- a/technicien-ui/src/app.tsx
+++ b/technicien-ui/src/app.tsx
@@ -65,7 +65,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={40} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
+                    <Image width={64} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu

--- a/technicien-ui/src/app.tsx
+++ b/technicien-ui/src/app.tsx
@@ -65,7 +65,7 @@ export default function App() {
         <Layout className="layout">
             <Sider breakpoint="lg" collapsedWidth="0">
                 <div className="logo">
-                    <Image width={40} src="/logo.png" preview={false} />
+                    <Image width={40} src={process.env.PUBLIC_URL + '/logo.png'} preview={false} />
                     <span style={{ fontWeight: 600, letterSpacing: '1.5px', fontSize: '1.2em' }}>mouss<span style={{ color: '#4096ff' }}>AI</span>llon</span>
                 </div>
                 <Menu


### PR DESCRIPTION
## Résumé
- Remplacement de `./logo.png` (chemin relatif) par `/logo.png` (absolu) dans `app.tsx` des deux UIs — le chemin relatif cassait lorsque l'URL contient une sous-route
- Ajout des balises `<link rel="icon" href="/favicon.ico">` et `<link rel="apple-touch-icon" href="/logo.png">` manquantes dans `public/index.html` des deux UIs — leur absence explique l'icône vide sur l'onglet du navigateur

## Test
- Vérifier que le logo s'affiche dans la barre latérale après navigation vers une sous-page
- Vérifier que l'icône de l'onglet s'affiche correctement

Closes #428