### PR TITLE
Nettoyer les colonnes NOT NULL obsolètes de ProduitCatalogueEntity au démarrage

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/services/DataInitializer.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/DataInitializer.java
@@ -3,16 +3,34 @@ package net.nanthrax.moussaillon.services;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import net.nanthrax.moussaillon.persistence.ProduitCatalogueEntity;
 import net.nanthrax.moussaillon.persistence.ReferenceValeurEntity;
 import net.nanthrax.moussaillon.persistence.SocieteEntity;
 import net.nanthrax.moussaillon.persistence.UserEntity;
+import org.hibernate.Session;
+import org.jboss.logging.Logger;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 @ApplicationScoped
 public class DataInitializer {
 
+    private static final Logger LOG = Logger.getLogger(DataInitializer.class);
+
     @Transactional
     void onStart(@Observes StartupEvent event) {
+        repairLegacySchema();
+
         if (UserEntity.count() == 0) {
             UserEntity admin = new UserEntity();
             admin.name = "admin";
@@ -64,6 +82,54 @@ public class DataInitializer {
                 ordre += 10;
             }
         }
+    }
+
+    /**
+     * Certaines bases H2 locales/volumes persistants ont accumulé, au fil des refactors,
+     * des colonnes NOT NULL (ex. FRAIS, PRIXPUBLIC) qui n'existent plus sur ProduitCatalogueEntity.
+     * La stratégie de schéma "update" n'ajoute que les colonnes manquantes et ne supprime jamais
+     * les colonnes obsolètes, ce qui fait échouer toute création de produit (issue #439).
+     * On supprime ici toute colonne NOT NULL de la table qui ne correspond plus à un champ de
+     * l'entité. Ce nettoyage est un no-op sur une base à jour ou fraîchement créée.
+     */
+    private void repairLegacySchema() {
+        try {
+            dropOrphanNotNullColumns(ProduitCatalogueEntity.class, "ProduitCatalogueEntity");
+        } catch (Exception e) {
+            LOG.warn("Impossible de nettoyer les colonnes obsolètes de ProduitCatalogueEntity", e);
+        }
+    }
+
+    private void dropOrphanNotNullColumns(Class<?> entityClass, String tableName) {
+        Set<String> expectedColumns = new HashSet<>();
+        for (Field field : entityClass.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            expectedColumns.add(field.getName().toLowerCase(Locale.ROOT));
+        }
+
+        EntityManager em = ProduitCatalogueEntity.getEntityManager();
+        em.unwrap(Session.class).doWork(connection -> {
+            List<String> orphanColumns = new ArrayList<>();
+            try (Statement query = connection.createStatement();
+                 ResultSet rs = query.executeQuery(
+                     "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+                         + "WHERE TABLE_NAME = '" + tableName.toUpperCase(Locale.ROOT) + "' AND IS_NULLABLE = 'NO'")) {
+                while (rs.next()) {
+                    String columnName = rs.getString("COLUMN_NAME");
+                    if (!"ID".equals(columnName) && !expectedColumns.contains(columnName.toLowerCase(Locale.ROOT))) {
+                        orphanColumns.add(columnName);
+                    }
+                }
+            }
+            try (Statement alter = connection.createStatement()) {
+                for (String column : orphanColumns) {
+                    alter.executeUpdate("ALTER TABLE " + tableName + " DROP COLUMN IF EXISTS \"" + column + "\"");
+                    LOG.infof("Colonne obsolète supprimée sur %s : %s", tableName, column);
+                }
+            }
+        });
     }
 
 }


### PR DESCRIPTION
## Résumé
- La stratégie de schéma Hibernate `update` ajoute les colonnes manquantes mais ne supprime jamais celles devenues obsolètes après un refactor d'entité
- Sur les bases H2 locales/volumes persistants créés avant la suppression de champs comme `frais` ou `prixPublic` de `ProduitCatalogueEntity`, ces colonnes restent `NOT NULL` sans mapping Java et font échouer toute création de produit (`500`) — y compris via l'endpoint existant `POST /catalogue/produits`, indépendamment de toute autre PR
- Au démarrage (`DataInitializer`), on compare désormais les colonnes `NOT NULL` réellement présentes en base pour `ProduitCatalogueEntity` à celles attendues par l'entité (réflexion sur les champs déclarés), et on supprime les colonnes orphelines. No-op sur une base à jour ou fraîchement créée

Closes #439

## Test plan
- [x] `mvn -pl backend test` (suite complète) passe
- [x] Vérifié manuellement sur l'environnement de dev qui présentait le bug : `POST /catalogue/produits` passait de `500` (colonne `FRAIS` puis `PRIXPUBLIC` NOT NULL) à `200` après le fix, sans intervention manuelle sur le fichier `.mv.db`. Donnée de test nettoyée après vérification
- [ ] Pas de test automatisé ajouté pour cette migration précise : simuler une base "déjà dérivée" dans `@QuarkusTest` demanderait de pré-seeder le schéma avant l'initialisation Hibernate, ce qui n'est pas trivial avec le cycle de vie actuel des tests