### PR TITLE
fix: sélection multiple de photos bateau perdue à l'upload (#458)

### DIFF
--- a/chantier-ui/src/ImageUpload.tsx
+++ b/chantier-ui/src/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Upload, message, Button, Input, Space } from 'antd';
 import { CloseOutlined, DeleteOutlined, InboxOutlined, LeftOutlined, LinkOutlined, RightOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
@@ -14,8 +14,14 @@ interface ImageUploadProps {
 const ImageUpload: React.FC<ImageUploadProps> = ({ value = [], onChange }) => {
     const [urlInput, setUrlInput] = useState('');
     const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+    // Uploading several files at once fires one customRequest per file concurrently;
+    // reading/writing through this ref (instead of the `value` closure) keeps concurrent
+    // completions from overwriting each other so every uploaded photo ends up in the list.
+    const valueRef = useRef(value);
+    useEffect(() => { valueRef.current = value; }, [value]);
 
     const triggerChange = (urls: string[]) => {
+        valueRef.current = urls;
         onChange?.(urls);
     };
 
@@ -29,7 +35,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ value = [], onChange }) => {
             });
             const urls: string[] = res.data;
             if (urls.length > 0) {
-                triggerChange([...value, ...urls]);
+                triggerChange([...valueRef.current, ...urls]);
             }
             onSuccess?.(res.data);
         } catch (err) {

--- a/client-ui/src/ImageUpload.tsx
+++ b/client-ui/src/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Upload, message, Button, Input, Space } from 'antd';
 import { CloseOutlined, DeleteOutlined, InboxOutlined, LeftOutlined, LinkOutlined, RightOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
@@ -14,8 +14,14 @@ interface ImageUploadProps {
 const ImageUpload: React.FC<ImageUploadProps> = ({ value = [], onChange }) => {
     const [urlInput, setUrlInput] = useState('');
     const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+    // Uploading several files at once fires one customRequest per file concurrently;
+    // reading/writing through this ref (instead of the `value` closure) keeps concurrent
+    // completions from overwriting each other so every uploaded photo ends up in the list.
+    const valueRef = useRef(value);
+    useEffect(() => { valueRef.current = value; }, [value]);
 
     const triggerChange = (urls: string[]) => {
+        valueRef.current = urls;
         onChange?.(urls);
     };
 
@@ -29,7 +35,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ value = [], onChange }) => {
             });
             const urls: string[] = res.data;
             if (urls.length > 0) {
-                triggerChange([...value, ...urls]);
+                triggerChange([...valueRef.current, ...urls]);
             }
             onSuccess?.(res.data);
         } catch (err) {

--- a/technicien-ui/src/ImageUpload.tsx
+++ b/technicien-ui/src/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Upload, message, Button, Input, Space } from 'antd';
 import { CloseOutlined, InboxOutlined, LeftOutlined, LinkOutlined, RightOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
@@ -14,8 +14,14 @@ interface ImageUploadProps {
 const ImageUpload: React.FC<ImageUploadProps> = ({ value = [], onChange }) => {
     const [urlInput, setUrlInput] = useState('');
     const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+    // Uploading several files at once fires one customRequest per file concurrently;
+    // reading/writing through this ref (instead of the `value` closure) keeps concurrent
+    // completions from overwriting each other so every uploaded photo ends up in the list.
+    const valueRef = useRef(value);
+    useEffect(() => { valueRef.current = value; }, [value]);
 
     const triggerChange = (urls: string[]) => {
+        valueRef.current = urls;
         onChange?.(urls);
     };
 
@@ -29,7 +35,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ value = [], onChange }) => {
             });
             const urls: string[] = res.data;
             if (urls.length > 0) {
-                triggerChange([...value, ...urls]);
+                triggerChange([...valueRef.current, ...urls]);
             }
             onSuccess?.(res.data);
         } catch (err) {


### PR DESCRIPTION
## Résumé
- `ImageUpload` (chantier-ui, client-ui, technicien-ui) déclenche un `customRequest` par fichier sélectionné. Avec un upload multiple, ces requêtes s'exécutent en parallèle et chacune calculait `[...value, ...urls]` à partir du même tableau `value` figé par closure au moment du rendu : seule la dernière réponse à se résoudre l'emportait, écrasant les photos uploadées en parallèle
- Ajoute une ref (`valueRef`) tenue synchronisée avec la prop `value`, utilisée en lecture/écriture dans `handleUpload` à la place du closure, pour que chaque upload fusionne sur le résultat le plus récent au lieu de l'état initial
- Appliqué identiquement aux 3 copies du composant

Closes #458

## Test plan
- [x] Simulé un dépôt de 2 fichiers en une seule sélection sur `ImageUpload` (chantier-ui) : les 2 requêtes `POST /images` aboutissent et les 2 photos apparaissent dans la galerie (avant le fix, un seul survivait)
- [x] Vérifier manuellement la sélection multiple via le sélecteur de fichiers natif (drag & drop et clic) sur chantier-ui, client-ui et technicien-ui — testé en local sur chantier-ui (fiche produit) et client-ui (fiche bateau "BOB") en déclenchant un véritable évènement `change` sur l'`<input type="file" multiple>` avec 2 fichiers réels (DataTransfer + File), sans passer par le code applicatif : sur les deux, les 2 requêtes `POST /api/images` concurrentes aboutissent (200) et les 2 photos apparaissent dans la galerie. Code de `technicien-ui/src/ImageUpload.tsx` identique aux deux autres copies (diff vérifié), non testé en direct faute d'accès UI pratique en local pour ce module.