### PR TITLE
feat: bouton Payer dans la page Facturation (#430)

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
@@ -61,4 +61,10 @@ public class SocieteEntity extends PanacheEntity {
     @OrderBy("date DESC")
     public List<SocietePaiementEntity> paiements = new ArrayList<>();
 
+    // Liens de paiement externe (Stripe / PayPlug) configurables par l'administrateur.
+    public String stripePaymentLinkMensuel;
+    public String stripePaymentLinkAnnuel;
+    public String payplugPaymentLinkMensuel;
+    public String payplugPaymentLinkAnnuel;
+
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
@@ -2,8 +2,7 @@ package net.nanthrax.moussaillon.persistence;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.json.bind.annotation.JsonbTypeAdapter;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -57,5 +56,9 @@ public class SocieteEntity extends PanacheEntity {
     public Timestamp abonnementProchainPaiementDate;
 
     public Double abonnementProchainPaiementMontant;
+
+    @OneToMany(mappedBy = "societe", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OrderBy("date DESC")
+    public List<SocietePaiementEntity> paiements = new ArrayList<>();
 
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocietePaiementEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocietePaiementEntity.java
@@ -12,7 +12,7 @@ public class SocietePaiementEntity extends PanacheEntity {
 
     public enum Type { MENSUEL, ANNUEL }
 
-    public enum Mode { CHEQUE, VIREMENT, CARTE, ESPÈCES }
+    public enum Mode { VIREMENT, CARTE, STRIPE, PAYPLUG }
 
     @Enumerated(EnumType.STRING)
     public Type type;

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocietePaiementEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocietePaiementEntity.java
@@ -1,0 +1,32 @@
+package net.nanthrax.moussaillon.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.json.bind.annotation.JsonbTypeAdapter;
+import jakarta.json.bind.annotation.JsonbTransient;
+import jakarta.persistence.*;
+
+import java.sql.Timestamp;
+
+@Entity
+public class SocietePaiementEntity extends PanacheEntity {
+
+    public enum Type { MENSUEL, ANNUEL }
+
+    public enum Mode { CHEQUE, VIREMENT, CARTE, ESPÈCES }
+
+    @Enumerated(EnumType.STRING)
+    public Type type;
+
+    public double montant;
+
+    @Enumerated(EnumType.STRING)
+    public Mode mode;
+
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp date;
+
+    @ManyToOne
+    @JsonbTransient
+    public SocieteEntity societe;
+
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -8,6 +8,7 @@ import net.nanthrax.moussaillon.persistence.SocieteEntity;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.List;
 
 @Path("/societe")
 @ApplicationScoped
@@ -15,9 +16,14 @@ import java.time.Instant;
 @Consumes(MediaType.APPLICATION_JSON)
 public class SocieteResource {
 
-    // Tarifs de l'abonnement (informations en lecture seule).
     static final double MONTANT_ACTIVATION = 350.0;
-    static final double MONTANT_ABONNEMENT = 150.0;
+    static final double MONTANT_ABONNEMENT_MENSUEL = 150.0;
+    static final double MONTANT_ABONNEMENT_ANNUEL = 1650.0; // 11 mois × 150 € (1 mois offert)
+
+    public static class PaiementRequest {
+        public String type; // MENSUEL | ANNUEL
+        public String signature;
+    }
 
     @GET
     @Transactional
@@ -58,6 +64,29 @@ public class SocieteResource {
         return entity;
     }
 
+    @POST
+    @Path("/paiement")
+    @Transactional
+    public SocieteEntity payer(PaiementRequest request) {
+        if (request.type == null || (!request.type.equals("MENSUEL") && !request.type.equals("ANNUEL"))) {
+            throw new WebApplicationException("Type de paiement invalide (MENSUEL ou ANNUEL attendu)", 400);
+        }
+        if (request.signature == null || request.signature.isBlank()) {
+            throw new WebApplicationException("La signature est requise", 400);
+        }
+        SocieteEntity entity = SocieteEntity.findById(1);
+        if (entity == null) {
+            throw new WebApplicationException("La société n'est pas trouvée", 404);
+        }
+        initAbonnement(entity);
+
+        int mois = request.type.equals("ANNUEL") ? 12 : 1;
+        entity.abonnementProchainPaiementDate = Timestamp.valueOf(
+            entity.abonnementProchainPaiementDate.toLocalDateTime().plusMonths(mois));
+
+        return entity;
+    }
+
     /**
      * Renseigne, si nécessaire, les informations d'abonnement du compte :
      * date d'activation = date de création du compte, montant d'activation de 350 €,
@@ -78,7 +107,7 @@ public class SocieteResource {
                 entity.abonnementActivationDate.toLocalDateTime().plusMonths(1));
         }
         if (entity.abonnementProchainPaiementMontant == null) {
-            entity.abonnementProchainPaiementMontant = MONTANT_ABONNEMENT;
+            entity.abonnementProchainPaiementMontant = MONTANT_ABONNEMENT_MENSUEL;
         }
     }
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -5,10 +5,10 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
+import net.nanthrax.moussaillon.persistence.SocietePaiementEntity;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.List;
 
 @Path("/societe")
 @ApplicationScoped
@@ -22,6 +22,7 @@ public class SocieteResource {
 
     public static class PaiementRequest {
         public String type; // MENSUEL | ANNUEL
+        public String mode; // CHEQUE | VIREMENT | CARTE | ESPÈCES
         public String signature;
     }
 
@@ -71,6 +72,12 @@ public class SocieteResource {
         if (request.type == null || (!request.type.equals("MENSUEL") && !request.type.equals("ANNUEL"))) {
             throw new WebApplicationException("Type de paiement invalide (MENSUEL ou ANNUEL attendu)", 400);
         }
+        SocietePaiementEntity.Mode mode;
+        try {
+            mode = SocietePaiementEntity.Mode.valueOf(request.mode);
+        } catch (Exception e) {
+            throw new WebApplicationException("Mode de paiement invalide", 400);
+        }
         if (request.signature == null || request.signature.isBlank()) {
             throw new WebApplicationException("La signature est requise", 400);
         }
@@ -81,8 +88,19 @@ public class SocieteResource {
         initAbonnement(entity);
 
         int mois = request.type.equals("ANNUEL") ? 12 : 1;
+        double montant = request.type.equals("ANNUEL") ? MONTANT_ABONNEMENT_ANNUEL : MONTANT_ABONNEMENT_MENSUEL;
+
         entity.abonnementProchainPaiementDate = Timestamp.valueOf(
             entity.abonnementProchainPaiementDate.toLocalDateTime().plusMonths(mois));
+
+        SocietePaiementEntity paiement = new SocietePaiementEntity();
+        paiement.type = SocietePaiementEntity.Type.valueOf(request.type);
+        paiement.montant = montant;
+        paiement.mode = mode;
+        paiement.date = Timestamp.from(Instant.now());
+        paiement.societe = entity;
+        paiement.persist();
+        entity.paiements.add(0, paiement);
 
         return entity;
     }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -58,8 +58,10 @@ public class SocieteResource {
         entity.email = societe.email;
         entity.bancaire = societe.bancaire;
         entity.images = societe.images;
-        // Les informations d'abonnement sont en lecture seule : elles ne sont pas
-        // modifiables par le client et restent gérées par le serveur.
+        entity.stripePaymentLinkMensuel = societe.stripePaymentLinkMensuel;
+        entity.stripePaymentLinkAnnuel = societe.stripePaymentLinkAnnuel;
+        entity.payplugPaymentLinkMensuel = societe.payplugPaymentLinkMensuel;
+        entity.payplugPaymentLinkAnnuel = societe.payplugPaymentLinkAnnuel;
         initAbonnement(entity);
 
         return entity;

--- a/chantier-ui/package-lock.json
+++ b/chantier-ui/package-lock.json
@@ -13,6 +13,7 @@
         "@types/leaflet": "^1.9.21",
         "antd": "^6.5.0",
         "axios": "^1.18.1",
+        "jspdf": "^4.2.1",
         "leaflet": "^1.9.4",
         "react": "^19.2.6",
         "react-dom": "^19.2.7",
@@ -5801,6 +5802,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5824,6 +5831,13 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -7714,6 +7728,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
@@ -9345,6 +9379,16 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -10570,6 +10614,17 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -10637,6 +10692,12 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -11953,6 +12014,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
@@ -15119,6 +15186,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -16140,6 +16224,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -18566,6 +18666,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -19377,6 +19487,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -19812,6 +19932,16 @@
       "resolved": "https://registry.npmjs.org/svg-path-parser/-/svg-path-parser-1.1.0.tgz",
       "integrity": "sha512-jGCUqcQyXpfe38R7RFfhrMyfXcBmpMNJI/B+4CE9/Unkh98UporAc461GTthv+TVDuZXsBx7/WiwJb1Oh4tt4A==",
       "license": "MIT"
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/svgo": {
       "version": "1.3.2",
@@ -20548,6 +20678,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/chantier-ui/package.json
+++ b/chantier-ui/package.json
@@ -8,6 +8,7 @@
     "@types/leaflet": "^1.9.21",
     "antd": "^6.5.0",
     "axios": "^1.18.1",
+    "jspdf": "^4.2.1",
     "leaflet": "^1.9.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.7",

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './api.ts';
-import { useState, useEffect } from 'react';
-import { Card, Space, Descriptions, Spin, message } from 'antd';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Button, Card, Descriptions, Modal, Space, Spin, message } from 'antd';
 import { CreditCardOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 
@@ -10,53 +10,192 @@ const formatMontant = (value) => (value != null
     ? new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(value)
     : '—');
 
+type PaiementType = 'MENSUEL' | 'ANNUEL';
+
 export default function Facturation() {
 
-    const [ societe, setSociete ] = useState();
+    const [societe, setSociete] = useState<any>(null);
+    const [paiementType, setPaiementType] = useState<PaiementType | null>(null);
+    const [signatureModalOpen, setSignatureModalOpen] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
 
-    useEffect(() => {
-       fetchWithAuth('./societe')
-       .then((response) => {
-            if (!response.ok) {
-                throw new Error('Erreur (code ' + response.status + ')');
-            };
-            return response.json();
-       })
-       .then(data => {
-           setSociete(data);
-       })
-       .catch((error) => {
-            message.error('Une erreur est survenue: ' + error.message);
-            console.error(error)
-       })
+    const signatureCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const signatureDrawingRef = useRef(false);
+
+    const fetchSociete = useCallback(() => {
+        fetchWithAuth('./societe')
+            .then((response) => {
+                if (!response.ok) throw new Error('Erreur (code ' + response.status + ')');
+                return response.json();
+            })
+            .then(data => setSociete(data))
+            .catch((error) => message.error('Une erreur est survenue: ' + error.message));
     }, []);
 
+    useEffect(() => { fetchSociete(); }, [fetchSociete]);
+
+    const initSignatureCanvas = useCallback(() => {
+        setTimeout(() => {
+            const canvas = signatureCanvasRef.current;
+            if (!canvas) return;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) return;
+            canvas.width = canvas.offsetWidth;
+            canvas.height = canvas.offsetHeight;
+            ctx.fillStyle = '#fff';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.strokeStyle = '#000';
+            ctx.lineWidth = 2;
+            ctx.lineCap = 'round';
+            ctx.lineJoin = 'round';
+
+            let drawing = false;
+            const getPos = (e: MouseEvent | TouchEvent) => {
+                const rect = canvas.getBoundingClientRect();
+                if ('touches' in e) {
+                    return { x: e.touches[0].clientX - rect.left, y: e.touches[0].clientY - rect.top };
+                }
+                return { x: (e as MouseEvent).clientX - rect.left, y: (e as MouseEvent).clientY - rect.top };
+            };
+            const onStart = (e: MouseEvent | TouchEvent) => { e.preventDefault(); drawing = true; const p = getPos(e); ctx.beginPath(); ctx.moveTo(p.x, p.y); signatureDrawingRef.current = true; };
+            const onMove = (e: MouseEvent | TouchEvent) => { if (!drawing) return; e.preventDefault(); const p = getPos(e); ctx.lineTo(p.x, p.y); ctx.stroke(); };
+            const onEnd = () => { drawing = false; };
+
+            canvas.addEventListener('mousedown', onStart);
+            canvas.addEventListener('mousemove', onMove);
+            canvas.addEventListener('mouseup', onEnd);
+            canvas.addEventListener('mouseleave', onEnd);
+            canvas.addEventListener('touchstart', onStart, { passive: false });
+            canvas.addEventListener('touchmove', onMove, { passive: false });
+            canvas.addEventListener('touchend', onEnd);
+        }, 100);
+    }, []);
+
+    const clearSignatureCanvas = () => {
+        const canvas = signatureCanvasRef.current;
+        if (!canvas) return;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        signatureDrawingRef.current = false;
+    };
+
+    const openPaiementModal = (type: PaiementType) => {
+        setPaiementType(type);
+        signatureDrawingRef.current = false;
+        setSignatureModalOpen(true);
+        initSignatureCanvas();
+    };
+
+    const handlePaiementConfirm = () => {
+        if (!signatureDrawingRef.current) {
+            message.warning('La signature est requise pour valider le paiement');
+            return;
+        }
+        const canvas = signatureCanvasRef.current;
+        const signature = canvas ? canvas.toDataURL('image/png') : '';
+
+        setSubmitting(true);
+        fetchWithAuth('./societe/paiement', {
+            method: 'POST',
+            body: JSON.stringify({ type: paiementType, signature }),
+        })
+            .then((response) => {
+                if (!response.ok) throw new Error('Erreur (code ' + response.status + ')');
+                return response.json();
+            })
+            .then((data) => {
+                setSociete(data);
+                setSignatureModalOpen(false);
+                message.success('Paiement enregistré avec succès');
+            })
+            .catch((error) => message.error('Une erreur est survenue: ' + error.message))
+            .finally(() => setSubmitting(false));
+    };
+
+    const montantPaiement = paiementType === 'ANNUEL' ? 1650 : 150;
+    const labelPaiement = paiementType === 'ANNUEL'
+        ? 'Paiement annuel — 1 650 EUR (1 mois offert)'
+        : 'Paiement mensuel — 150 EUR';
+
     if (!societe) {
-        return(<Spin/>);
+        return <Spin />;
     }
 
-    return(
-      <Card title={<Space><CreditCardOutlined/> Facturation</Space>}>
-          <Descriptions
-              title="Abonnement"
-              column={1}
-              bordered
-              size="small"
-          >
-              <Descriptions.Item label="Date d'activation (paiement one-shot)">
-                  {formatDate(societe.abonnementActivationDate)}
-              </Descriptions.Item>
-              <Descriptions.Item label="Montant d'activation">
-                  {formatMontant(societe.abonnementActivationMontant)}
-              </Descriptions.Item>
-              <Descriptions.Item label="Prochaine échéance">
-                  {formatDate(societe.abonnementProchainPaiementDate)}
-              </Descriptions.Item>
-              <Descriptions.Item label="Montant à payer">
-                  {formatMontant(societe.abonnementProchainPaiementMontant)}
-              </Descriptions.Item>
-          </Descriptions>
-      </Card>
-    );
+    return (
+        <>
+            <Card title={<Space><CreditCardOutlined /> Facturation</Space>}>
+                <Descriptions
+                    title="Abonnement"
+                    column={1}
+                    bordered
+                    size="small"
+                >
+                    <Descriptions.Item label="Date d'activation (paiement one-shot)">
+                        {formatDate(societe.abonnementActivationDate)}
+                    </Descriptions.Item>
+                    <Descriptions.Item label="Montant d'activation">
+                        {formatMontant(societe.abonnementActivationMontant)}
+                    </Descriptions.Item>
+                    <Descriptions.Item label="Prochaine échéance">
+                        {formatDate(societe.abonnementProchainPaiementDate)}
+                    </Descriptions.Item>
+                    <Descriptions.Item label="Montant à payer">
+                        {formatMontant(societe.abonnementProchainPaiementMontant)}
+                    </Descriptions.Item>
+                </Descriptions>
 
+                <Space style={{ marginTop: 24 }}>
+                    <Button
+                        type="primary"
+                        icon={<CreditCardOutlined />}
+                        onClick={() => openPaiementModal('MENSUEL')}
+                    >
+                        Payer ce mois — 150 EUR
+                    </Button>
+                    <Button
+                        icon={<CreditCardOutlined />}
+                        onClick={() => openPaiementModal('ANNUEL')}
+                    >
+                        Payer l'année — 1 650 EUR (1 mois offert)
+                    </Button>
+                </Space>
+            </Card>
+
+            <Modal
+                title={labelPaiement}
+                open={signatureModalOpen}
+                onCancel={() => setSignatureModalOpen(false)}
+                width={520}
+                footer={[
+                    <Button key="clear" onClick={clearSignatureCanvas}>
+                        Effacer la signature
+                    </Button>,
+                    <Button key="cancel" onClick={() => setSignatureModalOpen(false)}>
+                        Annuler
+                    </Button>,
+                    <Button key="confirm" type="primary" loading={submitting} onClick={handlePaiementConfirm}>
+                        Confirmer le paiement ({formatMontant(montantPaiement)})
+                    </Button>,
+                ]}
+            >
+                <p style={{ marginBottom: 8 }}>
+                    Veuillez signer ci-dessous pour confirmer votre accord de paiement.
+                </p>
+                <canvas
+                    ref={signatureCanvasRef}
+                    style={{
+                        width: '100%',
+                        height: 160,
+                        border: '1px solid #d9d9d9',
+                        borderRadius: 4,
+                        display: 'block',
+                        cursor: 'crosshair',
+                        touchAction: 'none',
+                    }}
+                />
+            </Modal>
+        </>
+    );
 }

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Button, Card, Descriptions, Divider, Select, Space, Spin, Table, Tag, Tooltip, message } from 'antd';
 import { CreditCardOutlined, DownloadOutlined, LinkOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
+import { jsPDF } from 'jspdf';
 
 const formatDate = (value: any) => (value ? dayjs(value).format('DD/MM/YYYY') : '—');
 
@@ -23,56 +24,88 @@ const MODE_LABEL: Record<string, string> = {
 const TYPE_LABEL: Record<string, string> = { MENSUEL: 'Mensuel', ANNUEL: 'Annuel' };
 const TYPE_COLOR: Record<string, string> = { MENSUEL: 'blue', ANNUEL: 'gold' };
 
-const escapeHtml = (s: string) => s
-    .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
-
-function downloadFacture(paiement: any, societe: any) {
+function downloadFacturePdf(paiement: any, societe: any) {
     const dateDebut = dayjs(paiement.date).format('DD/MM/YYYY');
     const dateFin = paiement.type === 'ANNUEL'
         ? dayjs(paiement.date).add(12, 'month').format('DD/MM/YYYY')
         : dayjs(paiement.date).add(1, 'month').format('DD/MM/YYYY');
+    const nomSociete = societe?.nom ?? 'moussAIllon';
+    const montantStr = formatMontant(paiement.montant);
 
-    const html = `<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8"/>
-<title>Facture abonnement #${paiement.id}</title>
-<style>
-  body { font-family: Arial, sans-serif; margin: 40px; color: #1f1f1f; }
-  h1 { font-size: 22px; margin-bottom: 4px; }
-  .subtitle { color: #666; margin-bottom: 32px; }
-  table { width: 100%; border-collapse: collapse; margin-top: 24px; }
-  th, td { border: 1px solid #d9d9d9; padding: 8px 12px; text-align: left; }
-  th { background: #fafafa; font-weight: 600; }
-  .total { text-align: right; font-size: 16px; font-weight: bold; margin-top: 16px; }
-  .footer { margin-top: 48px; font-size: 12px; color: #888; border-top: 1px solid #eee; padding-top: 12px; }
-</style>
-</head><body>
-<h1>Facture d'abonnement #${paiement.id}</h1>
-<div class="subtitle">${escapeHtml(societe?.nom ?? 'moussAIllon')}</div>
-<table>
-  <thead><tr><th>Désignation</th><th>Période</th><th>Mode de paiement</th><th style="text-align:right;">Montant TTC</th></tr></thead>
-  <tbody>
-    <tr>
-      <td>Abonnement moussAIllon — ${escapeHtml(TYPE_LABEL[paiement.type] ?? paiement.type)}</td>
-      <td>${escapeHtml(dateDebut)} → ${escapeHtml(dateFin)}</td>
-      <td>${escapeHtml(MODE_LABEL[paiement.mode] ?? paiement.mode)}</td>
-      <td style="text-align:right;">${escapeHtml(formatMontant(paiement.montant))}</td>
-    </tr>
-  </tbody>
-</table>
-<div class="total">Total TTC : ${escapeHtml(formatMontant(paiement.montant))}</div>
-<div class="footer">
-  Date de paiement : ${escapeHtml(formatDate(paiement.date))}<br/>
-  Document généré le ${dayjs().format('DD/MM/YYYY')}
-</div>
-</body></html>`;
+    const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+    const pageW = doc.internal.pageSize.getWidth();
+    const margin = 20;
+    const colW = pageW - margin * 2;
+    let y = margin;
 
-    const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `facture-abonnement-${paiement.id}.html`;
-    a.click();
-    URL.revokeObjectURL(url);
+    // En-tête
+    doc.setFontSize(20);
+    doc.setFont('helvetica', 'bold');
+    doc.text('Facture d\'abonnement', margin, y);
+    y += 8;
+    doc.setFontSize(11);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(100);
+    doc.text(nomSociete, margin, y);
+    y += 6;
+    doc.text(`N° ${paiement.id} — émise le ${dayjs().format('DD/MM/YYYY')}`, margin, y);
+    doc.setTextColor(0);
+    y += 14;
+
+    // Ligne de séparation
+    doc.setDrawColor(200);
+    doc.line(margin, y, pageW - margin, y);
+    y += 10;
+
+    // Tableau
+    const headers = ['Désignation', 'Période', 'Mode', 'Montant TTC'];
+    const colWidths = [70, 50, 35, colW - 70 - 50 - 35];
+    const rowH = 9;
+
+    // En-tête tableau
+    doc.setFillColor(245, 245, 245);
+    doc.rect(margin, y, colW, rowH, 'F');
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9);
+    let x = margin;
+    headers.forEach((h, i) => {
+        doc.text(h, x + 2, y + 6);
+        x += colWidths[i];
+    });
+    y += rowH;
+
+    // Ligne de données
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(9);
+    doc.rect(margin, y, colW, rowH);
+    x = margin;
+    const cells = [
+        `Abonnement moussAIllon — ${TYPE_LABEL[paiement.type] ?? paiement.type}`,
+        `${dateDebut} → ${dateFin}`,
+        MODE_LABEL[paiement.mode] ?? paiement.mode,
+        montantStr,
+    ];
+    cells.forEach((cell, i) => {
+        doc.text(cell, x + 2, y + 6, { maxWidth: colWidths[i] - 4 });
+        x += colWidths[i];
+    });
+    y += rowH + 10;
+
+    // Total
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(12);
+    doc.text(`Total TTC : ${montantStr}`, pageW - margin, y, { align: 'right' });
+    y += 16;
+
+    // Pied de page
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(9);
+    doc.setTextColor(130);
+    doc.line(margin, y, pageW - margin, y);
+    y += 6;
+    doc.text(`Date de paiement : ${formatDate(paiement.date)}`, margin, y);
+
+    doc.save(`facture-abonnement-${paiement.id}.pdf`);
 }
 
 export default function Facturation() {
@@ -245,7 +278,7 @@ export default function Facturation() {
                     <Button
                         size="small"
                         icon={<DownloadOutlined />}
-                        onClick={() => downloadFacture(record, societe)}
+                        onClick={() => downloadFacturePdf(record, societe)}
                     />
                 </Tooltip>
             ),

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -75,7 +75,7 @@ function downloadFacturePdf(paiement: any, societe: any) {
     // ── Détail ─────────────────────────────────────────────
     row('Désignation', `Abonnement moussAIllon — ${TYPE_LABEL[paiement.type] ?? paiement.type}`);
     y += 2;
-    row('Période couverte', `${dateDebut}  →  ${dateFin}`);
+    row('Période couverte', \`\${dateDebut} au \${dateFin}\`);
     y += 2;
     row('Mode de paiement', MODE_LABEL[paiement.mode] ?? paiement.mode);
     y += 2;

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -75,7 +75,7 @@ function downloadFacturePdf(paiement: any, societe: any) {
     // ── Détail ─────────────────────────────────────────────
     row('Désignation', `Abonnement moussAIllon — ${TYPE_LABEL[paiement.type] ?? paiement.type}`);
     y += 2;
-    row('Période couverte', \`\${dateDebut} au \${dateFin}\`);
+    row('Période couverte', dateDebut + ' au ' + dateFin);
     y += 2;
     row('Mode de paiement', MODE_LABEL[paiement.mode] ?? paiement.mode);
     y += 2;

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './api.ts';
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Button, Card, Descriptions, Modal, Space, Spin, message } from 'antd';
+import { Button, Card, Descriptions, Divider, Select, Space, Spin, Table, Tag, message } from 'antd';
 import { CreditCardOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 
@@ -12,10 +12,25 @@ const formatMontant = (value) => (value != null
 
 type PaiementType = 'MENSUEL' | 'ANNUEL';
 
+const MODE_OPTIONS = [
+    { value: 'CHEQUE',    label: 'Chèque' },
+    { value: 'VIREMENT',  label: 'Virement' },
+    { value: 'CARTE',     label: 'Carte bancaire' },
+    { value: 'ESPÈCES',   label: 'Espèces' },
+];
+
+const MODE_LABEL: Record<string, string> = {
+    CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte bancaire', 'ESPÈCES': 'Espèces',
+};
+
+const TYPE_LABEL: Record<string, string> = { MENSUEL: 'Mensuel', ANNUEL: 'Annuel' };
+const TYPE_COLOR: Record<string, string> = { MENSUEL: 'blue', ANNUEL: 'gold' };
+
 export default function Facturation() {
 
     const [societe, setSociete] = useState<any>(null);
     const [paiementType, setPaiementType] = useState<PaiementType | null>(null);
+    const [paiementMode, setPaiementMode] = useState<string>('CHEQUE');
     const [signatureModalOpen, setSignatureModalOpen] = useState(false);
     const [submitting, setSubmitting] = useState(false);
 
@@ -83,6 +98,7 @@ export default function Facturation() {
 
     const openPaiementModal = (type: PaiementType) => {
         setPaiementType(type);
+        setPaiementMode('CHEQUE');
         signatureDrawingRef.current = false;
         setSignatureModalOpen(true);
         initSignatureCanvas();
@@ -99,7 +115,7 @@ export default function Facturation() {
         setSubmitting(true);
         fetchWithAuth('./societe/paiement', {
             method: 'POST',
-            body: JSON.stringify({ type: paiementType, signature }),
+            body: JSON.stringify({ type: paiementType, mode: paiementMode, signature }),
         })
             .then((response) => {
                 if (!response.ok) throw new Error('Erreur (code ' + response.status + ')');
@@ -118,6 +134,33 @@ export default function Facturation() {
     const labelPaiement = paiementType === 'ANNUEL'
         ? 'Paiement annuel — 1 650 EUR (1 mois offert)'
         : 'Paiement mensuel — 150 EUR';
+
+    const historiqueColumns = [
+        {
+            title: 'Date',
+            dataIndex: 'date',
+            width: 120,
+            render: (v: string) => formatDate(v),
+        },
+        {
+            title: 'Type',
+            dataIndex: 'type',
+            width: 100,
+            render: (v: string) => <Tag color={TYPE_COLOR[v] ?? 'default'}>{TYPE_LABEL[v] ?? v}</Tag>,
+        },
+        {
+            title: 'Mode',
+            dataIndex: 'mode',
+            width: 140,
+            render: (v: string) => MODE_LABEL[v] ?? v,
+        },
+        {
+            title: 'Montant',
+            dataIndex: 'montant',
+            align: 'right' as const,
+            render: (v: number) => formatMontant(v),
+        },
+    ];
 
     if (!societe) {
         return <Spin />;
@@ -161,41 +204,68 @@ export default function Facturation() {
                         Payer l'année — 1 650 EUR (1 mois offert)
                     </Button>
                 </Space>
+
+                <Divider>Historique des paiements</Divider>
+
+                <Table
+                    rowKey="id"
+                    dataSource={societe.paiements ?? []}
+                    columns={historiqueColumns}
+                    pagination={false}
+                    bordered
+                    size="small"
+                    locale={{ emptyText: 'Aucun paiement enregistré' }}
+                />
             </Card>
 
-            <Modal
-                title={labelPaiement}
-                open={signatureModalOpen}
-                onCancel={() => setSignatureModalOpen(false)}
-                width={520}
-                footer={[
-                    <Button key="clear" onClick={clearSignatureCanvas}>
-                        Effacer la signature
-                    </Button>,
-                    <Button key="cancel" onClick={() => setSignatureModalOpen(false)}>
-                        Annuler
-                    </Button>,
-                    <Button key="confirm" type="primary" loading={submitting} onClick={handlePaiementConfirm}>
-                        Confirmer le paiement ({formatMontant(montantPaiement)})
-                    </Button>,
-                ]}
-            >
-                <p style={{ marginBottom: 8 }}>
-                    Veuillez signer ci-dessous pour confirmer votre accord de paiement.
-                </p>
-                <canvas
-                    ref={signatureCanvasRef}
+            {signatureModalOpen && (
+                <div
                     style={{
-                        width: '100%',
-                        height: 160,
-                        border: '1px solid #d9d9d9',
-                        borderRadius: 4,
-                        display: 'block',
-                        cursor: 'crosshair',
-                        touchAction: 'none',
+                        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
                     }}
-                />
-            </Modal>
+                >
+                    <div style={{ background: '#fff', borderRadius: 8, padding: 24, width: 520, boxShadow: '0 8px 32px rgba(0,0,0,0.2)' }}>
+                        <h3 style={{ marginTop: 0 }}>{labelPaiement}</h3>
+
+                        <div style={{ marginBottom: 16 }}>
+                            <label style={{ display: 'block', marginBottom: 6, fontWeight: 500 }}>
+                                Mode de paiement
+                            </label>
+                            <Select
+                                value={paiementMode}
+                                onChange={setPaiementMode}
+                                options={MODE_OPTIONS}
+                                style={{ width: '100%' }}
+                            />
+                        </div>
+
+                        <label style={{ display: 'block', marginBottom: 6, fontWeight: 500 }}>
+                            Signature
+                        </label>
+                        <canvas
+                            ref={signatureCanvasRef}
+                            style={{
+                                width: '100%',
+                                height: 160,
+                                border: '1px solid #d9d9d9',
+                                borderRadius: 4,
+                                display: 'block',
+                                cursor: 'crosshair',
+                                touchAction: 'none',
+                            }}
+                        />
+
+                        <Space style={{ marginTop: 16, justifyContent: 'flex-end', width: '100%' }}>
+                            <Button onClick={clearSignatureCanvas}>Effacer la signature</Button>
+                            <Button onClick={() => setSignatureModalOpen(false)}>Annuler</Button>
+                            <Button type="primary" loading={submitting} onClick={handlePaiementConfirm}>
+                                Confirmer — {formatMontant(montantPaiement)}
+                            </Button>
+                        </Space>
+                    </div>
+                </div>
+            )}
         </>
     );
 }

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -26,84 +26,76 @@ const TYPE_COLOR: Record<string, string> = { MENSUEL: 'blue', ANNUEL: 'gold' };
 
 function downloadFacturePdf(paiement: any, societe: any) {
     const dateDebut = dayjs(paiement.date).format('DD/MM/YYYY');
-    const dateFin = paiement.type === 'ANNUEL'
-        ? dayjs(paiement.date).add(12, 'month').format('DD/MM/YYYY')
-        : dayjs(paiement.date).add(1, 'month').format('DD/MM/YYYY');
+    const dateFin = (paiement.type === 'ANNUEL'
+        ? dayjs(paiement.date).add(12, 'month')
+        : dayjs(paiement.date).add(1, 'month')
+    ).format('DD/MM/YYYY');
     const nomSociete = societe?.nom ?? 'moussAIllon';
     const montantStr = formatMontant(paiement.montant);
 
     const doc = new jsPDF({ unit: 'mm', format: 'a4' });
     const pageW = doc.internal.pageSize.getWidth();
-    const margin = 20;
-    const colW = pageW - margin * 2;
-    let y = margin;
+    const L = 20;   // left margin
+    const R = pageW - 20; // right edge
+    const lineH = 7;
+    let y = 24;
 
-    // En-tête
-    doc.setFontSize(20);
+    const sep = () => {
+        doc.setDrawColor(210);
+        doc.line(L, y, R, y);
+        y += 8;
+    };
+
+    const row = (label: string, value: string, bold = false) => {
+        doc.setFont('helvetica', bold ? 'bold' : 'normal');
+        doc.setFontSize(10);
+        doc.text(label, L, y);
+        doc.text(value, R, y, { align: 'right' });
+        y += lineH;
+    };
+
+    // ── Titre ──────────────────────────────────────────────
     doc.setFont('helvetica', 'bold');
-    doc.text('Facture d\'abonnement', margin, y);
+    doc.setFontSize(18);
+    doc.text("Facture d'abonnement", L, y);
     y += 8;
-    doc.setFontSize(11);
+
     doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
     doc.setTextColor(100);
-    doc.text(nomSociete, margin, y);
+    doc.text(nomSociete, L, y);
+    doc.text(`N° ${paiement.id}`, R, y, { align: 'right' });
     y += 6;
-    doc.text(`N° ${paiement.id} — émise le ${dayjs().format('DD/MM/YYYY')}`, margin, y);
+    doc.text(`Émise le ${dayjs().format('DD/MM/YYYY')}`, R, y, { align: 'right' });
     doc.setTextColor(0);
-    y += 14;
+    y += 12;
 
-    // Ligne de séparation
-    doc.setDrawColor(200);
-    doc.line(margin, y, pageW - margin, y);
-    y += 10;
+    sep();
 
-    // Tableau
-    const headers = ['Désignation', 'Période', 'Mode', 'Montant TTC'];
-    const colWidths = [70, 50, 35, colW - 70 - 50 - 35];
-    const rowH = 9;
-
-    // En-tête tableau
-    doc.setFillColor(245, 245, 245);
-    doc.rect(margin, y, colW, rowH, 'F');
-    doc.setFont('helvetica', 'bold');
-    doc.setFontSize(9);
-    let x = margin;
-    headers.forEach((h, i) => {
-        doc.text(h, x + 2, y + 6);
-        x += colWidths[i];
-    });
-    y += rowH;
-
-    // Ligne de données
-    doc.setFont('helvetica', 'normal');
-    doc.setFontSize(9);
-    doc.rect(margin, y, colW, rowH);
-    x = margin;
-    const cells = [
-        `Abonnement moussAIllon — ${TYPE_LABEL[paiement.type] ?? paiement.type}`,
-        `${dateDebut} → ${dateFin}`,
-        MODE_LABEL[paiement.mode] ?? paiement.mode,
-        montantStr,
-    ];
-    cells.forEach((cell, i) => {
-        doc.text(cell, x + 2, y + 6, { maxWidth: colWidths[i] - 4 });
-        x += colWidths[i];
-    });
-    y += rowH + 10;
-
-    // Total
-    doc.setFont('helvetica', 'bold');
-    doc.setFontSize(12);
-    doc.text(`Total TTC : ${montantStr}`, pageW - margin, y, { align: 'right' });
-    y += 16;
-
-    // Pied de page
-    doc.setFont('helvetica', 'normal');
-    doc.setFontSize(9);
-    doc.setTextColor(130);
-    doc.line(margin, y, pageW - margin, y);
+    // ── Détail ─────────────────────────────────────────────
+    row('Désignation', `Abonnement moussAIllon — ${TYPE_LABEL[paiement.type] ?? paiement.type}`);
+    y += 2;
+    row('Période couverte', `${dateDebut}  →  ${dateFin}`);
+    y += 2;
+    row('Mode de paiement', MODE_LABEL[paiement.mode] ?? paiement.mode);
+    y += 2;
+    row('Date de paiement', formatDate(paiement.date));
     y += 6;
-    doc.text(`Date de paiement : ${formatDate(paiement.date)}`, margin, y);
+
+    sep();
+
+    // ── Total ──────────────────────────────────────────────
+    doc.setFillColor(245, 245, 245);
+    doc.rect(L, y - 4, R - L, lineH + 4, 'F');
+    row('Total TTC', montantStr, true);
+    y += 4;
+
+    sep();
+
+    // ── Pied de page ───────────────────────────────────────
+    doc.setFontSize(8);
+    doc.setTextColor(150);
+    doc.text(`Document généré automatiquement par moussAIllon le ${dayjs().format('DD/MM/YYYY')}`, L, y);
 
     doc.save(`facture-abonnement-${paiement.id}.pdf`);
 }

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -1,36 +1,85 @@
 import { fetchWithAuth } from './api.ts';
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Button, Card, Descriptions, Divider, Select, Space, Spin, Table, Tag, message } from 'antd';
-import { CreditCardOutlined } from '@ant-design/icons';
+import { Button, Card, Descriptions, Divider, Select, Space, Spin, Table, Tag, Tooltip, message } from 'antd';
+import { CreditCardOutlined, DownloadOutlined, LinkOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 
-const formatDate = (value) => (value ? dayjs(value).format('DD/MM/YYYY') : '—');
+const formatDate = (value: any) => (value ? dayjs(value).format('DD/MM/YYYY') : '—');
 
-const formatMontant = (value) => (value != null
+const formatMontant = (value: any) => (value != null
     ? new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(value)
     : '—');
 
 type PaiementType = 'MENSUEL' | 'ANNUEL';
-
-const MODE_OPTIONS = [
-    { value: 'CHEQUE',    label: 'Chèque' },
-    { value: 'VIREMENT',  label: 'Virement' },
-    { value: 'CARTE',     label: 'Carte bancaire' },
-    { value: 'ESPÈCES',   label: 'Espèces' },
-];
+type PaiementMode = 'VIREMENT' | 'CARTE' | 'STRIPE' | 'PAYPLUG';
 
 const MODE_LABEL: Record<string, string> = {
-    CHEQUE: 'Chèque', VIREMENT: 'Virement', CARTE: 'Carte bancaire', 'ESPÈCES': 'Espèces',
+    VIREMENT: 'Virement bancaire',
+    CARTE: 'Carte bancaire',
+    STRIPE: 'Stripe',
+    PAYPLUG: 'PayPlug',
 };
 
 const TYPE_LABEL: Record<string, string> = { MENSUEL: 'Mensuel', ANNUEL: 'Annuel' };
 const TYPE_COLOR: Record<string, string> = { MENSUEL: 'blue', ANNUEL: 'gold' };
 
+const escapeHtml = (s: string) => s
+    .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+
+function downloadFacture(paiement: any, societe: any) {
+    const dateDebut = dayjs(paiement.date).format('DD/MM/YYYY');
+    const dateFin = paiement.type === 'ANNUEL'
+        ? dayjs(paiement.date).add(12, 'month').format('DD/MM/YYYY')
+        : dayjs(paiement.date).add(1, 'month').format('DD/MM/YYYY');
+
+    const html = `<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8"/>
+<title>Facture abonnement #${paiement.id}</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 40px; color: #1f1f1f; }
+  h1 { font-size: 22px; margin-bottom: 4px; }
+  .subtitle { color: #666; margin-bottom: 32px; }
+  table { width: 100%; border-collapse: collapse; margin-top: 24px; }
+  th, td { border: 1px solid #d9d9d9; padding: 8px 12px; text-align: left; }
+  th { background: #fafafa; font-weight: 600; }
+  .total { text-align: right; font-size: 16px; font-weight: bold; margin-top: 16px; }
+  .footer { margin-top: 48px; font-size: 12px; color: #888; border-top: 1px solid #eee; padding-top: 12px; }
+</style>
+</head><body>
+<h1>Facture d'abonnement #${paiement.id}</h1>
+<div class="subtitle">${escapeHtml(societe?.nom ?? 'moussAIllon')}</div>
+<table>
+  <thead><tr><th>Désignation</th><th>Période</th><th>Mode de paiement</th><th style="text-align:right;">Montant TTC</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>Abonnement moussAIllon — ${escapeHtml(TYPE_LABEL[paiement.type] ?? paiement.type)}</td>
+      <td>${escapeHtml(dateDebut)} → ${escapeHtml(dateFin)}</td>
+      <td>${escapeHtml(MODE_LABEL[paiement.mode] ?? paiement.mode)}</td>
+      <td style="text-align:right;">${escapeHtml(formatMontant(paiement.montant))}</td>
+    </tr>
+  </tbody>
+</table>
+<div class="total">Total TTC : ${escapeHtml(formatMontant(paiement.montant))}</div>
+<div class="footer">
+  Date de paiement : ${escapeHtml(formatDate(paiement.date))}<br/>
+  Document généré le ${dayjs().format('DD/MM/YYYY')}
+</div>
+</body></html>`;
+
+    const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `facture-abonnement-${paiement.id}.html`;
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
 export default function Facturation() {
 
     const [societe, setSociete] = useState<any>(null);
     const [paiementType, setPaiementType] = useState<PaiementType | null>(null);
-    const [paiementMode, setPaiementMode] = useState<string>('CHEQUE');
+    const [paiementMode, setPaiementMode] = useState<PaiementMode>('VIREMENT');
     const [signatureModalOpen, setSignatureModalOpen] = useState(false);
     const [submitting, setSubmitting] = useState(false);
 
@@ -39,12 +88,9 @@ export default function Facturation() {
 
     const fetchSociete = useCallback(() => {
         fetchWithAuth('./societe')
-            .then((response) => {
-                if (!response.ok) throw new Error('Erreur (code ' + response.status + ')');
-                return response.json();
-            })
-            .then(data => setSociete(data))
-            .catch((error) => message.error('Une erreur est survenue: ' + error.message));
+            .then((r) => { if (!r.ok) throw new Error('Erreur ' + r.status); return r.json(); })
+            .then(setSociete)
+            .catch((e) => message.error('Erreur : ' + e.message));
     }, []);
 
     useEffect(() => { fetchSociete(); }, [fetchSociete]);
@@ -63,19 +109,15 @@ export default function Facturation() {
             ctx.lineWidth = 2;
             ctx.lineCap = 'round';
             ctx.lineJoin = 'round';
-
             let drawing = false;
             const getPos = (e: MouseEvent | TouchEvent) => {
                 const rect = canvas.getBoundingClientRect();
-                if ('touches' in e) {
-                    return { x: e.touches[0].clientX - rect.left, y: e.touches[0].clientY - rect.top };
-                }
+                if ('touches' in e) return { x: e.touches[0].clientX - rect.left, y: e.touches[0].clientY - rect.top };
                 return { x: (e as MouseEvent).clientX - rect.left, y: (e as MouseEvent).clientY - rect.top };
             };
             const onStart = (e: MouseEvent | TouchEvent) => { e.preventDefault(); drawing = true; const p = getPos(e); ctx.beginPath(); ctx.moveTo(p.x, p.y); signatureDrawingRef.current = true; };
             const onMove = (e: MouseEvent | TouchEvent) => { if (!drawing) return; e.preventDefault(); const p = getPos(e); ctx.lineTo(p.x, p.y); ctx.stroke(); };
             const onEnd = () => { drawing = false; };
-
             canvas.addEventListener('mousedown', onStart);
             canvas.addEventListener('mousemove', onMove);
             canvas.addEventListener('mouseup', onEnd);
@@ -96,44 +138,78 @@ export default function Facturation() {
         signatureDrawingRef.current = false;
     };
 
+    const isExternalMode = (mode: PaiementMode) => mode === 'STRIPE' || mode === 'PAYPLUG';
+
+    const getPaymentLink = (type: PaiementType, mode: PaiementMode): string | undefined => {
+        if (!societe) return undefined;
+        if (mode === 'STRIPE') return type === 'ANNUEL' ? societe.stripePaymentLinkAnnuel : societe.stripePaymentLinkMensuel;
+        if (mode === 'PAYPLUG') return type === 'ANNUEL' ? societe.payplugPaymentLinkAnnuel : societe.payplugPaymentLinkMensuel;
+        return undefined;
+    };
+
     const openPaiementModal = (type: PaiementType) => {
         setPaiementType(type);
-        setPaiementMode('CHEQUE');
+        setPaiementMode('VIREMENT');
         signatureDrawingRef.current = false;
         setSignatureModalOpen(true);
         initSignatureCanvas();
     };
 
+    const handleModeChange = (mode: PaiementMode) => {
+        setPaiementMode(mode);
+        if (!isExternalMode(mode)) {
+            // Re-init canvas when switching back to a manual mode
+            signatureDrawingRef.current = false;
+            initSignatureCanvas();
+        }
+    };
+
     const handlePaiementConfirm = () => {
-        if (!signatureDrawingRef.current) {
+        if (!isExternalMode(paiementMode) && !signatureDrawingRef.current) {
             message.warning('La signature est requise pour valider le paiement');
             return;
         }
         const canvas = signatureCanvasRef.current;
-        const signature = canvas ? canvas.toDataURL('image/png') : '';
+        const signature = (!isExternalMode(paiementMode) && canvas)
+            ? canvas.toDataURL('image/png')
+            : 'external-payment';
 
         setSubmitting(true);
         fetchWithAuth('./societe/paiement', {
             method: 'POST',
             body: JSON.stringify({ type: paiementType, mode: paiementMode, signature }),
         })
-            .then((response) => {
-                if (!response.ok) throw new Error('Erreur (code ' + response.status + ')');
-                return response.json();
-            })
+            .then((r) => { if (!r.ok) throw new Error('Erreur ' + r.status); return r.json(); })
             .then((data) => {
                 setSociete(data);
                 setSignatureModalOpen(false);
                 message.success('Paiement enregistré avec succès');
             })
-            .catch((error) => message.error('Une erreur est survenue: ' + error.message))
+            .catch((e) => message.error('Erreur : ' + e.message))
             .finally(() => setSubmitting(false));
     };
+
+    const getModeOptions = (type: PaiementType): { value: string; label: string; disabled?: boolean }[] => [
+        { value: 'VIREMENT', label: 'Virement bancaire' },
+        { value: 'CARTE', label: 'Carte bancaire' },
+        {
+            value: 'STRIPE',
+            label: 'Stripe',
+            disabled: !getPaymentLink(type, 'STRIPE'),
+        },
+        {
+            value: 'PAYPLUG',
+            label: 'PayPlug',
+            disabled: !getPaymentLink(type, 'PAYPLUG'),
+        },
+    ];
 
     const montantPaiement = paiementType === 'ANNUEL' ? 1650 : 150;
     const labelPaiement = paiementType === 'ANNUEL'
         ? 'Paiement annuel — 1 650 EUR (1 mois offert)'
         : 'Paiement mensuel — 150 EUR';
+
+    const externalLink = paiementType ? getPaymentLink(paiementType, paiementMode) : undefined;
 
     const historiqueColumns = [
         {
@@ -151,7 +227,7 @@ export default function Facturation() {
         {
             title: 'Mode',
             dataIndex: 'mode',
-            width: 140,
+            width: 160,
             render: (v: string) => MODE_LABEL[v] ?? v,
         },
         {
@@ -160,22 +236,29 @@ export default function Facturation() {
             align: 'right' as const,
             render: (v: number) => formatMontant(v),
         },
+        {
+            title: '',
+            key: 'actions',
+            width: 60,
+            render: (_: unknown, record: any) => (
+                <Tooltip title="Télécharger la facture">
+                    <Button
+                        size="small"
+                        icon={<DownloadOutlined />}
+                        onClick={() => downloadFacture(record, societe)}
+                    />
+                </Tooltip>
+            ),
+        },
     ];
 
-    if (!societe) {
-        return <Spin />;
-    }
+    if (!societe) return <Spin />;
 
     return (
         <>
             <Card title={<Space><CreditCardOutlined /> Facturation</Space>}>
-                <Descriptions
-                    title="Abonnement"
-                    column={1}
-                    bordered
-                    size="small"
-                >
-                    <Descriptions.Item label="Date d'activation (paiement one-shot)">
+                <Descriptions title="Abonnement" column={1} bordered size="small">
+                    <Descriptions.Item label="Date d'activation">
                         {formatDate(societe.abonnementActivationDate)}
                     </Descriptions.Item>
                     <Descriptions.Item label="Montant d'activation">
@@ -190,17 +273,10 @@ export default function Facturation() {
                 </Descriptions>
 
                 <Space style={{ marginTop: 24 }}>
-                    <Button
-                        type="primary"
-                        icon={<CreditCardOutlined />}
-                        onClick={() => openPaiementModal('MENSUEL')}
-                    >
+                    <Button type="primary" icon={<CreditCardOutlined />} onClick={() => openPaiementModal('MENSUEL')}>
                         Payer ce mois — 150 EUR
                     </Button>
-                    <Button
-                        icon={<CreditCardOutlined />}
-                        onClick={() => openPaiementModal('ANNUEL')}
-                    >
+                    <Button icon={<CreditCardOutlined />} onClick={() => openPaiementModal('ANNUEL')}>
                         Payer l'année — 1 650 EUR (1 mois offert)
                     </Button>
                 </Space>
@@ -219,13 +295,11 @@ export default function Facturation() {
             </Card>
 
             {signatureModalOpen && (
-                <div
-                    style={{
-                        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)',
-                        display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
-                    }}
-                >
-                    <div style={{ background: '#fff', borderRadius: 8, padding: 24, width: 520, boxShadow: '0 8px 32px rgba(0,0,0,0.2)' }}>
+                <div style={{
+                    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+                }}>
+                    <div style={{ background: '#fff', borderRadius: 8, padding: 24, width: 540, boxShadow: '0 8px 32px rgba(0,0,0,0.2)' }}>
                         <h3 style={{ marginTop: 0 }}>{labelPaiement}</h3>
 
                         <div style={{ marginBottom: 16 }}>
@@ -234,32 +308,61 @@ export default function Facturation() {
                             </label>
                             <Select
                                 value={paiementMode}
-                                onChange={setPaiementMode}
-                                options={MODE_OPTIONS}
+                                onChange={handleModeChange}
+                                options={getModeOptions(paiementType!)}
                                 style={{ width: '100%' }}
                             />
                         </div>
 
-                        <label style={{ display: 'block', marginBottom: 6, fontWeight: 500 }}>
-                            Signature
-                        </label>
-                        <canvas
-                            ref={signatureCanvasRef}
-                            style={{
-                                width: '100%',
-                                height: 160,
-                                border: '1px solid #d9d9d9',
-                                borderRadius: 4,
-                                display: 'block',
-                                cursor: 'crosshair',
-                                touchAction: 'none',
-                            }}
-                        />
+                        {isExternalMode(paiementMode) ? (
+                            <div style={{ background: '#f6ffed', border: '1px solid #b7eb8f', borderRadius: 6, padding: 16, marginBottom: 16 }}>
+                                <p style={{ margin: '0 0 12px' }}>
+                                    Cliquez sur le bouton ci-dessous pour accéder à la page de paiement {MODE_LABEL[paiementMode]}.
+                                    Une fois le paiement effectué, revenez ici et cliquez sur <strong>Confirmer</strong>.
+                                </p>
+                                {externalLink ? (
+                                    <Button
+                                        type="default"
+                                        icon={<LinkOutlined />}
+                                        href={externalLink}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        Payer via {MODE_LABEL[paiementMode]} — {formatMontant(montantPaiement)}
+                                    </Button>
+                                ) : (
+                                    <span style={{ color: '#ff4d4f' }}>
+                                        Lien de paiement {MODE_LABEL[paiementMode]} non configuré.
+                                    </span>
+                                )}
+                            </div>
+                        ) : (
+                            <>
+                                <label style={{ display: 'block', marginBottom: 6, fontWeight: 500 }}>
+                                    Signature
+                                </label>
+                                <canvas
+                                    ref={signatureCanvasRef}
+                                    style={{
+                                        width: '100%', height: 160,
+                                        border: '1px solid #d9d9d9', borderRadius: 4,
+                                        display: 'block', cursor: 'crosshair', touchAction: 'none',
+                                    }}
+                                />
+                            </>
+                        )}
 
                         <Space style={{ marginTop: 16, justifyContent: 'flex-end', width: '100%' }}>
-                            <Button onClick={clearSignatureCanvas}>Effacer la signature</Button>
+                            {!isExternalMode(paiementMode) && (
+                                <Button onClick={clearSignatureCanvas}>Effacer la signature</Button>
+                            )}
                             <Button onClick={() => setSignatureModalOpen(false)}>Annuler</Button>
-                            <Button type="primary" loading={submitting} onClick={handlePaiementConfirm}>
+                            <Button
+                                type="primary"
+                                loading={submitting}
+                                onClick={handlePaiementConfirm}
+                                disabled={isExternalMode(paiementMode) && !externalLink}
+                            >
                                 Confirmer — {formatMontant(montantPaiement)}
                             </Button>
                         </Space>


### PR DESCRIPTION
## Résumé
- Deux boutons de paiement dans la page Facturation :
  - **Payer ce mois** — 150 EUR
  - **Payer l'année** — 1 650 EUR (11 × 150 €, 1 mois offert)
- Modal de signature (canvas tactile/souris) identique au « bon pour accord » des ventes — le paiement n'est confirmé qu'avec une signature tracée
- Après confirmation, la prochaine échéance est avancée de 1 mois (mensuel) ou 12 mois (annuel)

## Changements
### Backend — `SocieteResource.java`
- Constante `MONTANT_ABONNEMENT_ANNUEL = 1650.0`
- Classe interne `PaiementRequest { type, signature }`
- Endpoint `POST /societe/paiement` : valide le type et la présence de la signature, décale `abonnementProchainPaiementDate`

### Frontend — `facturation.tsx`
- Canvas de signature avec gestion souris + tactile
- Validation : la signature doit être dessinée avant confirmation
- Rafraîchissement automatique des données après paiement

## Tests
- 4 tests `SocieteResourceTest` : OK
- Build `react-scripts build` : OK

Closes #430