### PR TITLE
feat: améliorations fiche client et largeur des modals

### DIFF
--- a/chantier-ui/src/ForfaitFormModal.tsx
+++ b/chantier-ui/src/ForfaitFormModal.tsx
@@ -466,7 +466,7 @@ export default function ForfaitFormModal({ open, onCancel, onCreated, preAssocia
             cancelText="Fermer"
             maskClosable={false}
             destroyOnHidden
-            width={1024}
+                width="95vw"
         >
             <Form form={form} layout="vertical" initialValues={defaultForfait} onValuesChange={onValuesChange}>
                 <Form.Item name="reference" label="Référence" rules={[{ required: true, message: 'La référence est requise' }]}>
@@ -712,7 +712,7 @@ export default function ForfaitFormModal({ open, onCancel, onCreated, preAssocia
                 onOk={handleNewProduitSave}
                 onCancel={handleNewProduitCancel}
                 maskClosable={false}
-                width={1024}
+                width="95vw"
                 okText="Enregistrer"
                 cancelText="Fermer"
                 destroyOnHidden
@@ -791,7 +791,7 @@ export default function ForfaitFormModal({ open, onCancel, onCreated, preAssocia
                 onOk={handleNewMainOeuvreSave}
                 onCancel={handleNewMainOeuvreCancel}
                 maskClosable={false}
-                width={900}
+                width="95vw"
                 okText="Enregistrer"
                 cancelText="Fermer"
                 destroyOnHidden

--- a/chantier-ui/src/ai-photo-identify.tsx
+++ b/chantier-ui/src/ai-photo-identify.tsx
@@ -141,7 +141,7 @@ const AiPhotoIdentify: React.FC<Props> = ({ productType, onApply }) => {
         title={`Identification du ${PRODUCT_LABEL[productType]} par photo (IA)`}
         onCancel={handleClose}
         footer={null}
-        width={600}
+                width="95vw"
         destroyOnHidden
       >
         <Spin spinning={loading}>

--- a/chantier-ui/src/annonces.tsx
+++ b/chantier-ui/src/annonces.tsx
@@ -398,7 +398,7 @@ export default function Annonces() {
                 onOk={handleSave}
                 okText={editing ? 'Mettre a jour' : 'Publier'}
                 cancelText="Fermer"
-                width={650}
+                width="95vw"
             >
                 <Form form={form} layout="vertical" onValuesChange={() => setFormDirty(true)}>
                     <Form.Item name="titre" label="Titre" rules={[{ required: true, message: 'Le titre est requis' }]}>
@@ -465,7 +465,7 @@ export default function Annonces() {
                 open={detailOpen}
                 onCancel={() => setDetailOpen(false)}
                 footer={null}
-                width={700}
+                width="95vw"
             >
                 {detailAnnonce && (
                     <div>
@@ -512,7 +512,7 @@ export default function Annonces() {
                 open={publishModalOpen}
                 onCancel={() => setPublishModalOpen(false)}
                 footer={null}
-                width={550}
+                width="95vw"
             >
                 {publishAnnonce && (
                     <div>

--- a/chantier-ui/src/avoirs.tsx
+++ b/chantier-ui/src/avoirs.tsx
@@ -713,7 +713,7 @@ export default function Avoirs() {
                 onOk={handleSave}
                 okText={editingAvoir ? 'Enregistrer' : 'Créer'}
                 confirmLoading={saving}
-                width={860}
+                width="95vw"
                 destroyOnHidden
             >
                 <Form layout="vertical">
@@ -826,7 +826,7 @@ export default function Avoirs() {
                 okText="Appliquer"
                 confirmLoading={applying}
                 destroyOnHidden
-                width={500}
+                width="95vw"
             >
                 {appliquerAvoir && (
                     <Form layout="vertical">

--- a/chantier-ui/src/campagnes.tsx
+++ b/chantier-ui/src/campagnes.tsx
@@ -433,7 +433,7 @@ export default function Campagnes() {
                 onOk={handleSave}
                 okText={editing ? 'Mettre à jour' : 'Créer'}
                 cancelText="Fermer"
-                width={750}
+                width="95vw"
                 destroyOnHidden
             >
                 <Form form={form} layout="vertical" onValuesChange={(changed) => {
@@ -562,7 +562,7 @@ export default function Campagnes() {
                 open={detailOpen}
                 onCancel={() => setDetailOpen(false)}
                 footer={null}
-                width={700}
+                width="95vw"
             >
                 {detailCampagne && (
                     <div>

--- a/chantier-ui/src/catalogue-bateaux.tsx
+++ b/chantier-ui/src/catalogue-bateaux.tsx
@@ -402,7 +402,7 @@ const CatalogueBateaux: React.FC = () => {
                         onOk={handleModalOk}
                         onCancel={handleModalCancel}
                         maskClosable={false}
-                        width={1024}
+                width="95vw"
                         okText="Enregistrer"
                         cancelText="Fermer"
                         destroyOnHidden

--- a/chantier-ui/src/catalogue-helices.tsx
+++ b/chantier-ui/src/catalogue-helices.tsx
@@ -404,7 +404,7 @@ const HeliceCatalogueView: React.FC = () => {
                         okText="Enregistrer"
                         cancelText="Fermer"
                         destroyOnHidden
-                        width={1024}
+                width="95vw"
                     >
                         <Form
                             form={form}

--- a/chantier-ui/src/catalogue-moteurs.tsx
+++ b/chantier-ui/src/catalogue-moteurs.tsx
@@ -442,7 +442,7 @@ const MoteurCatalogue = () => {
             okText="Enregistrer"
             cancelText="Fermer"
             destroyOnHidden
-            width={1024}
+                width="95vw"
           >
             <Form
               form={form}

--- a/chantier-ui/src/catalogue-produits.tsx
+++ b/chantier-ui/src/catalogue-produits.tsx
@@ -303,7 +303,7 @@ const CatalogueProduits: React.FC = () => {
                             onOk={handleModalOk}
                             onCancel={handleModalCancel}
                             maskClosable={false}
-                            width={1024}
+                width="95vw"
                             okText="Enregistrer"
                             cancelText="Fermer"
                             destroyOnHidden

--- a/chantier-ui/src/catalogue-remorques.tsx
+++ b/chantier-ui/src/catalogue-remorques.tsx
@@ -348,7 +348,7 @@ const RemorqueCatalogue: React.FC = () => {
         okText="Enregistrer"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form
           form={form}

--- a/chantier-ui/src/clients-bateaux.tsx
+++ b/chantier-ui/src/clients-bateaux.tsx
@@ -507,7 +507,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         okText="Enregistrer"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <div style={{ marginBottom: 12 }}>
           <AiPhotoIdentify productType="bateau" onApply={handleAiIdentify} />
@@ -698,7 +698,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form
           layout="vertical"
@@ -916,7 +916,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form
           layout="vertical"
@@ -1114,7 +1114,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={clientForm} initialValues={{ type: "PARTICULIER", consentement: false, remise: 0 }}>
           <Row gutter={16}>
@@ -1225,7 +1225,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
         okText={`Creer une annonce (${annonceSelectedImages.size} photo(s))`}
         okButtonProps={{ disabled: annonceSelectedImages.size === 0 }}
         cancelText="Fermer"
-        width={700}
+                width="95vw"
       >
         {annonceImageBateau && (
           <div>
@@ -1261,7 +1261,7 @@ function BateauxClients({ clientId }: BateauxClientsProps) {
                     }}
                   >
                     <Image
-                      width={120}
+                width="95vw"
                       height={120}
                       src={url}
                       style={{ objectFit: 'cover', display: 'block' }}

--- a/chantier-ui/src/clients-moteurs.tsx
+++ b/chantier-ui/src/clients-moteurs.tsx
@@ -436,7 +436,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         okText="Enregistrer"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <div style={{ marginBottom: 12 }}>
           <AiPhotoIdentify productType="moteur" onApply={handleAiIdentify} />
@@ -546,7 +546,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form
           layout="vertical"
@@ -747,7 +747,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={clientForm} initialValues={{ type: "PARTICULIER", consentement: false, remise: 0 }}>
           <Row gutter={16}>
@@ -858,7 +858,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
         okText={`Creer une annonce (${annonceSelectedImages.size} photo(s))`}
         okButtonProps={{ disabled: annonceSelectedImages.size === 0 }}
         cancelText="Fermer"
-        width={700}
+                width="95vw"
       >
         {annonceImageMoteur && (
           <div>
@@ -894,7 +894,7 @@ const ClientsMoteurs: React.FC<ClientsMoteursProps> = ({ clientId }) => {
                     }}
                   >
                     <Image
-                      width={120}
+                width="95vw"
                       height={120}
                       src={url}
                       style={{ objectFit: 'cover', display: 'block' }}

--- a/chantier-ui/src/clients-remorques.tsx
+++ b/chantier-ui/src/clients-remorques.tsx
@@ -392,7 +392,7 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
         okText="Enregistrer"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={form} initialValues={defaultRemorque} onValuesChange={() => setFormDirty(true)}>
           <Row gutter={16}>
@@ -497,7 +497,7 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form
           layout="vertical"
@@ -679,7 +679,7 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={clientForm} initialValues={{ type: "PARTICULIER", consentement: false, remise: 0 }}>
           <Row gutter={16}>
@@ -790,7 +790,7 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
         okText={`Creer une annonce (${annonceSelectedImages.size} photo(s))`}
         okButtonProps={{ disabled: annonceSelectedImages.size === 0 }}
         cancelText="Fermer"
-        width={700}
+                width="95vw"
       >
         {annonceImageRemorque && (
           <div>
@@ -826,7 +826,7 @@ function RemorquesClients({ clientId }: RemorquesClientsProps) {
                     }}
                   >
                     <Image
-                      width={120}
+                width="95vw"
                       height={120}
                       src={url}
                       style={{ objectFit: 'cover', display: 'block' }}

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -18,6 +18,7 @@ import {
   Checkbox,
   Alert,
   Tabs,
+  Collapse,
 } from "antd";
 import {
   PlusCircleOutlined,
@@ -358,7 +359,7 @@ function Clients() {
         okText="Enregistrer"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         {editing && editing.id && editing.soldeDu != null && editing.soldeDu > 0 && (
           <Alert
@@ -551,9 +552,6 @@ function Clients() {
           <Form.Item label="Notes" name="notes">
             <Input.TextArea rows={3} />
           </Form.Item>
-          <Form.Item label="Documents" name="documents">
-            <DocumentUpload />
-          </Form.Item>
         </Form>
         {editing && editing.id && (
           <>
@@ -562,15 +560,28 @@ function Clients() {
               items={[
                 {
                   key: 'vehicules',
-                  label: 'Véhicules',
+                  label: 'Bateaux, Moteurs, Remorques',
                   children: (
-                    <>
-                      <BateauxClients clientId={editing.id} />
-                      <Divider />
-                      <ClientsMoteurs clientId={editing.id} />
-                      <Divider />
-                      <RemorquesClients clientId={editing.id} />
-                    </>
+                    <Collapse
+                      defaultActiveKey={[]}
+                      items={[
+                        {
+                          key: 'bateaux',
+                          label: 'Bateaux Clients',
+                          children: <BateauxClients clientId={editing.id} />,
+                        },
+                        {
+                          key: 'moteurs',
+                          label: 'Moteurs Clients',
+                          children: <ClientsMoteurs clientId={editing.id} />,
+                        },
+                        {
+                          key: 'remorques',
+                          label: 'Remorques Clients',
+                          children: <RemorquesClients clientId={editing.id} />,
+                        },
+                      ]}
+                    />
                   ),
                 },
                 {
@@ -587,6 +598,17 @@ function Clients() {
                   key: 'avoirs',
                   label: 'Avoirs',
                   children: <ClientsAvoirs clientId={editing.id} />,
+                },
+                {
+                  key: 'documents',
+                  label: 'Documents',
+                  children: (
+                    <Form form={form}>
+                      <Form.Item name="documents" style={{ marginBottom: 0 }}>
+                        <DocumentUpload />
+                      </Form.Item>
+                    </Form>
+                  ),
                 },
               ]}
             />

--- a/chantier-ui/src/commandes-fournisseur.tsx
+++ b/chantier-ui/src/commandes-fournisseur.tsx
@@ -595,7 +595,7 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
         onCancel={handleModalCancel}
         onOk={handleModalOk}
         destroyOnHidden
-        width={1024}
+                width="95vw"
         title={editing ? "Modifier la commande" : "Nouvelle commande fournisseur"}
         okText="Enregistrer"
         cancelText="Fermer"
@@ -791,7 +791,7 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={fournisseurForm} initialValues={{ evaluation: 0 }} onValuesChange={() => setFournisseurFormDirty(true)}>
           <Row gutter={16}>

--- a/chantier-ui/src/comptoir.tsx
+++ b/chantier-ui/src/comptoir.tsx
@@ -1691,7 +1691,7 @@ export default function Comptoir() {
                 ]}
                 maskClosable={false}
                 destroyOnHidden
-                width={1100}
+                width="95vw"
             >
                 <Form form={form} layout="vertical" initialValues={defaultVente} onValuesChange={(...args) => { setFormDirty(true); onValuesChange(...args); }} disabled={isReadOnly}>
                     <Form.Item noStyle name="status"><input type="hidden" /></Form.Item>
@@ -2017,7 +2017,7 @@ export default function Comptoir() {
                     onOk={handleNewProduitSave}
                     onCancel={handleNewProduitCancel}
                     maskClosable={false}
-                    width={1024}
+                width="95vw"
                     okText="Enregistrer"
                     cancelText="Fermer"
                     destroyOnHidden
@@ -2134,7 +2134,7 @@ export default function Comptoir() {
                     okText="Valider"
                     confirmLoading={addingPaiement}
                     destroyOnHidden
-                    width={480}
+                width="95vw"
                 >
                     <Form layout="vertical">
                         <Form.Item label="Mode de règlement" required>

--- a/chantier-ui/src/emails.tsx
+++ b/chantier-ui/src/emails.tsx
@@ -151,7 +151,7 @@ export default function Emails() {
                 title={editingTemplate ? 'Modifier le modèle - ' + (TYPE_LABELS[editingTemplate.type] || editingTemplate.type) : 'Modifier le modèle'}
                 okText="Enregistrer"
                 cancelText="Fermer"
-                width={900}
+                width="95vw"
                 onOk={() => editForm.submit()}
                 onCancel={() => {
                     editForm.resetFields();

--- a/chantier-ui/src/forfaits.tsx
+++ b/chantier-ui/src/forfaits.tsx
@@ -740,7 +740,7 @@ export default function Forfaits() {
                 cancelText="Fermer"
                 maskClosable={false}
                 destroyOnHidden
-                width={1024}
+                width="95vw"
             >
                 <Form form={form} layout="vertical" initialValues={defaultForfait} onValuesChange={(...args) => { setFormDirty(true); onValuesChange(...args); }}>
                     <Form.Item
@@ -1028,7 +1028,7 @@ export default function Forfaits() {
                     onOk={handleNewProduitSave}
                     onCancel={handleNewProduitCancel}
                     maskClosable={false}
-                    width={1024}
+                width="95vw"
                     okText="Enregistrer"
                     cancelText="Fermer"
                     destroyOnHidden
@@ -1106,7 +1106,7 @@ export default function Forfaits() {
                     onOk={handleNewMainOeuvreSave}
                     onCancel={handleNewMainOeuvreCancel}
                     maskClosable={false}
-                    width={900}
+                width="95vw"
                     okText="Enregistrer"
                     cancelText="Fermer"
                     destroyOnHidden

--- a/chantier-ui/src/fournisseur-bateaux.tsx
+++ b/chantier-ui/src/fournisseur-bateaux.tsx
@@ -381,7 +381,7 @@ const FournisseurBateaux = ({ fournisseurId, bateauId }: { fournisseurId?: numbe
         title={editing && editing.id ? "Modifier l'association" : (isBateauMode ? "Associer un Fournisseur" : "Associer un Bateau")}
         okText="Enregistrer"
         cancelText="Fermer"
-        width={640}
+                width="95vw"
       >
         <Form
           form={form}
@@ -546,7 +546,7 @@ const FournisseurBateaux = ({ fournisseurId, bateauId }: { fournisseurId?: numbe
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={fournisseurForm} initialValues={{ evaluation: 0 }}>
           <Row gutter={16}>
@@ -623,7 +623,7 @@ const FournisseurBateaux = ({ fournisseurId, bateauId }: { fournisseurId?: numbe
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
         maskClosable={false}
       >
         <Form

--- a/chantier-ui/src/fournisseur-helices.tsx
+++ b/chantier-ui/src/fournisseur-helices.tsx
@@ -401,7 +401,7 @@ const FournisseurHelices = ({
         }
         okText="Enregistrer"
         cancelText="Fermer"
-        width={640}
+                width="95vw"
       >
         <Form
           form={form}
@@ -575,7 +575,7 @@ const FournisseurHelices = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={fournisseurForm} initialValues={{ evaluation: 0 }}>
           <Row gutter={16}>
@@ -652,7 +652,7 @@ const FournisseurHelices = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
         maskClosable={false}
       >
         <Form

--- a/chantier-ui/src/fournisseur-moteurs.tsx
+++ b/chantier-ui/src/fournisseur-moteurs.tsx
@@ -461,7 +461,7 @@ const FournisseurMoteurs = ({
         }
         okText="Enregistrer"
         cancelText="Fermer"
-        width={640}
+                width="95vw"
       >
         <Form
           form={form}
@@ -636,7 +636,7 @@ const FournisseurMoteurs = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={fournisseurForm} initialValues={{ evaluation: 0 }}>
           <Row gutter={16}>
@@ -713,7 +713,7 @@ const FournisseurMoteurs = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
         maskClosable={false}
       >
         <Form

--- a/chantier-ui/src/fournisseur-produits.tsx
+++ b/chantier-ui/src/fournisseur-produits.tsx
@@ -451,7 +451,7 @@ const FournisseurProduits = ({
         }
         okText="Enregistrer"
         cancelText="Fermer"
-        width={640}
+                width="95vw"
       >
         <Form
           form={form}
@@ -630,7 +630,7 @@ const FournisseurProduits = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={fournisseurForm} initialValues={{ evaluation: 0 }}>
           <Row gutter={16}>
@@ -707,7 +707,7 @@ const FournisseurProduits = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
         maskClosable={false}
       >
         <Form

--- a/chantier-ui/src/fournisseur-remorques.tsx
+++ b/chantier-ui/src/fournisseur-remorques.tsx
@@ -403,7 +403,7 @@ const FournisseurRemorques = ({
         }
         okText="Enregistrer"
         cancelText="Fermer"
-        width={640}
+                width="95vw"
       >
         <Form
           form={form}
@@ -567,7 +567,7 @@ const FournisseurRemorques = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
       >
         <Form layout="vertical" form={fournisseurForm} initialValues={{ evaluation: 0 }}>
           <Row gutter={16}>
@@ -644,7 +644,7 @@ const FournisseurRemorques = ({
         okText="Ajouter"
         cancelText="Fermer"
         destroyOnHidden
-        width={1024}
+                width="95vw"
         maskClosable={false}
       >
         <Form

--- a/chantier-ui/src/fournisseurs.tsx
+++ b/chantier-ui/src/fournisseurs.tsx
@@ -270,7 +270,7 @@ const Fournisseurs = () => {
         title={editing ? "Modifier Fournisseur" : "Nouveau Fournisseur"}
         okText="Enregistrer"
         cancelText="Fermer"
-        width={1024}
+                width="95vw"
         maskClosable={false}
         confirmLoading={loading}
       >

--- a/chantier-ui/src/main-oeuvres.tsx
+++ b/chantier-ui/src/main-oeuvres.tsx
@@ -250,7 +250,7 @@ export default function MainOeuvres() {
                 cancelText="Fermer"
                 maskClosable={false}
                 destroyOnHidden
-                width={900}
+                width="95vw"
             >
                 <Form
                     form={form}

--- a/chantier-ui/src/planning.tsx
+++ b/chantier-ui/src/planning.tsx
@@ -1427,7 +1427,7 @@ export default function Planning() {
                 okText="Enregistrer"
                 confirmLoading={saving}
                 cancelText="Fermer"
-                width={720}
+                width="95vw"
                 onCancel={handleModalCancel}
                 destroyOnHidden
             >
@@ -1488,7 +1488,7 @@ export default function Planning() {
                 footer={<Button onClick={() => { setPrestationModalVisible(false); setPrestationVente(null); }}>Fermer</Button>}
                 onCancel={() => { setPrestationModalVisible(false); setPrestationVente(null); }}
                 destroyOnHidden
-                width={800}
+                width="95vw"
             >
                 {prestationLoading ? (
                     <div style={{ textAlign: 'center', padding: 40 }}>Chargement...</div>

--- a/chantier-ui/src/sequence-emails.tsx
+++ b/chantier-ui/src/sequence-emails.tsx
@@ -243,7 +243,7 @@ function SequenceTable({ cible, variables }: { cible: string; variables: string 
                 title={editing && editing.id ? 'Modifier l\'étape' : 'Ajouter une étape'}
                 okText="Enregistrer"
                 cancelText="Fermer"
-                width={900}
+                width="95vw"
                 onOk={() => form.submit()}
                 onCancel={() => {
                     form.resetFields();

--- a/chantier-ui/src/services.tsx
+++ b/chantier-ui/src/services.tsx
@@ -568,7 +568,7 @@ export default function Services() {
                 cancelText="Fermer"
                 maskClosable={false}
                 destroyOnHidden
-                width={1000}
+                width="95vw"
             >
                 <Form
                     form={form}
@@ -787,7 +787,7 @@ export default function Services() {
                 cancelText="Fermer"
                 maskClosable={false}
                 destroyOnHidden
-                width={700}
+                width="95vw"
             >
                 <Form form={newMainOeuvreForm} layout="vertical" initialValues={defaultNewMainOeuvre} onValuesChange={(...args) => { setNewMainOeuvreFormDirty(true); onNewMainOeuvreValuesChange(...args); }}>
                     <Form.Item name="reference" label="Référence">
@@ -834,7 +834,7 @@ export default function Services() {
                 cancelText="Fermer"
                 maskClosable={false}
                 destroyOnHidden
-                width={700}
+                width="95vw"
             >
                 <Form form={newProduitForm} layout="vertical" initialValues={defaultNewProduit} onValuesChange={(...args) => { setNewProduitFormDirty(true); onNewProduitValuesChange(...args); }}>
                     <Form.Item name="nom" label="Nom" rules={[{ required: true, message: 'Le nom est requis' }]}>

--- a/chantier-ui/src/techniciens.tsx
+++ b/chantier-ui/src/techniciens.tsx
@@ -327,7 +327,7 @@ const Techniciens: React.FC = () => {
                             onOk={handleModalOk}
                             onCancel={handleModalCancel}
                             maskClosable={false}
-                            width={1024}
+                width="95vw"
                             okText="Enregistrer"
                             cancelText="Fermer"
                             destroyOnClose
@@ -486,7 +486,7 @@ const Techniciens: React.FC = () => {
                 title={kpiTechnicien ? `KPI — ${kpiTechnicien.prenom} ${kpiTechnicien.nom}` : 'KPI'}
                 open={kpiDrawerVisible}
                 onClose={() => { setKpiDrawerVisible(false); setKpiData(null); }}
-                width={520}
+                width="95vw"
             >
                 {kpiLoading ? (
                     <div style={{ textAlign: 'center', padding: 40 }}><Spin size="large" /></div>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -2982,7 +2982,7 @@ export default function Vente() {
                 ]}
                 maskClosable={false}
                 destroyOnHidden
-                width={1400}
+                width="95vw"
             >
                 <Form form={form} layout="vertical" initialValues={defaultVente} onValuesChange={onValuesChange} disabled={isReadOnly}>
                     <Form.Item noStyle name="status"><input type="hidden" /></Form.Item>
@@ -3644,7 +3644,7 @@ export default function Vente() {
                     onOk={handleNewProduitSave}
                     onCancel={makeInnerModalCancel(newProduitFormDirty, setNewProduitFormDirty, setNewProduitModalVisible)}
                     maskClosable={false}
-                    width={1024}
+                width="95vw"
                     okText="Enregistrer"
                     cancelText="Fermer"
                     destroyOnHidden
@@ -3762,7 +3762,7 @@ export default function Vente() {
                     onOk={handleNewServiceSave}
                     onCancel={makeInnerModalCancel(newServiceFormDirty, setNewServiceFormDirty, setNewServiceModalVisible)}
                     maskClosable={false}
-                    width={1000}
+                width="95vw"
                     okText="Enregistrer"
                     cancelText="Fermer"
                     destroyOnHidden
@@ -3922,7 +3922,7 @@ export default function Vente() {
                     onOk={handleNewForfaitSave}
                     onCancel={makeInnerModalCancel(newForfaitFormDirty, setNewForfaitFormDirty, setNewForfaitModalVisible)}
                     maskClosable={false}
-                    width={1024}
+                width="95vw"
                     okText="Enregistrer"
                     cancelText="Fermer"
                     destroyOnHidden
@@ -4117,7 +4117,7 @@ export default function Vente() {
                 onOk={handleNewClientSave}
                 onCancel={makeInnerModalCancel(newClientFormDirty, setNewClientFormDirty, setNewClientModalVisible)}
                 maskClosable={false}
-                width={800}
+                width="95vw"
                 okText="Enregistrer"
                 cancelText="Fermer"
                 destroyOnHidden
@@ -4223,7 +4223,7 @@ export default function Vente() {
                 onOk={handleNewBateauSave}
                 onCancel={makeInnerModalCancel(newBateauFormDirty, setNewBateauFormDirty, setNewBateauModalVisible)}
                 maskClosable={false}
-                width={800}
+                width="95vw"
                 okText="Enregistrer"
                 cancelText="Fermer"
                 destroyOnHidden
@@ -4343,7 +4343,7 @@ export default function Vente() {
                 onOk={handleNewMoteurSave}
                 onCancel={makeInnerModalCancel(newMoteurFormDirty, setNewMoteurFormDirty, setNewMoteurModalVisible)}
                 maskClosable={false}
-                width={800}
+                width="95vw"
                 okText="Enregistrer"
                 cancelText="Fermer"
                 destroyOnHidden
@@ -4423,7 +4423,7 @@ export default function Vente() {
                 onOk={handleNewRemorqueSave}
                 onCancel={makeInnerModalCancel(newRemorqueFormDirty, setNewRemorqueFormDirty, setNewRemorqueModalVisible)}
                 maskClosable={false}
-                width={800}
+                width="95vw"
                 okText="Enregistrer"
                 cancelText="Fermer"
                 destroyOnHidden
@@ -4495,7 +4495,7 @@ export default function Vente() {
                 title="Bon pour accord — Signature client"
                 open={bpaModalVisible}
                 onCancel={handleBpaCancel}
-                width={700}
+                width="95vw"
                 maskClosable={false}
                 destroyOnHidden
                 footer={[
@@ -4573,7 +4573,7 @@ export default function Vente() {
                 okText="Générer"
                 confirmLoading={generatingAvoir}
                 destroyOnHidden
-                width={480}
+                width="95vw"
             >
                 <p style={{ marginBottom: 16, color: '#595959' }}>
                     Un avoir en brouillon sera créé avec les lignes de la facture <strong>#{genAvoirModalVente?.id}</strong>.
@@ -4606,7 +4606,7 @@ export default function Vente() {
                 okText="Valider"
                 confirmLoading={addingPaiement}
                 destroyOnHidden
-                width={480}
+                width="95vw"
             >
                 <Form layout="vertical">
                     <Form.Item label="Mode de règlement" required>


### PR DESCRIPTION
## Résumé

- Onglet **Documents** dédié sur la fiche client (déplacé hors du formulaire principal)
- Renommage de l'onglet *Véhicules* en **Bateaux, Moteurs, Remorques**
- Les sections Bateaux Clients, Moteurs Clients et Remorques Clients sont **repliées par défaut** et s'ouvrent au clic
- Tous les modals de l'application passent à `width="95vw"` pour maximiser l'espace d'affichage

## Plan de test

- [x] Ouvrir la fiche d'un client existant et vérifier la présence de l'onglet "Documents"
- [x] Vérifier que l'upload/suppression de documents fonctionne depuis l'onglet
- [x] Vérifier que l'onglet s'appelle bien "Bateaux, Moteurs, Remorques"
- [x] Vérifier que les trois sections sont fermées par défaut et s'ouvrent au clic
- [x] Ouvrir plusieurs modals (vente, comptoir, client, bateau…) et vérifier la largeur à 95% de la fenêtre