### PR TITLE
fix: afficher la référence fournisseur dans la saisie de commande (#456)

### DIFF
--- a/chantier-ui/src/commandes-fournisseur.tsx
+++ b/chantier-ui/src/commandes-fournisseur.tsx
@@ -65,6 +65,7 @@ type Helice = {
 type FournisseurProduit = {
   id: number;
   produit: Produit;
+  reference?: string;
   prixAchatHT: number;
   tva: number;
   montantTVA: number;
@@ -102,6 +103,7 @@ type ArticleItem = {
   type: ArticleType;
   id: number;
   label: string;
+  reference?: string;
   prixAchatHT: number;
   tva: number;
 };
@@ -211,7 +213,8 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
           key: `produit-${fp.produit.id}`,
           type: "produit" as ArticleType,
           id: fp.produit.id,
-          label: `${fp.produit.nom}${fp.produit.marque ? ` (${fp.produit.marque})` : ""}`,
+          label: `${fp.produit.nom}${fp.produit.marque ? ` (${fp.produit.marque})` : ""}${fp.reference ? ` — Réf: ${fp.reference}` : ""}`,
+          reference: fp.reference,
           prixAchatHT: fp.prixAchatHT,
           tva: fp.tva,
         })),
@@ -680,9 +683,11 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
 
           <Divider orientation="left">Lignes de commande</Divider>
 
-          {lignes.map((ligne, index) => (
+          {lignes.map((ligne, index) => {
+            const selectedArticle = articles.find((a) => a.key === ligne.articleKey);
+            return (
             <Row gutter={8} key={index} align="middle" style={{ marginBottom: 8 }}>
-              <Col span={8}>
+              <Col span={7}>
                 <Select
                   showSearch
                   placeholder="Article"
@@ -696,6 +701,13 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
                     { label: "Moteurs", options: articles.filter((a) => a.type === "moteur").map((a) => ({ value: a.key, label: a.label })) },
                     { label: "Hélices", options: articles.filter((a) => a.type === "helice").map((a) => ({ value: a.key, label: a.label })) },
                   ].filter((g) => g.options.length > 0)}
+                />
+              </Col>
+              <Col span={3}>
+                <Input
+                  placeholder="Réf. fournisseur"
+                  value={selectedArticle?.reference || ""}
+                  disabled
                 />
               </Col>
               <Col span={3}>
@@ -717,7 +729,7 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
                   addonAfter="€"
                 />
               </Col>
-              <Col span={3}>
+              <Col span={2}>
                 <InputNumber
                   min={0}
                   max={100}
@@ -728,7 +740,7 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
                   addonAfter="%"
                 />
               </Col>
-              <Col span={4}>
+              <Col span={3}>
                 <InputNumber
                   value={ligne.prixTotalTTC}
                   disabled
@@ -745,7 +757,8 @@ const CommandesFournisseur = ({ fournisseurId }: { fournisseurId?: number }) => 
                 />
               </Col>
             </Row>
-          ))}
+            );
+          })}
 
 
           <Divider orientation="left">Totaux</Divider>

--- a/chantier-ui/src/fournisseur-produits.tsx
+++ b/chantier-ui/src/fournisseur-produits.tsx
@@ -84,7 +84,7 @@ type FournisseurProduit = {
   tauxMarge?: number;
   tauxMarque?: number;
   delaiLivraison?: string;
-  referenceFournisseur?: string;
+  reference?: string;
   notes?: string;
 };
 
@@ -99,7 +99,7 @@ const defaultFournisseurProduit: Partial<FournisseurProduit> = {
   tauxMarge: 0,
   tauxMarque: 0,
   delaiLivraison: "",
-  referenceFournisseur: "",
+  reference: "",
   notes: "",
 };
 
@@ -394,6 +394,7 @@ const FournisseurProduits = ({
             ),
           },
         ]),
+    { title: "Référence fournisseur", dataIndex: "reference", key: "reference", sorter: (a, b) => (a.reference || "").localeCompare(b.reference || ""), render: (v: string) => v || "-" },
     { title: "Prix Achat HT", dataIndex: "prixAchatHT", key: "prixAchatHT", sorter: (a, b) => a.prixAchatHT - b.prixAchatHT },
     { title: "TVA (%)", dataIndex: "tva", key: "tva", sorter: (a, b) => (a.tva ?? 0) - (b.tva ?? 0) },
     { title: "Montant TVA", dataIndex: "montantTVA", key: "montantTVA", sorter: (a, b) => (a.montantTVA ?? 0) - (b.montantTVA ?? 0) },
@@ -613,7 +614,7 @@ const FournisseurProduits = ({
           <Form.Item label="Délai de livraison" name="delaiLivraison">
             <Input />
           </Form.Item>
-          <Form.Item label="Référence Fournisseur" name="referenceFournisseur">
+          <Form.Item label="Référence Fournisseur" name="reference">
             <Input />
           </Form.Item>
           <Form.Item label="Notes" name="notes">


### PR DESCRIPTION
## Résumé
- **Bug corrigé** : le formulaire d'association fournisseur/produit (`fournisseur-produits.tsx`) envoyait un champ `referenceFournisseur`, alors que le backend (`FournisseurProduitEntity.reference`) attend `reference`. La référence saisie était donc toujours silencieusement perdue à l'enregistrement. Ajout aussi de la colonne "Référence fournisseur" dans le tableau des associations pour la rendre visible.
- **Fix de l'issue** : cette référence est maintenant surfacée dans la saisie de commande fournisseur (`commandes-fournisseur.tsx`) :
  - visible et recherchable directement dans le select d'article (`Produit1 (Marque) — Réf: XXX`)
  - affichée dans une case dédiée en lecture seule sur la ligne de commande dès qu'un article est sélectionné, pour éviter toute recherche ailleurs

Aucun changement backend nécessaire (le champ `reference` existait déjà sur `FournisseurProduitEntity`).

Closes #456

## Test plan
- [x] Éditer une association fournisseur/produit, saisir une référence fournisseur, enregistrer → vérifié via l'API que `reference` est bien persistée (avant le fix : toujours vide)
- [x] La colonne "Référence fournisseur" du tableau des associations affiche la valeur
- [x] Dans "Nouvelle commande fournisseur", sélectionner le fournisseur puis un article → le select affiche la référence dans le libellé, et la case "Réf. fournisseur" de la ligne se remplit automatiquement sans recherche supplémentaire