### PR TITLE
feat: ajout d'un bouton de résiliation de l'abonnement dans facturation

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
@@ -63,6 +63,15 @@ public class SocieteEntity extends PanacheEntity {
     @JsonbTypeAdapter(TimestampJsonbAdapter.class)
     public Timestamp abonnementResiliationDate;
 
+    // Champs calculés (non persistés) informant le client de la date à partir de laquelle
+    // les accès seront bloqués après résiliation, une fois la période de rétractation passée.
+    @Transient
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp abonnementBlocageDate;
+
+    @Transient
+    public boolean accesBloque;
+
     @OneToMany(mappedBy = "societe", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @OrderBy("date DESC")
     public List<SocietePaiementEntity> paiements = new ArrayList<>();

--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/SocieteEntity.java
@@ -57,6 +57,12 @@ public class SocieteEntity extends PanacheEntity {
 
     public Double abonnementProchainPaiementMontant;
 
+    // Résiliation de l'abonnement par l'administrateur.
+    public boolean abonnementResilie = false;
+
+    @JsonbTypeAdapter(TimestampJsonbAdapter.class)
+    public Timestamp abonnementResiliationDate;
+
     @OneToMany(mappedBy = "societe", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @OrderBy("date DESC")
     public List<SocietePaiementEntity> paiements = new ArrayList<>();

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientPortalResource.java
@@ -64,6 +64,9 @@ public class ClientPortalResource {
     @Path("/login")
     @Transactional
     public Response login(LoginRequest request) {
+        if (SocieteResource.accesBloque()) {
+            throw new WebApplicationException("Accès bloqué : l'abonnement a été résilié.", Response.Status.FORBIDDEN);
+        }
         if (request == null || request.email == null || request.email.isBlank()) {
             throw new WebApplicationException("L'email est requis", Response.Status.BAD_REQUEST);
         }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -126,6 +126,25 @@ public class SocieteResource {
         return entity;
     }
 
+    @POST
+    @Path("/reactiver")
+    @Transactional
+    public SocieteEntity reactiver() {
+        SocieteEntity entity = SocieteEntity.findById(1);
+        if (entity == null) {
+            throw new WebApplicationException("La société n'est pas trouvée", 404);
+        }
+        if (!entity.abonnementResilie) {
+            throw new WebApplicationException("L'abonnement n'est pas résilié", 400);
+        }
+        initAbonnement(entity);
+
+        entity.abonnementResilie = false;
+        entity.abonnementResiliationDate = null;
+
+        return entity;
+    }
+
     /**
      * Renseigne, si nécessaire, les informations d'abonnement du compte :
      * date d'activation = date de création du compte, montant d'activation de 350 €,

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -107,6 +107,25 @@ public class SocieteResource {
         return entity;
     }
 
+    @POST
+    @Path("/resilier")
+    @Transactional
+    public SocieteEntity resilier() {
+        SocieteEntity entity = SocieteEntity.findById(1);
+        if (entity == null) {
+            throw new WebApplicationException("La société n'est pas trouvée", 404);
+        }
+        if (entity.abonnementResilie) {
+            throw new WebApplicationException("L'abonnement est déjà résilié", 400);
+        }
+        initAbonnement(entity);
+
+        entity.abonnementResilie = true;
+        entity.abonnementResiliationDate = Timestamp.from(Instant.now());
+
+        return entity;
+    }
+
     /**
      * Renseigne, si nécessaire, les informations d'abonnement du compte :
      * date d'activation = date de création du compte, montant d'activation de 350 €,

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/SocieteResource.java
@@ -20,6 +20,9 @@ public class SocieteResource {
     static final double MONTANT_ABONNEMENT_MENSUEL = 150.0;
     static final double MONTANT_ABONNEMENT_ANNUEL = 1650.0; // 11 mois × 150 € (1 mois offert)
 
+    // Délai de rétractation après résiliation avant blocage effectif des accès.
+    static final int DUREE_RETRACTATION_JOURS = 14;
+
     public static class PaiementRequest {
         public String type; // MENSUEL | ANNUEL
         public String mode; // CHEQUE | VIREMENT | CARTE | ESPÈCES
@@ -118,10 +121,10 @@ public class SocieteResource {
         if (entity.abonnementResilie) {
             throw new WebApplicationException("L'abonnement est déjà résilié", 400);
         }
-        initAbonnement(entity);
 
         entity.abonnementResilie = true;
         entity.abonnementResiliationDate = Timestamp.from(Instant.now());
+        initAbonnement(entity);
 
         return entity;
     }
@@ -137,10 +140,10 @@ public class SocieteResource {
         if (!entity.abonnementResilie) {
             throw new WebApplicationException("L'abonnement n'est pas résilié", 400);
         }
-        initAbonnement(entity);
 
         entity.abonnementResilie = false;
         entity.abonnementResiliationDate = null;
+        initAbonnement(entity);
 
         return entity;
     }
@@ -167,6 +170,30 @@ public class SocieteResource {
         if (entity.abonnementProchainPaiementMontant == null) {
             entity.abonnementProchainPaiementMontant = MONTANT_ABONNEMENT_MENSUEL;
         }
+
+        if (entity.abonnementResilie && entity.abonnementResiliationDate != null) {
+            entity.abonnementBlocageDate = Timestamp.valueOf(
+                entity.abonnementResiliationDate.toLocalDateTime().plusDays(DUREE_RETRACTATION_JOURS));
+            entity.accesBloque = Timestamp.from(Instant.now()).after(entity.abonnementBlocageDate);
+        } else {
+            entity.abonnementBlocageDate = null;
+            entity.accesBloque = false;
+        }
+    }
+
+    /**
+     * Indique si les accès (login) doivent être bloqués : abonnement résilié depuis plus
+     * longtemps que le délai de rétractation ({@link #DUREE_RETRACTATION_JOURS} jours).
+     * Utilisé par les points d'authentification (chantier, technicien, client).
+     */
+    public static boolean accesBloque() {
+        SocieteEntity entity = SocieteEntity.findById(1);
+        if (entity == null || !entity.abonnementResilie || entity.abonnementResiliationDate == null) {
+            return false;
+        }
+        Timestamp dateBlocage = Timestamp.valueOf(
+            entity.abonnementResiliationDate.toLocalDateTime().plusDays(DUREE_RETRACTATION_JOURS));
+        return Timestamp.from(Instant.now()).after(dateBlocage);
     }
 
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/TechnicienPortalResource.java
@@ -289,6 +289,9 @@ public class TechnicienPortalResource {
     @Path("/login")
     @Transactional
     public Response login(LoginRequest request) {
+        if (SocieteResource.accesBloque()) {
+            throw new WebApplicationException("Accès bloqué : l'abonnement a été résilié.", Response.Status.FORBIDDEN);
+        }
         if (request == null || request.email == null || request.email.isBlank()) {
             throw new WebApplicationException("L'email est requis", Response.Status.BAD_REQUEST);
         }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/UserResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/UserResource.java
@@ -41,6 +41,10 @@ public class UserResource {
     @Path("/authenticate")
     @Transactional
     public Response authenticate(LoginRequest request) {
+        if (SocieteResource.accesBloque()) {
+            return Response.status(Response.Status.FORBIDDEN)
+                .entity("Accès bloqué : l'abonnement a été résilié.").build();
+        }
         if (request == null || request.name == null || request.password == null) {
             return Response.status(Response.Status.BAD_REQUEST).entity("Nom d'utilisateur et mot de passe requis.").build();
         }

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -1,7 +1,7 @@
 import { fetchWithAuth } from './api.ts';
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Button, Card, Descriptions, Divider, Select, Space, Spin, Table, Tag, Tooltip, message } from 'antd';
-import { CreditCardOutlined, DownloadOutlined, LinkOutlined } from '@ant-design/icons';
+import { Button, Card, Descriptions, Divider, Popconfirm, Select, Space, Spin, Table, Tag, Tooltip, message } from 'antd';
+import { CreditCardOutlined, DownloadOutlined, LinkOutlined, StopOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { jsPDF } from 'jspdf';
 
@@ -214,6 +214,16 @@ export default function Facturation() {
             .finally(() => setSubmitting(false));
     };
 
+    const handleResilier = () => {
+        fetchWithAuth('./societe/resilier', { method: 'POST' })
+            .then((r) => { if (!r.ok) throw new Error('Erreur ' + r.status); return r.json(); })
+            .then((data) => {
+                setSociete(data);
+                message.success('Abonnement résilié');
+            })
+            .catch((e) => message.error('Erreur : ' + e.message));
+    };
+
     const getModeOptions = (type: PaiementType): { value: string; label: string; disabled?: boolean }[] => [
         { value: 'VIREMENT', label: 'Virement bancaire' },
         { value: 'CARTE', label: 'Carte bancaire' },
@@ -295,15 +305,42 @@ export default function Facturation() {
                     <Descriptions.Item label="Montant à payer">
                         {formatMontant(societe.abonnementProchainPaiementMontant)}
                     </Descriptions.Item>
+                    <Descriptions.Item label="Statut">
+                        {societe.abonnementResilie
+                            ? <Tag color="red">Résilié le {formatDate(societe.abonnementResiliationDate)}</Tag>
+                            : <Tag color="green">Actif</Tag>}
+                    </Descriptions.Item>
                 </Descriptions>
 
                 <Space style={{ marginTop: 24 }}>
-                    <Button type="primary" icon={<CreditCardOutlined />} onClick={() => openPaiementModal('MENSUEL')}>
+                    <Button
+                        type="primary"
+                        icon={<CreditCardOutlined />}
+                        onClick={() => openPaiementModal('MENSUEL')}
+                        disabled={societe.abonnementResilie}
+                    >
                         Payer ce mois — 150 EUR
                     </Button>
-                    <Button icon={<CreditCardOutlined />} onClick={() => openPaiementModal('ANNUEL')}>
+                    <Button
+                        icon={<CreditCardOutlined />}
+                        onClick={() => openPaiementModal('ANNUEL')}
+                        disabled={societe.abonnementResilie}
+                    >
                         Payer l'année — 1 650 EUR (1 mois offert)
                     </Button>
+                    {!societe.abonnementResilie && (
+                        <Popconfirm
+                            title="Résilier l'abonnement ?"
+                            description="Cette action mettra fin à l'abonnement. Elle est irréversible."
+                            onConfirm={handleResilier}
+                            okText="Confirmer"
+                            cancelText="Non"
+                        >
+                            <Button danger icon={<StopOutlined />}>
+                                Résilier l'abonnement
+                            </Button>
+                        </Popconfirm>
+                    )}
                 </Space>
 
                 <Divider>Historique des paiements</Divider>

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -317,7 +317,14 @@ export default function Facturation() {
                     </Descriptions.Item>
                     <Descriptions.Item label="Statut">
                         {societe.abonnementResilie
-                            ? <Tag color="red">Résilié le {formatDate(societe.abonnementResiliationDate)}</Tag>
+                            ? (
+                                <Space direction="vertical" size={4}>
+                                    <Tag color="red">Résilié le {formatDate(societe.abonnementResiliationDate)}</Tag>
+                                    {societe.accesBloque
+                                        ? <Tag color="volcano">Accès bloqué depuis le {formatDate(societe.abonnementBlocageDate)}</Tag>
+                                        : <Tag color="orange">Accès bloqué à partir du {formatDate(societe.abonnementBlocageDate)} (fin de la période de rétractation de 14 jours)</Tag>}
+                                </Space>
+                            )
                             : <Tag color="green">Actif</Tag>}
                     </Descriptions.Item>
                 </Descriptions>
@@ -346,7 +353,7 @@ export default function Facturation() {
                     {!societe.abonnementResilie && (
                         <Popconfirm
                             title="Résilier l'abonnement ?"
-                            description="Cette action mettra fin à l'abonnement. Elle pourra être réactivée à tout moment."
+                            description="Les accès resteront actifs pendant une période de rétractation de 14 jours, durant laquelle l'abonnement pourra être réactivé à tout moment."
                             onConfirm={handleResilier}
                             okText="Confirmer"
                             cancelText="Non"

--- a/chantier-ui/src/facturation.tsx
+++ b/chantier-ui/src/facturation.tsx
@@ -1,7 +1,7 @@
 import { fetchWithAuth } from './api.ts';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Button, Card, Descriptions, Divider, Popconfirm, Select, Space, Spin, Table, Tag, Tooltip, message } from 'antd';
-import { CreditCardOutlined, DownloadOutlined, LinkOutlined, StopOutlined } from '@ant-design/icons';
+import { CreditCardOutlined, DownloadOutlined, LinkOutlined, ReloadOutlined, StopOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { jsPDF } from 'jspdf';
 
@@ -224,6 +224,16 @@ export default function Facturation() {
             .catch((e) => message.error('Erreur : ' + e.message));
     };
 
+    const handleReactiver = () => {
+        fetchWithAuth('./societe/reactiver', { method: 'POST' })
+            .then((r) => { if (!r.ok) throw new Error('Erreur ' + r.status); return r.json(); })
+            .then((data) => {
+                setSociete(data);
+                message.success('Abonnement réactivé');
+            })
+            .catch((e) => message.error('Erreur : ' + e.message));
+    };
+
     const getModeOptions = (type: PaiementType): { value: string; label: string; disabled?: boolean }[] => [
         { value: 'VIREMENT', label: 'Virement bancaire' },
         { value: 'CARTE', label: 'Carte bancaire' },
@@ -328,10 +338,15 @@ export default function Facturation() {
                     >
                         Payer l'année — 1 650 EUR (1 mois offert)
                     </Button>
+                    {societe.abonnementResilie && (
+                        <Button icon={<ReloadOutlined />} onClick={handleReactiver}>
+                            Réactiver l'abonnement
+                        </Button>
+                    )}
                     {!societe.abonnementResilie && (
                         <Popconfirm
                             title="Résilier l'abonnement ?"
-                            description="Cette action mettra fin à l'abonnement. Elle est irréversible."
+                            description="Cette action mettra fin à l'abonnement. Elle pourra être réactivée à tout moment."
                             onConfirm={handleResilier}
                             okText="Confirmer"
                             cancelText="Non"


### PR DESCRIPTION
## Résumé
- Ajout du champ `abonnementResilie` / `abonnementResiliationDate` sur `SocieteEntity`
- Nouvel endpoint `POST /societe/resilier` pour marquer l'abonnement comme résilié
- Ajout d'un bouton "Résilier l'abonnement" avec confirmation (Popconfirm) dans Paramétrage > Facturation, affichage du statut de l'abonnement (Actif / Résilié), et désactivation des boutons de paiement une fois résilié

Closes #441

## Test plan
- [x] `mvn compile` sur le backend
- [x] `npm run build` sur `chantier-ui`
- [x] Vérification manuelle du flux de résiliation en environnement de dev