### PR TITLE
Critères de recherche client et mailing immédiat à l'entrée en parc

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/ClientEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/ClientEntity.java
@@ -55,4 +55,7 @@ public class ClientEntity extends PanacheEntity {
     @jakarta.persistence.Transient
     public Double soldeDu;
 
+    @jakarta.persistence.Transient
+    public Long nombreBateaux;
+
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/BateauClientResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/BateauClientResource.java
@@ -1,5 +1,7 @@
 package net.nanthrax.moussaillon.services;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -15,9 +17,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Path("/bateaux")
+@ApplicationScoped
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class BateauClientResource {
+
+    @Inject
+    EmailSequenceScheduler emailSequenceScheduler;
 
     @GET
     public List<BateauClientEntity> listAll() {
@@ -99,6 +105,8 @@ public class BateauClientResource {
             entity.dateCreation = new Timestamp(System.currentTimeMillis());
         }
         entity.persist();
+        // Entrée en parc : déclenche immédiatement le mailing de bienvenue plutôt que d'attendre le cron du lendemain
+        emailSequenceScheduler.declencherEntreeEnParc(entity);
         return Response.status(Response.Status.CREATED).entity(entity).build();
     }
 

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
@@ -8,6 +8,7 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import net.nanthrax.moussaillon.persistence.BateauClientEntity;
 import net.nanthrax.moussaillon.persistence.ClientEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
 import net.nanthrax.moussaillon.persistence.VenteEntity;
@@ -30,6 +31,7 @@ public class ClientResource {
         clients.forEach(c -> {
             c.motDePasse = null;
             c.soldeDu = computeSoldeDu(c.id);
+            c.nombreBateaux = computeNombreBateaux(c.id);
         });
         return clients;
     }
@@ -37,19 +39,20 @@ public class ClientResource {
     @GET
     @Path("/search")
     public List<ClientEntity> search(@QueryParam("q") String q) {
+        List<ClientEntity> clients;
         if (q == null || q.trim().isEmpty()) {
-            List<ClientEntity> clients = ClientEntity.listAll();
-            clients.forEach(c -> {
-                c.motDePasse = null;
-                c.soldeDu = computeSoldeDu(c.id);
-            });
-            return clients;
+            clients = ClientEntity.listAll();
+        } else {
+            String likePattern = "%" + q.toLowerCase() + "%";
+            clients = ClientEntity.list(
+                "LOWER(nom) LIKE ?1 OR LOWER(prenom) LIKE ?1 OR LOWER(type) LIKE ?1 OR LOWER(email) LIKE ?1 OR LOWER(telephone) LIKE ?1 OR LOWER(adresse) LIKE ?1",
+                likePattern
+            );
         }
-        String likePattern = "%" + q.toLowerCase() + "%";
-        List<ClientEntity> clients = ClientEntity.list("LOWER(nom) LIKE ?1 OR LOWER(prenom) LIKE ?1 OR LOWER(type) LIKE ?1 OR LOWER(email) LIKE ?1 OR LOWER(telephone) LIKE ?1", likePattern);
         clients.forEach(c -> {
             c.motDePasse = null;
             c.soldeDu = computeSoldeDu(c.id);
+            c.nombreBateaux = computeNombreBateaux(c.id);
         });
         return clients;
     }
@@ -80,6 +83,7 @@ public class ClientResource {
         }
         entity.motDePasse = null;
         entity.soldeDu = computeSoldeDu(id);
+        entity.nombreBateaux = computeNombreBateaux(id);
         return entity;
     }
 
@@ -129,6 +133,7 @@ public class ClientResource {
         ClientEntity.getEntityManager().detach(entity);
         entity.motDePasse = null;
         entity.soldeDu = computeSoldeDu(id);
+        entity.nombreBateaux = computeNombreBateaux(id);
         return entity;
     }
 
@@ -138,6 +143,13 @@ public class ClientResource {
             clientId, VenteEntity.Status.FACTURE_EN_ATTENTE, VenteEntity.Status.FACTURE_PRETE
         );
         return unpaid.stream().mapToDouble(v -> v.prixVenteTTC).sum();
+    }
+
+    private long computeNombreBateaux(long clientId) {
+        return BateauClientEntity.getEntityManager()
+            .createQuery("SELECT COUNT(b) FROM BateauClientEntity b JOIN b.proprietaires p WHERE p.id = :clientId", Long.class)
+            .setParameter("clientId", clientId)
+            .getSingleResult();
     }
 
     @POST

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/EmailSequenceScheduler.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/EmailSequenceScheduler.java
@@ -19,9 +19,12 @@ import net.nanthrax.moussaillon.persistence.EmailSequenceHistoriqueEntity;
 import net.nanthrax.moussaillon.persistence.MoteurClientEntity;
 import net.nanthrax.moussaillon.persistence.RemorqueClientEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class EmailSequenceScheduler {
+
+    private static final Logger LOG = Logger.getLogger(EmailSequenceScheduler.class);
 
     @Inject
     Mailer mailer;
@@ -38,6 +41,21 @@ public class EmailSequenceScheduler {
         traiterBateaux(today, societeNom);
         traiterMoteurs(today, societeNom);
         traiterRemorques(today, societeNom);
+    }
+
+    /**
+     * Déclenche immédiatement (sans attendre le cron du lendemain) l'étape de bienvenue
+     * (delaiJours = 0) pour un bateau qui vient d'être enregistré, c'est-à-dire une "entrée en parc".
+     */
+    @Transactional
+    public void declencherEntreeEnParc(BateauClientEntity bateau) {
+        List<EmailSequenceEtapeEntity> etapes = EmailSequenceEtapeEntity.listActivesByCible(Cible.BATEAU);
+        if (etapes.isEmpty()) return;
+
+        SocieteEntity societe = SocieteEntity.findById(1L);
+        String societeNom = societe != null ? societe.nom : "moussAIllon";
+
+        traiterBateau(LocalDate.now(), societeNom, etapes, bateau);
     }
 
     private void traiterClients(LocalDate today, String societeNom) {
@@ -67,22 +85,27 @@ public class EmailSequenceScheduler {
 
         List<BateauClientEntity> bateaux = BateauClientEntity.list("dateCreation is not null");
         for (BateauClientEntity bateau : bateaux) {
-            if (bateau.proprietaires == null || bateau.proprietaires.isEmpty()) continue;
-            LocalDate dateCreation = bateau.dateCreation.toLocalDateTime().toLocalDate();
+            traiterBateau(today, societeNom, etapes, bateau);
+        }
+    }
 
-            for (ClientEntity proprietaire : bateau.proprietaires) {
-                if (!proprietaire.consentement) continue;
-                if (proprietaire.email == null || proprietaire.email.isBlank()) continue;
-                String clientName = proprietaire.prenom != null && !proprietaire.prenom.isBlank() ? proprietaire.prenom : proprietaire.nom;
-                String bateauNom = bateau.name != null ? bateau.name : (bateau.immatriculation != null ? bateau.immatriculation : String.valueOf(bateau.id));
+    private void traiterBateau(LocalDate today, String societeNom, List<EmailSequenceEtapeEntity> etapes, BateauClientEntity bateau) {
+        if (bateau.proprietaires == null || bateau.proprietaires.isEmpty()) return;
+        if (bateau.dateCreation == null) return;
+        LocalDate dateCreation = bateau.dateCreation.toLocalDateTime().toLocalDate();
 
-                for (EmailSequenceEtapeEntity etape : etapes) {
-                    long jours = ChronoUnit.DAYS.between(dateCreation, today);
-                    if (jours >= etape.delaiJours && !EmailSequenceHistoriqueEntity.dejaSent(Cible.BATEAU, bateau.id, etape.id)) {
-                        String subject = applyEquipementVariables(etape.sujet, clientName, societeNom, bateauNom, proprietaire);
-                        String body = applyEquipementVariables(etape.contenu, clientName, societeNom, bateauNom, proprietaire);
-                        envoyerEtape(Cible.BATEAU, bateau.id, proprietaire.email, etape, subject, body);
-                    }
+        for (ClientEntity proprietaire : bateau.proprietaires) {
+            if (!proprietaire.consentement) continue;
+            if (proprietaire.email == null || proprietaire.email.isBlank()) continue;
+            String clientName = proprietaire.prenom != null && !proprietaire.prenom.isBlank() ? proprietaire.prenom : proprietaire.nom;
+            String bateauNom = bateau.name != null ? bateau.name : (bateau.immatriculation != null ? bateau.immatriculation : String.valueOf(bateau.id));
+
+            for (EmailSequenceEtapeEntity etape : etapes) {
+                long jours = ChronoUnit.DAYS.between(dateCreation, today);
+                if (jours >= etape.delaiJours && !EmailSequenceHistoriqueEntity.dejaSent(Cible.BATEAU, bateau.id, etape.id)) {
+                    String subject = applyEquipementVariables(etape.sujet, clientName, societeNom, bateauNom, proprietaire);
+                    String body = applyEquipementVariables(etape.contenu, clientName, societeNom, bateauNom, proprietaire);
+                    envoyerEtape(Cible.BATEAU, bateau.id, proprietaire.email, etape, subject, body);
                 }
             }
         }
@@ -133,7 +156,12 @@ public class EmailSequenceScheduler {
     }
 
     private void envoyerEtape(Cible cible, long cibleId, String email, EmailSequenceEtapeEntity etape, String subject, String body) {
-        mailer.send(Mail.withHtml(email, subject, body));
+        try {
+            mailer.send(Mail.withHtml(email, subject, body));
+        } catch (Exception e) {
+            LOG.warnf(e, "Échec de l'envoi de l'email de séquence (cible=%s, cibleId=%d, etapeId=%d) à %s", cible, cibleId, etape.id, email);
+            return;
+        }
 
         EmailSequenceHistoriqueEntity historique = new EmailSequenceHistoriqueEntity();
         historique.cible = cible;

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -67,6 +67,7 @@ interface Client {
   canalAcquisition?: string;
   documents?: string[];
   soldeDu?: number;
+  nombreBateaux?: number;
 }
 
 const defaultClient = {
@@ -255,6 +256,7 @@ function Clients() {
       render: (type) => (type === "PROFESSIONNEL" ? "Professionnel" : "Particulier"),
     },
     { title: "Email", dataIndex: "email", key: "email", sorter: (a, b) => (a.email || '').localeCompare(b.email || '') },
+    { title: "Adresse", dataIndex: "adresse", key: "adresse", sorter: (a, b) => (a.adresse || '').localeCompare(b.adresse || '') },
     {
       title: "Canal d'acquisition",
       dataIndex: "canalAcquisition",
@@ -284,6 +286,18 @@ function Clients() {
         if (!val || val === 0) return <span style={{ color: "#52c41a" }}>0,00 €</span>;
         return <span style={{ color: "#ff4d4f", fontWeight: 600 }}>{val.toLocaleString("fr-FR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €</span>;
       },
+    },
+    {
+      title: "Bateau(x)",
+      dataIndex: "nombreBateaux",
+      key: "nombreBateaux",
+      sorter: (a, b) => (a.nombreBateaux || 0) - (b.nombreBateaux || 0),
+      filters: [
+        { text: "Avec bateau(x)", value: "OUI" },
+        { text: "Sans bateau", value: "NON" },
+      ],
+      onFilter: (value, record) => (value === "OUI" ? (record.nombreBateaux || 0) > 0 : !(record.nombreBateaux || 0)),
+      render: (val) => (val ? <span>{val}</span> : <span style={{ color: "#bfbfbf" }}>0</span>),
     },
     {
       title: "Actions",


### PR DESCRIPTION
## Résumé
- Recherche client (`/clients/search`) étendue à l'adresse en plus de nom/prénom/type/email/téléphone
- Nouvelle colonne "Bateau(x)" sur la vue client, filtrable (avec/sans bateau enregistré), et colonne "Adresse" affichée
- Le mail de bienvenue "bateau" (séquence email, étape à délai 0) est désormais déclenché immédiatement à l'enregistrement d'un bateau (entrée en parc), au lieu d'attendre le prochain passage du cron (le lendemain 8h05)
- L'envoi d'email est maintenant protégé (try/catch + log) pour ne jamais faire échouer la création d'un bateau en cas de souci SMTP

Closes #6

## Test plan
- [x] `mvn -pl backend test` (suite complète) passe
- [x] `npm run build` sur `chantier-ui` passe
- [x] Vérifié manuellement en environnement de dev : création d'un client consentant + d'un bateau associé → mail de bienvenue envoyé et historisé (`EmailSequenceHistoriqueEntity`) quelques millisecondes après la création du bateau, sans attendre le cron du lendemain
- [x] Vérifié le filtre "Bateau(x)" (avec/sans bateau) et la colonne "Adresse" sur la vue client (chantier-ui)