### PR TITLE
Import de fichiers Excel/CSV pour peupler le chantier

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -93,6 +93,18 @@
             <version>2.2.0</version>
         </dependency>
 
+        <!-- Import Excel/CSV (issue #433) -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jacoco</artifactId>

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ImportResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ImportResource.java
@@ -1,0 +1,594 @@
+package net.nanthrax.moussaillon.services;
+
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import net.nanthrax.moussaillon.persistence.BateauClientEntity;
+import net.nanthrax.moussaillon.persistence.ClientEntity;
+import net.nanthrax.moussaillon.persistence.MoteurClientEntity;
+import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
+import net.nanthrax.moussaillon.persistence.RemorqueClientEntity;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.sql.Timestamp;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Import en masse (issue #433) : un classeur Excel (.xlsx) avec un onglet par type
+ * ("Clients", "Produits", "Bateaux", "Moteurs", "Remorques"), ou un fichier CSV
+ * contenant un seul type (précisé via le champ "type" du formulaire).
+ *
+ * Les bateaux/moteurs/remorques sont rattachés à un client via une colonne
+ * "clientEmail", résolue sur les clients déjà en base ou fraîchement importés
+ * dans le même fichier (l'onglet Clients est toujours traité en premier).
+ */
+@Path("/import")
+public class ImportResource {
+
+    private enum ImportType {
+        CLIENTS, PRODUITS, BATEAUX, MOTEURS, REMORQUES
+    }
+
+    public static class RowError {
+        public int ligne;
+        public String message;
+
+        public RowError(int ligne, String message) {
+            this.ligne = ligne;
+            this.message = message;
+        }
+    }
+
+    public static class SheetReport {
+        public String type;
+        public int crees;
+        public int misAJour;
+        public List<RowError> erreurs = new ArrayList<>();
+
+        public SheetReport(String type) {
+            this.type = type;
+        }
+    }
+
+    public static class ImportReport {
+        public List<SheetReport> onglets = new ArrayList<>();
+    }
+
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional
+    public ImportReport importFile(@RestForm("file") FileUpload file, @RestForm("type") String typeParam) throws IOException {
+        if (file == null) {
+            throw new BadRequestException("Aucun fichier fourni");
+        }
+
+        String filename = file.fileName() != null ? file.fileName().toLowerCase(Locale.ROOT) : "";
+        Map<ImportType, List<Map<String, String>>> rowsByType = new LinkedHashMap<>();
+
+        if (filename.endsWith(".xlsx") || filename.endsWith(".xls")) {
+            try (Workbook workbook = WorkbookFactory.create(Files.newInputStream(file.uploadedFile()))) {
+                for (int i = 0; i < workbook.getNumberOfSheets(); i++) {
+                    Sheet sheet = workbook.getSheetAt(i);
+                    ImportType type = resolveType(sheet.getSheetName());
+                    if (type == null) {
+                        continue;
+                    }
+                    rowsByType.put(type, readSheet(sheet));
+                }
+            }
+        } else if (filename.endsWith(".csv")) {
+            ImportType type = resolveType(typeParam);
+            if (type == null) {
+                throw new BadRequestException("Le type de données (clients, produits, bateaux, moteurs, remorques) est requis pour un import CSV");
+            }
+            try (Reader reader = new InputStreamReader(Files.newInputStream(file.uploadedFile()), StandardCharsets.UTF_8)) {
+                rowsByType.put(type, readCsv(reader));
+            }
+        } else {
+            throw new BadRequestException("Format de fichier non supporté (attendu : .xlsx ou .csv)");
+        }
+
+        // Les clients et les produits doivent être résolus avant les équipements qui les référencent.
+        Map<String, ClientEntity> clientsByEmail = loadExistingClientsByEmail();
+        Map<String, ProduitCatalogueEntity> produitsByNom = loadExistingProduitsByNom();
+
+        ImportReport report = new ImportReport();
+        List<ImportType> ordre = List.of(ImportType.CLIENTS, ImportType.PRODUITS, ImportType.BATEAUX, ImportType.MOTEURS, ImportType.REMORQUES);
+        for (ImportType type : ordre) {
+            List<Map<String, String>> rows = rowsByType.get(type);
+            if (rows == null) {
+                continue;
+            }
+            report.onglets.add(switch (type) {
+                case CLIENTS -> importClients(rows, clientsByEmail);
+                case PRODUITS -> importProduits(rows, produitsByNom);
+                case BATEAUX -> importBateaux(rows, clientsByEmail);
+                case MOTEURS -> importMoteurs(rows, clientsByEmail);
+                case REMORQUES -> importRemorques(rows, clientsByEmail);
+            });
+        }
+
+        return report;
+    }
+
+    // ---------------------------------------------------------------------
+    // Import par type
+    // ---------------------------------------------------------------------
+
+    private SheetReport importClients(List<Map<String, String>> rows, Map<String, ClientEntity> clientsByEmail) {
+        SheetReport sheetReport = new SheetReport("Clients");
+        int ligne = 1;
+        for (Map<String, String> row : rows) {
+            ligne++;
+            String nom = value(row, "nom");
+            if (isBlank(nom)) {
+                sheetReport.erreurs.add(new RowError(ligne, "Le nom est requis"));
+                continue;
+            }
+            String email = value(row, "email");
+            String emailKey = normalizeKey(email);
+
+            ClientEntity client = emailKey != null ? clientsByEmail.get(emailKey) : null;
+            boolean isNew = client == null;
+            if (isNew) {
+                client = new ClientEntity();
+            }
+
+            client.nom = nom;
+            client.prenom = orKeepExisting(value(row, "prenom"), isNew ? null : client.prenom);
+            client.type = resolveClientType(value(row, "type"), isNew ? "PARTICULIER" : client.type);
+            if (!isBlank(email)) {
+                client.email = email;
+            }
+            client.telephone = orKeepExisting(value(row, "telephone"), isNew ? null : client.telephone);
+            client.adresse = orKeepExisting(value(row, "adresse"), isNew ? null : client.adresse);
+            client.canalAcquisition = orKeepExisting(value(row, "canalAcquisition"), isNew ? null : client.canalAcquisition);
+            client.notes = orKeepExisting(value(row, "notes"), isNew ? null : client.notes);
+            String consentement = value(row, "consentement");
+            if (!isBlank(consentement)) {
+                client.consentement = parseBoolean(consentement);
+            }
+
+            if (isNew) {
+                client.dateCreation = new Timestamp(System.currentTimeMillis());
+                client.persist();
+                sheetReport.crees++;
+            } else {
+                sheetReport.misAJour++;
+            }
+            if (emailKey != null) {
+                clientsByEmail.put(emailKey, client);
+            }
+        }
+        return sheetReport;
+    }
+
+    private SheetReport importProduits(List<Map<String, String>> rows, Map<String, ProduitCatalogueEntity> produitsByNom) {
+        SheetReport sheetReport = new SheetReport("Produits");
+        int ligne = 1;
+        for (Map<String, String> row : rows) {
+            ligne++;
+            String nom = value(row, "nom");
+            String categorie = value(row, "categorie");
+            if (isBlank(nom) || isBlank(categorie)) {
+                sheetReport.erreurs.add(new RowError(ligne, "Le nom et la catégorie sont requis"));
+                continue;
+            }
+
+            String key = normalizeKey(nom);
+            ProduitCatalogueEntity produit = produitsByNom.get(key);
+            boolean isNew = produit == null;
+            if (isNew) {
+                produit = new ProduitCatalogueEntity();
+                produit.nom = nom;
+            }
+
+            produit.marque = orKeepExisting(value(row, "marque"), isNew ? null : produit.marque);
+            produit.categorie = categorie;
+            produit.ref = orKeepExisting(value(row, "ref"), isNew ? null : produit.ref);
+            produit.description = orKeepExisting(value(row, "description"), isNew ? null : produit.description);
+            produit.emplacement = orKeepExisting(value(row, "emplacement"), isNew ? null : produit.emplacement);
+
+            Integer stock = parseInt(value(row, "stock"));
+            if (stock != null) {
+                produit.stock = stock;
+            }
+            Integer stockMini = parseInt(value(row, "stockMini"));
+            if (stockMini != null) {
+                produit.stockMini = stockMini;
+            }
+
+            Double prixVenteHT = parseDouble(value(row, "prixVenteHT"));
+            Double tva = parseDouble(value(row, "tva"));
+            if (prixVenteHT != null) {
+                produit.prixVenteHT = prixVenteHT;
+            }
+            if (tva != null) {
+                produit.tva = tva;
+            }
+            if (prixVenteHT != null || tva != null) {
+                produit.montantTVA = round2(produit.prixVenteHT * (produit.tva / 100));
+                produit.prixVenteTTC = round2(produit.prixVenteHT + produit.montantTVA);
+            }
+
+            if (isNew) {
+                produit.persist();
+                sheetReport.crees++;
+            } else {
+                sheetReport.misAJour++;
+            }
+            produitsByNom.put(key, produit);
+        }
+        return sheetReport;
+    }
+
+    private SheetReport importBateaux(List<Map<String, String>> rows, Map<String, ClientEntity> clientsByEmail) {
+        SheetReport sheetReport = new SheetReport("Bateaux");
+        int ligne = 1;
+        for (Map<String, String> row : rows) {
+            ligne++;
+            String name = value(row, "name");
+            if (isBlank(name)) {
+                sheetReport.erreurs.add(new RowError(ligne, "Le nom du bateau est requis"));
+                continue;
+            }
+            ClientEntity proprietaire = resolveClient(row, clientsByEmail);
+            if (proprietaire == null) {
+                sheetReport.erreurs.add(new RowError(ligne, "Client introuvable pour l'email '" + value(row, "clientEmail") + "'"));
+                continue;
+            }
+
+            BateauClientEntity bateau = new BateauClientEntity();
+            bateau.name = name;
+            bateau.immatriculation = value(row, "immatriculation");
+            bateau.numeroSerie = value(row, "numeroSerie");
+            bateau.numeroClef = value(row, "numeroClef");
+            bateau.dateMeS = value(row, "dateMeS");
+            bateau.dateAchat = value(row, "dateAchat");
+            bateau.localisation = value(row, "localisation");
+            bateau.proprietaires.add(proprietaire);
+            bateau.dateCreation = new Timestamp(System.currentTimeMillis());
+            bateau.persist();
+            sheetReport.crees++;
+        }
+        return sheetReport;
+    }
+
+    private SheetReport importMoteurs(List<Map<String, String>> rows, Map<String, ClientEntity> clientsByEmail) {
+        SheetReport sheetReport = new SheetReport("Moteurs");
+        int ligne = 1;
+        for (Map<String, String> row : rows) {
+            ligne++;
+            ClientEntity proprietaire = resolveClient(row, clientsByEmail);
+            if (proprietaire == null) {
+                sheetReport.erreurs.add(new RowError(ligne, "Client introuvable pour l'email '" + value(row, "clientEmail") + "'"));
+                continue;
+            }
+
+            MoteurClientEntity moteur = new MoteurClientEntity();
+            moteur.numeroSerie = value(row, "numeroSerie");
+            moteur.numeroClef = value(row, "numeroClef");
+            moteur.dateMeS = value(row, "dateMeS");
+            moteur.dateAchat = value(row, "dateAchat");
+            moteur.proprietaire = proprietaire;
+            moteur.dateCreation = new Timestamp(System.currentTimeMillis());
+            moteur.persist();
+            sheetReport.crees++;
+        }
+        return sheetReport;
+    }
+
+    private SheetReport importRemorques(List<Map<String, String>> rows, Map<String, ClientEntity> clientsByEmail) {
+        SheetReport sheetReport = new SheetReport("Remorques");
+        int ligne = 1;
+        for (Map<String, String> row : rows) {
+            ligne++;
+            ClientEntity proprietaire = resolveClient(row, clientsByEmail);
+            if (proprietaire == null) {
+                sheetReport.erreurs.add(new RowError(ligne, "Client introuvable pour l'email '" + value(row, "clientEmail") + "'"));
+                continue;
+            }
+
+            RemorqueClientEntity remorque = new RemorqueClientEntity();
+            remorque.immatriculation = value(row, "immatriculation");
+            remorque.dateMeS = value(row, "dateMeS");
+            remorque.dateAchat = value(row, "dateAchat");
+            remorque.proprietaire = proprietaire;
+            remorque.dateCreation = new Timestamp(System.currentTimeMillis());
+            remorque.persist();
+            sheetReport.crees++;
+        }
+        return sheetReport;
+    }
+
+    private ClientEntity resolveClient(Map<String, String> row, Map<String, ClientEntity> clientsByEmail) {
+        String key = normalizeKey(value(row, "clientEmail"));
+        return key != null ? clientsByEmail.get(key) : null;
+    }
+
+    // ---------------------------------------------------------------------
+    // Chargement de l'état existant pour la déduplication
+    // ---------------------------------------------------------------------
+
+    private Map<String, ClientEntity> loadExistingClientsByEmail() {
+        Map<String, ClientEntity> byEmail = new HashMap<>();
+        for (ClientEntity client : ClientEntity.<ClientEntity>list("email is not null and email <> ''")) {
+            byEmail.put(normalizeKey(client.email), client);
+        }
+        return byEmail;
+    }
+
+    private Map<String, ProduitCatalogueEntity> loadExistingProduitsByNom() {
+        Map<String, ProduitCatalogueEntity> byNom = new HashMap<>();
+        for (ProduitCatalogueEntity produit : ProduitCatalogueEntity.<ProduitCatalogueEntity>listAll()) {
+            byNom.put(normalizeKey(produit.nom), produit);
+        }
+        return byNom;
+    }
+
+    // ---------------------------------------------------------------------
+    // Lecture des fichiers
+    // ---------------------------------------------------------------------
+
+    private List<Map<String, String>> readSheet(Sheet sheet) {
+        List<Map<String, String>> rows = new ArrayList<>();
+        Row headerRow = sheet.getRow(sheet.getFirstRowNum());
+        if (headerRow == null) {
+            return rows;
+        }
+        Map<Integer, String> headers = new LinkedHashMap<>();
+        for (Cell cell : headerRow) {
+            String header = normalizeHeader(cellValueAsString(cell));
+            if (!header.isEmpty()) {
+                headers.put(cell.getColumnIndex(), header);
+            }
+        }
+
+        for (int r = sheet.getFirstRowNum() + 1; r <= sheet.getLastRowNum(); r++) {
+            Row row = sheet.getRow(r);
+            if (row == null) {
+                continue;
+            }
+            Map<String, String> values = new HashMap<>();
+            boolean hasContent = false;
+            for (Map.Entry<Integer, String> entry : headers.entrySet()) {
+                Cell cell = row.getCell(entry.getKey());
+                String cellValue = cellValueAsString(cell);
+                if (!isBlank(cellValue)) {
+                    hasContent = true;
+                }
+                values.put(entry.getValue(), cellValue);
+            }
+            if (hasContent) {
+                rows.add(values);
+            }
+        }
+        return rows;
+    }
+
+    private List<Map<String, String>> readCsv(Reader reader) throws IOException {
+        List<Map<String, String>> rows = new ArrayList<>();
+        CSVFormat format = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setTrim(true).build();
+        try (CSVParser parser = format.parse(reader)) {
+            Map<String, Integer> headerMap = parser.getHeaderMap();
+            Map<Integer, String> normalizedHeaders = new LinkedHashMap<>();
+            for (Map.Entry<String, Integer> entry : headerMap.entrySet()) {
+                normalizedHeaders.put(entry.getValue(), normalizeHeader(entry.getKey()));
+            }
+            for (CSVRecord record : parser) {
+                Map<String, String> values = new HashMap<>();
+                boolean hasContent = false;
+                for (Map.Entry<Integer, String> entry : normalizedHeaders.entrySet()) {
+                    String cellValue = entry.getKey() < record.size() ? record.get(entry.getKey()) : "";
+                    if (!isBlank(cellValue)) {
+                        hasContent = true;
+                    }
+                    values.put(entry.getValue(), cellValue);
+                }
+                if (hasContent) {
+                    rows.add(values);
+                }
+            }
+        }
+        return rows;
+    }
+
+    private String cellValueAsString(Cell cell) {
+        if (cell == null) {
+            return "";
+        }
+        return switch (cell.getCellType()) {
+            case STRING -> cell.getStringCellValue().trim();
+            case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+            case NUMERIC -> {
+                double num = cell.getNumericCellValue();
+                yield num == Math.floor(num) && !Double.isInfinite(num) ? String.valueOf((long) num) : String.valueOf(num);
+            }
+            case FORMULA -> cellValueAsFormulaResult(cell);
+            case BLANK -> "";
+            default -> "";
+        };
+    }
+
+    private String cellValueAsFormulaResult(Cell cell) {
+        try {
+            return switch (cell.getCachedFormulaResultType()) {
+                case STRING -> cell.getStringCellValue().trim();
+                case NUMERIC -> String.valueOf(cell.getNumericCellValue());
+                case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+                default -> "";
+            };
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Utilitaires
+    // ---------------------------------------------------------------------
+
+    private static final Map<String, ImportType> TYPE_ALIASES = new HashMap<>();
+    static {
+        for (String alias : Set.of("clients", "client")) TYPE_ALIASES.put(alias, ImportType.CLIENTS);
+        for (String alias : Set.of("produits", "produit", "products", "product")) TYPE_ALIASES.put(alias, ImportType.PRODUITS);
+        for (String alias : Set.of("bateaux", "bateau", "boats", "boat")) TYPE_ALIASES.put(alias, ImportType.BATEAUX);
+        for (String alias : Set.of("moteurs", "moteur", "engines", "engine")) TYPE_ALIASES.put(alias, ImportType.MOTEURS);
+        for (String alias : Set.of("remorques", "remorque", "trailers", "trailer")) TYPE_ALIASES.put(alias, ImportType.REMORQUES);
+    }
+
+    private ImportType resolveType(String label) {
+        if (isBlank(label)) {
+            return null;
+        }
+        return TYPE_ALIASES.get(normalizeHeader(label));
+    }
+
+    private static final Map<String, Set<String>> HEADER_ALIASES = new HashMap<>();
+    static {
+        HEADER_ALIASES.put("prenom", normalizedAliases("prenom", "prénom", "firstname"));
+        HEADER_ALIASES.put("nom", normalizedAliases("nom", "lastname", "name"));
+        HEADER_ALIASES.put("name", normalizedAliases("nom", "name"));
+        HEADER_ALIASES.put("type", normalizedAliases("type"));
+        HEADER_ALIASES.put("email", normalizedAliases("email", "mail", "courriel"));
+        HEADER_ALIASES.put("telephone", normalizedAliases("telephone", "téléphone", "tel", "phone"));
+        HEADER_ALIASES.put("adresse", normalizedAliases("adresse", "address", "ville"));
+        HEADER_ALIASES.put("consentement", normalizedAliases("consentement", "consent", "rgpd"));
+        HEADER_ALIASES.put("canalAcquisition", normalizedAliases("canal acquisition", "canal d'acquisition", "canal", "source"));
+        HEADER_ALIASES.put("notes", normalizedAliases("notes", "note", "commentaire", "commentaires"));
+        HEADER_ALIASES.put("marque", normalizedAliases("marque", "brand"));
+        HEADER_ALIASES.put("categorie", normalizedAliases("categorie", "catégorie", "category"));
+        HEADER_ALIASES.put("ref", normalizedAliases("ref", "référence", "reference", "sku"));
+        HEADER_ALIASES.put("description", normalizedAliases("description", "desc"));
+        HEADER_ALIASES.put("stock", normalizedAliases("stock", "quantite", "quantité", "qty"));
+        HEADER_ALIASES.put("stockMini", normalizedAliases("stock mini", "stock minimum", "stockmin"));
+        HEADER_ALIASES.put("emplacement", normalizedAliases("emplacement", "location"));
+        HEADER_ALIASES.put("prixVenteHT", normalizedAliases("prix vente ht", "prix ht", "prix vente", "prix", "pu ht"));
+        HEADER_ALIASES.put("tva", normalizedAliases("tva", "vat"));
+        HEADER_ALIASES.put("immatriculation", normalizedAliases("immatriculation", "immat"));
+        HEADER_ALIASES.put("numeroSerie", normalizedAliases("numero serie", "numéro de série", "num serie", "serial number"));
+        HEADER_ALIASES.put("numeroClef", normalizedAliases("numero clef", "numéro de clef", "clef", "clé", "cle"));
+        HEADER_ALIASES.put("dateMeS", normalizedAliases("date mes", "date de mise en service", "mes"));
+        HEADER_ALIASES.put("dateAchat", normalizedAliases("date achat", "date d'achat", "achat"));
+        HEADER_ALIASES.put("localisation", normalizedAliases("localisation", "location"));
+        HEADER_ALIASES.put("clientEmail", normalizedAliases("client email", "email client", "email", "proprietaire email"));
+    }
+
+    private static Set<String> normalizedAliases(String... raw) {
+        Set<String> normalized = new java.util.HashSet<>();
+        for (String r : raw) {
+            normalized.add(normalizeHeader(r));
+        }
+        return normalized;
+    }
+
+    /**
+     * L'en-tête brute est normalisée à la lecture du fichier ; ce qu'on stocke dans
+     * chaque ligne est donc déjà la forme normalisée. On construit ici l'inverse
+     * (alias normalisé -> nom de champ canonique) pour retrouver une valeur.
+     */
+    private String value(Map<String, String> row, String canonicalField) {
+        Set<String> aliases = HEADER_ALIASES.get(canonicalField);
+        if (aliases == null) {
+            return row.get(normalizeHeader(canonicalField));
+        }
+        for (String alias : aliases) {
+            String v = row.get(alias);
+            if (v != null) {
+                return v;
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeHeader(String header) {
+        if (header == null) {
+            return "";
+        }
+        return Normalizer.normalize(header.trim().toLowerCase(Locale.ROOT), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .replaceAll("[^a-z0-9]", "");
+    }
+
+    private String normalizeKey(String s) {
+        if (isBlank(s)) {
+            return null;
+        }
+        return s.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    private String orKeepExisting(String newValue, String existing) {
+        return isBlank(newValue) ? existing : newValue;
+    }
+
+    private String resolveClientType(String value, String fallback) {
+        if (isBlank(value)) {
+            return fallback;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT).replace(' ', '_');
+        return switch (normalized) {
+            case "PARTICULIER", "PROFESSIONNEL", "PROFESSIONNEL_MER" -> normalized;
+            default -> fallback;
+        };
+    }
+
+    private boolean parseBoolean(String value) {
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return normalized.equals("true") || normalized.equals("1") || normalized.equals("oui") || normalized.equals("yes");
+    }
+
+    private Integer parseInt(String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+        try {
+            return (int) Double.parseDouble(value.trim().replace(',', '.'));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Double parseDouble(String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value.trim().replace(',', '.'));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private double round2(double value) {
+        return Math.round((value + 1e-9) * 100) / 100.0;
+    }
+}

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ImportResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ImportResource.java
@@ -168,7 +168,7 @@ public class ImportResource {
             }
             client.telephone = orKeepExisting(value(row, "telephone"), isNew ? null : client.telephone);
             client.adresse = orKeepExisting(value(row, "adresse"), isNew ? null : client.adresse);
-            client.canalAcquisition = orKeepExisting(value(row, "canalAcquisition"), isNew ? null : client.canalAcquisition);
+            client.canalAcquisition = orKeepExisting(resolveCanalAcquisition(value(row, "canalAcquisition")), isNew ? null : client.canalAcquisition);
             client.notes = orKeepExisting(value(row, "notes"), isNew ? null : client.notes);
             String consentement = value(row, "consentement");
             if (!isBlank(consentement)) {
@@ -559,6 +559,30 @@ public class ImportResource {
             case "PARTICULIER", "PROFESSIONNEL", "PROFESSIONNEL_MER" -> normalized;
             default -> fallback;
         };
+    }
+
+    /**
+     * La vue Clients (chantier-ui) n'affiche que les codes canaux connus
+     * (BOUCHE_A_OREILLE, FACEBOOK, ...). On accepte en entrée aussi bien le
+     * code que le libellé français affiché dans le sélecteur.
+     */
+    private static final Map<String, String> CANAL_ACQUISITION_ALIASES = new HashMap<>();
+    static {
+        CANAL_ACQUISITION_ALIASES.put(normalizeHeader("Bouche à oreille"), "BOUCHE_A_OREILLE");
+        CANAL_ACQUISITION_ALIASES.put(normalizeHeader("Facebook"), "FACEBOOK");
+        CANAL_ACQUISITION_ALIASES.put(normalizeHeader("Instagram"), "INSTAGRAM");
+        CANAL_ACQUISITION_ALIASES.put(normalizeHeader("LinkedIn"), "LINKEDIN");
+        CANAL_ACQUISITION_ALIASES.put(normalizeHeader("Passage"), "PASSAGE");
+        CANAL_ACQUISITION_ALIASES.put(normalizeHeader("Site Internet"), "SITE_INTERNET");
+        CANAL_ACQUISITION_ALIASES.put(normalizeHeader("Pages Jaunes"), "PAGES_JAUNES");
+    }
+
+    private String resolveCanalAcquisition(String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+        String code = CANAL_ACQUISITION_ALIASES.get(normalizeHeader(value));
+        return code != null ? code : value.trim().toUpperCase(Locale.ROOT).replace(' ', '_');
     }
 
     private boolean parseBoolean(String value) {

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/ImportResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/ImportResourceTest.java
@@ -1,0 +1,183 @@
+package net.nanthrax.moussaillon.services;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@QuarkusTest
+public class ImportResourceTest {
+
+    private byte[] buildWorkbook(String[][] clientsSheet, String[][] bateauxSheet) throws IOException {
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            if (clientsSheet != null) {
+                writeSheet(workbook.createSheet("Clients"), clientsSheet);
+            }
+            if (bateauxSheet != null) {
+                writeSheet(workbook.createSheet("Bateaux"), bateauxSheet);
+            }
+            workbook.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private void writeSheet(Sheet sheet, String[][] data) {
+        for (int r = 0; r < data.length; r++) {
+            Row row = sheet.createRow(r);
+            for (int c = 0; c < data[r].length; c++) {
+                row.createCell(c).setCellValue(data[r][c]);
+            }
+        }
+    }
+
+    @Test
+    void testImportXlsxClientsEtBateaux() throws IOException {
+        byte[] xlsx = buildWorkbook(
+            new String[][] {
+                { "Prenom", "Nom", "Email", "Type", "Consentement" },
+                { "Alice", "ImportTest", "alice.importtest@test.com", "Particulier", "oui" }
+            },
+            new String[][] {
+                { "Nom", "Immatriculation", "Email Client" },
+                { "Bateau ImportTest", "IMPORT001", "alice.importtest@test.com" }
+            }
+        );
+
+        given()
+            .multiPart("file", "import.xlsx", xlsx, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+            .when().post("/import")
+            .then()
+            .statusCode(200)
+            .body("onglets.size()", is(2))
+            .body("onglets[0].type", is("Clients"))
+            .body("onglets[0].crees", is(1))
+            .body("onglets[0].erreurs.size()", is(0))
+            .body("onglets[1].type", is("Bateaux"))
+            .body("onglets[1].crees", is(1))
+            .body("onglets[1].erreurs.size()", is(0));
+
+        given()
+            .when().get("/clients/search?q=alice.importtest@test.com")
+            .then()
+            .statusCode(200)
+            .body("size()", is(1))
+            .body("[0].nom", is("ImportTest"))
+            .body("[0].consentement", is(true));
+
+        given()
+            .when().get("/bateaux/search?q=IMPORT001")
+            .then()
+            .statusCode(200)
+            .body("size()", is(1))
+            .body("[0].name", is("Bateau ImportTest"));
+    }
+
+    @Test
+    void testImportBateauAvecEmailClientInconnu() throws IOException {
+        byte[] xlsx = buildWorkbook(
+            null,
+            new String[][] {
+                { "Nom", "Email Client" },
+                { "Bateau Orphelin", "inconnu.importtest@test.com" }
+            }
+        );
+
+        given()
+            .multiPart("file", "import.xlsx", xlsx, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+            .when().post("/import")
+            .then()
+            .statusCode(200)
+            .body("onglets.size()", is(1))
+            .body("onglets[0].type", is("Bateaux"))
+            .body("onglets[0].crees", is(0))
+            .body("onglets[0].erreurs.size()", is(1))
+            .body("onglets[0].erreurs[0].ligne", is(2));
+    }
+
+    @Test
+    void testImportCsvClients() throws IOException {
+        String csv = "Nom,Prenom,Email\nDupontCsvImport,Marc,marc.dupontcsvimport@test.com\n";
+        byte[] bytes = csv.getBytes(StandardCharsets.UTF_8);
+
+        given()
+            .multiPart("file", "clients.csv", bytes, "text/csv")
+            .multiPart("type", "clients")
+            .when().post("/import")
+            .then()
+            .statusCode(200)
+            .body("onglets.size()", is(1))
+            .body("onglets[0].type", is("Clients"))
+            .body("onglets[0].crees", is(1));
+
+        given()
+            .when().get("/clients/search?q=marc.dupontcsvimport@test.com")
+            .then()
+            .statusCode(200)
+            .body("size()", is(1))
+            .body("[0].prenom", is("Marc"));
+    }
+
+    @Test
+    void testImportCsvSansType() throws IOException {
+        String csv = "Nom\nSansType\n";
+        given()
+            .multiPart("file", "clients.csv", csv.getBytes(StandardCharsets.UTF_8), "text/csv")
+            .when().post("/import")
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void testImportClientExistantMisAJour() throws IOException {
+        byte[] xlsx1 = buildWorkbook(
+            new String[][] {
+                { "Nom", "Email", "Telephone" },
+                { "MiseAJourTest", "maj.importtest@test.com", "0600000000" }
+            },
+            null
+        );
+        given()
+            .multiPart("file", "import.xlsx", xlsx1, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+            .when().post("/import")
+            .then().statusCode(200).body("onglets[0].crees", is(1));
+
+        byte[] xlsx2 = buildWorkbook(
+            new String[][] {
+                { "Nom", "Email", "Telephone" },
+                { "MiseAJourTest", "maj.importtest@test.com", "0611111111" }
+            },
+            null
+        );
+        given()
+            .multiPart("file", "import.xlsx", xlsx2, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+            .when().post("/import")
+            .then()
+            .statusCode(200)
+            .body("onglets[0].crees", is(0))
+            .body("onglets[0].misAJour", is(1));
+
+        given()
+            .when().get("/clients/search?q=maj.importtest@test.com")
+            .then()
+            .statusCode(200)
+            .body("[0].telephone", is("0611111111"));
+    }
+
+    @Test
+    void testImportFormatNonSupporte() {
+        given()
+            .multiPart("file", "notes.txt", "contenu".getBytes(StandardCharsets.UTF_8), "text/plain")
+            .when().post("/import")
+            .then()
+            .statusCode(400);
+    }
+}

--- a/chantier-ui/src/import.tsx
+++ b/chantier-ui/src/import.tsx
@@ -1,0 +1,202 @@
+import React, { useState } from "react";
+import { Card, Upload, Button, Select, message, Table, Tag, Collapse, Typography, Space, Alert } from "antd";
+import { InboxOutlined, UploadOutlined } from "@ant-design/icons";
+import type { UploadProps } from "antd";
+import api from "./api.ts";
+
+const { Dragger } = Upload;
+const { Text, Paragraph } = Typography;
+
+interface RowError {
+  ligne: number;
+  message: string;
+}
+
+interface SheetReport {
+  type: string;
+  crees: number;
+  misAJour: number;
+  erreurs: RowError[];
+}
+
+interface ImportReport {
+  onglets: SheetReport[];
+}
+
+const typeOptions = [
+  { value: "clients", label: "Clients" },
+  { value: "produits", label: "Produits" },
+  { value: "bateaux", label: "Bateaux" },
+  { value: "moteurs", label: "Moteurs" },
+  { value: "remorques", label: "Remorques" },
+];
+
+const columnsHelp = [
+  {
+    key: "clients",
+    label: "Clients",
+    colonnes: "Prénom, Nom (requis), Type (Particulier/Professionnel/Professionnel_Mer), Email, Téléphone, Adresse, Consentement (oui/non), Canal Acquisition, Notes",
+    cle: "Déduplication par Email : une ligne avec un email déjà connu met à jour le client existant.",
+  },
+  {
+    key: "produits",
+    label: "Produits",
+    colonnes: "Nom (requis, unique), Marque, Catégorie (requis), Ref, Description, Stock, Stock Mini, Emplacement, Prix Vente HT, TVA",
+    cle: "Déduplication par Nom : une ligne avec un nom déjà connu met à jour le produit existant.",
+  },
+  {
+    key: "bateaux",
+    label: "Bateaux",
+    colonnes: "Nom (requis), Immatriculation, Numéro Série, Numéro Clef, Date MES, Date Achat, Localisation, Email Client (requis)",
+    cle: "Email Client doit correspondre à un client existant ou présent dans l'onglet Clients du même fichier.",
+  },
+  {
+    key: "moteurs",
+    label: "Moteurs",
+    colonnes: "Numéro Série, Numéro Clef, Date MES, Date Achat, Email Client (requis)",
+    cle: "Email Client doit correspondre à un client existant ou présent dans l'onglet Clients du même fichier.",
+  },
+  {
+    key: "remorques",
+    label: "Remorques",
+    colonnes: "Immatriculation, Date MES, Date Achat, Email Client (requis)",
+    cle: "Email Client doit correspondre à un client existant ou présent dans l'onglet Clients du même fichier.",
+  },
+];
+
+export default function Import() {
+  const [file, setFile] = useState<File | null>(null);
+  const [csvType, setCsvType] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [report, setReport] = useState<ImportReport | null>(null);
+
+  const isCsv = file ? file.name.toLowerCase().endsWith(".csv") : false;
+
+  const uploadProps: UploadProps = {
+    multiple: false,
+    fileList: file ? [{ uid: "1", name: file.name, status: "done" }] : [],
+    beforeUpload: (selected) => {
+      setFile(selected);
+      setReport(null);
+      return false;
+    },
+    onRemove: () => {
+      setFile(null);
+      setCsvType(undefined);
+    },
+    accept: ".xlsx,.xls,.csv",
+  };
+
+  const handleImport = async () => {
+    if (!file) {
+      message.warning("Veuillez sélectionner un fichier");
+      return;
+    }
+    if (isCsv && !csvType) {
+      message.warning("Veuillez préciser le type de données pour un fichier CSV");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("file", file);
+    if (isCsv && csvType) {
+      formData.append("type", csvType);
+    }
+
+    setLoading(true);
+    try {
+      const res = await api.post("/import", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      setReport(res.data);
+      message.success("Import terminé");
+    } catch (e: any) {
+      message.error(e?.response?.data?.message || "Erreur lors de l'import");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const errorColumns = [
+    { title: "Ligne", dataIndex: "ligne", key: "ligne", width: 80 },
+    { title: "Erreur", dataIndex: "message", key: "message" },
+  ];
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: "100%" }}>
+      <Card title="Import de fichier">
+        <Paragraph>
+          Importez un classeur Excel (.xlsx) avec un onglet par type de données
+          (<Text code>Clients</Text>, <Text code>Produits</Text>, <Text code>Bateaux</Text>,{" "}
+          <Text code>Moteurs</Text>, <Text code>Remorques</Text>), ou un fichier CSV pour un seul type à la fois.
+        </Paragraph>
+        <Dragger {...uploadProps} style={{ marginBottom: 16 }}>
+          <p className="ant-upload-drag-icon">
+            <InboxOutlined />
+          </p>
+          <p className="ant-upload-text">Cliquer ou glisser-déposer un fichier ici</p>
+          <p className="ant-upload-hint">Formats acceptés : XLSX, XLS, CSV</p>
+        </Dragger>
+
+        {isCsv && (
+          <Select
+            placeholder="Type de données du fichier CSV"
+            options={typeOptions}
+            value={csvType}
+            onChange={setCsvType}
+            style={{ width: 300, marginBottom: 16 }}
+          />
+        )}
+
+        <div>
+          <Button type="primary" icon={<UploadOutlined />} loading={loading} disabled={!file} onClick={handleImport}>
+            Importer
+          </Button>
+        </div>
+      </Card>
+
+      {report && (
+        <Card title="Résultat de l'import">
+          <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+            {report.onglets.length === 0 && (
+              <Alert type="warning" showIcon message="Aucun onglet reconnu dans le fichier (attendu : Clients, Produits, Bateaux, Moteurs, Remorques)." />
+            )}
+            {report.onglets.map((sheet) => (
+              <Card key={sheet.type} type="inner" title={sheet.type}>
+                <Space style={{ marginBottom: sheet.erreurs.length > 0 ? 12 : 0 }}>
+                  <Tag color="success">{sheet.crees} créé(s)</Tag>
+                  <Tag color="processing">{sheet.misAJour} mis à jour</Tag>
+                  {sheet.erreurs.length > 0 && <Tag color="error">{sheet.erreurs.length} erreur(s)</Tag>}
+                </Space>
+                {sheet.erreurs.length > 0 && (
+                  <Table
+                    size="small"
+                    rowKey="ligne"
+                    dataSource={sheet.erreurs}
+                    columns={errorColumns}
+                    pagination={false}
+                  />
+                )}
+              </Card>
+            ))}
+          </Space>
+        </Card>
+      )}
+
+      <Card title="Format attendu des colonnes">
+        <Collapse
+          items={columnsHelp.map((h) => ({
+            key: h.key,
+            label: h.label,
+            children: (
+              <Space direction="vertical">
+                <Text>{h.colonnes}</Text>
+                <Text type="secondary">{h.cle}</Text>
+              </Space>
+            ),
+          }))}
+        />
+      </Card>
+    </Space>
+  );
+}

--- a/chantier-ui/src/import.tsx
+++ b/chantier-ui/src/import.tsx
@@ -35,7 +35,7 @@ const columnsHelp = [
   {
     key: "clients",
     label: "Clients",
-    colonnes: "Prénom, Nom (requis), Type (Particulier/Professionnel/Professionnel_Mer), Email, Téléphone, Adresse, Consentement (oui/non), Canal Acquisition, Notes",
+    colonnes: "Prénom, Nom (requis), Type (Particulier/Professionnel/Professionnel_Mer), Email, Téléphone, Adresse, Consentement (oui/non), Canal Acquisition (Bouche à oreille/Facebook/Instagram/LinkedIn/Passage/Site Internet/Pages Jaunes), Notes",
     cle: "Déduplication par Email : une ligne avec un email déjà connu met à jour le client existant.",
   },
   {

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -1,7 +1,7 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Layout, Input, Col, Row, Image, Menu, Form, Modal, message, ConfigProvider, theme as antdTheme, Switch as AntSwitch } from 'antd';
-import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined, RollbackOutlined } from '@ant-design/icons';
+import { UserOutlined, TeamOutlined, HomeOutlined, RocketOutlined, SettingOutlined, ToolOutlined, StockOutlined, NotificationOutlined, TruckOutlined, ReadOutlined, ShopOutlined, DeploymentUnitOutlined, DisconnectOutlined, CalendarOutlined, FileDoneOutlined, CheckSquareOutlined, HourglassOutlined, ShoppingCartOutlined, MailOutlined, SendOutlined, BankOutlined, NodeIndexOutlined, DatabaseOutlined, DollarOutlined, AppstoreOutlined, SolutionOutlined, RollbackOutlined, UploadOutlined } from '@ant-design/icons';
 import { NavigationContext } from './navigation-context.tsx';
 import Icon from '@ant-design/icons';
 import { ReactComponent as BoatOutlined } from './boat.svg';
@@ -38,6 +38,7 @@ import CommandesFournisseur from './commandes-fournisseur.tsx';
 import Emails from './emails.tsx';
 import SequenceEmails from './sequence-emails.tsx';
 import ReferenceValeurs from './reference-valeurs.tsx';
+import Import from './import.tsx';
 
 export function demo() {
     message.warning("Vous êtes sur une version de démonstration de moussAIllon. Il n'est pas possible d'ajouter ou supprimer des éléments.")
@@ -125,7 +126,8 @@ function SideMenu(props) {
         { key: '/utilisateurs', label: 'Utilisateurs', icon: <UserOutlined/> },
         { key: '/emails', label: 'Emails', icon: <MailOutlined/> },
         { key: '/sequence-emails', label: 'Séquence emails', icon: <NodeIndexOutlined/> },
-        { key: '/reference-valeurs', label: 'Valeurs de Référence', icon: <DatabaseOutlined/> }
+        { key: '/reference-valeurs', label: 'Valeurs de Référence', icon: <DatabaseOutlined/> },
+        { key: '/import', label: 'Import', icon: <UploadOutlined/> }
       ] }
     ];
 
@@ -505,6 +507,8 @@ export default function Workspace(props) {
                 return <ProtectedRoute roles={props.roles} requiredRole="admin"><Campagnes /></ProtectedRoute>;
             case '/reference-valeurs':
                 return <ProtectedRoute roles={props.roles} requiredRole="admin"><ReferenceValeurs /></ProtectedRoute>;
+            case '/import':
+                return <ProtectedRoute roles={props.roles} requiredRole="admin"><Import /></ProtectedRoute>;
             default:
                 return accueil;
         }


### PR DESCRIPTION
## Résumé
- Nouvel endpoint `POST /import` (multipart) : accepte un classeur `.xlsx` avec un onglet par type (`Clients`, `Produits`, `Bateaux`, `Moteurs`, `Remorques`), ou un `.csv` pour un seul type (précisé via le champ `type`)
- Les bateaux/moteurs/remorques sont rattachés à leur propriétaire via une colonne `Email Client`, résolue sur les clients déjà en base ou fraîchement importés dans le même fichier (l'onglet Clients est toujours traité en premier)
- Déduplication : clients par email, produits par nom (unique) → mise à jour au lieu de doublon ; bateaux/moteurs/remorques toujours créés
- En-têtes de colonnes tolérants à la casse/accents/espaces (ex. "Numéro Série", "Prix Vente HT", "Canal Acquisition")
- Le canal d'acquisition importé (libellé français ou code) est résolu vers le code attendu par la vue Clients (`BOUCHE_A_OREILLE`, etc.)
- Rapport détaillé par onglet (créés / mis à jour / erreurs avec numéro de ligne), une ligne invalide n'interrompt pas le reste de l'import
- Nouvelle page **Import** (chantier-ui, sous Paramétrage) : glisser-déposer, sélecteur de type pour le CSV, affichage du rapport, aide sur les colonnes attendues

Closes #433

## Test plan
- [x] `ImportResourceTest` (6 tests : xlsx multi-onglets avec liaison bateau→client, email client inconnu, CSV, mise à jour d'un client existant par email, formats non supportés) passent
- [x] `mvn -pl backend test` (suite complète) passe
- [x] `npm run build` sur `chantier-ui` passe
- [x] Vérifié manuellement en environnement de dev : import d'un classeur xlsx (Clients, Bateaux, Moteurs, Remorques) et d'un CSV clients via l'endpoint réel authentifié — clients/bateau/moteur/remorque correctement créés et liés par email, ré-import met bien à jour le client existant au lieu de dupliquer, canal d'acquisition correctement résolu. Données de test nettoyées après vérification.

## Note (hors périmètre de cette PR)
En testant manuellement, l'onglet **Produits** échoue en 500 sur cet environnement de dev local à cause d'une colonne `FRAIS` `NOT NULL` restée dans le fichier H2 local (`backend/data/moussaillon.mv.db`), alors que `ProduitCatalogueEntity` n'a plus ce champ. Ce n'est pas un bug introduit par cette PR : l'endpoint existant `POST /catalogue/produits` échoue de la même façon sur cette base. C'est une dérive du schéma local (stratégie `update` qui n'a jamais supprimé l'ancienne colonne), à traiter séparément (recréer la base de dev locale ou migrer la colonne).