### PR TITLE
Ligne de séparation visuelle entre techniciens sur le planning

### DIFF
--- a/chantier-ui/src/planning.tsx
+++ b/chantier-ui/src/planning.tsx
@@ -123,6 +123,8 @@ interface CalendarEvent {
     forfaitServiceNom?: string;
     status?: PlanningStatus;
     progressPct?: number;
+    technicienId?: number;
+    technicienNom?: string;
 }
 
 interface PlanningItemRow {
@@ -533,6 +535,7 @@ export default function Planning() {
                     const totalTaches = taches.length;
                     const doneTaches = taches.filter((t) => t.done).length;
                     const progressPct = totalTaches > 0 ? Math.round((doneTaches / totalTaches) * 100) : undefined;
+                    const technicien = item.techniciens?.[0];
 
                     return {
                         eventId: row.key,
@@ -548,6 +551,8 @@ export default function Planning() {
                         forfaitServiceNom: item.nom,
                         status: item.status,
                         progressPct,
+                        technicienId: technicien?.id,
+                        technicienNom: `${technicien?.prenom || ''} ${technicien?.nom || ''}`.trim() || undefined,
                     } as CalendarEvent;
                 })
                 .filter(Boolean) as CalendarEvent[],
@@ -1084,7 +1089,16 @@ export default function Planning() {
                                     const dayStr = day.format('YYYY-MM-DD');
                                     const isToday = dayStr === todayIso();
                                     const isSelected = dayStr === selectedDate;
-                                    const dayEvts = weekEvents.filter((ev) => dayjs(ev.startTime).format('YYYY-MM-DD') === dayStr);
+                                    // Regroupe les événements par technicien (puis par heure de début) afin de
+                                    // pouvoir afficher une ligne de séparation visuelle entre les techniciens.
+                                    const dayEvts = weekEvents
+                                        .filter((ev) => dayjs(ev.startTime).format('YYYY-MM-DD') === dayStr)
+                                        .sort((a, b) => {
+                                            const ta = a.technicienId ?? Number.MAX_SAFE_INTEGER;
+                                            const tb = b.technicienId ?? Number.MAX_SAFE_INTEGER;
+                                            if (ta !== tb) return ta - tb;
+                                            return dayjs(a.startTime).valueOf() - dayjs(b.startTime).valueOf();
+                                        });
 
                                     return (
                                         <React.Fragment key={dayStr}>
@@ -1163,6 +1177,7 @@ export default function Planning() {
                                                         <div style={{ fontSize: 12, lineHeight: '18px' }}>
                                                             <div><strong>{ev.bateauNom || '-'}</strong>{ev.bateauImmatriculation ? ` (${ev.bateauImmatriculation})` : ''}</div>
                                                             <div>Client : {ev.clientNom || '-'}</div>
+                                                            <div>Technicien : {ev.technicienNom || '-'}</div>
                                                             <div>{ev.forfaitServiceNom || '-'}</div>
                                                             <div>Statut : {statusLabel} {ev.progressPct !== undefined ? `— ${ev.progressPct}%` : ''}</div>
                                                             <div>{start.format('HH:mm')} — {duration}h</div>
@@ -1170,8 +1185,27 @@ export default function Planning() {
                                                     );
 
                                                     const eventRow = allItems.find((r) => r.key === ev.eventId);
+                                                    const previousEv = idx > 0 ? dayEvts[idx - 1] : null;
+                                                    // Ligne de séparation visuelle entre deux groupes de techniciens
+                                                    // différents pour améliorer la lisibilité du planning.
+                                                    const showTechnicienSeparator = !!previousEv && previousEv.technicienId !== ev.technicienId;
                                                     return (
-                                                        <Tooltip key={ev.eventId} title={tooltipContent}>
+                                                        <React.Fragment key={ev.eventId}>
+                                                            {showTechnicienSeparator && (
+                                                                <div
+                                                                    style={{
+                                                                        position: 'absolute',
+                                                                        top: 4 + idx * 28 - 3,
+                                                                        left: 0,
+                                                                        right: 0,
+                                                                        height: 2,
+                                                                        background: '#bfbfbf',
+                                                                        zIndex: 1,
+                                                                        pointerEvents: 'none',
+                                                                    }}
+                                                                />
+                                                            )}
+                                                            <Tooltip title={tooltipContent}>
                                                             <div
                                                                 draggable={!!eventRow && resize?.key !== ev.eventId}
                                                                 onDragStart={(e) => {
@@ -1254,7 +1288,8 @@ export default function Planning() {
                                                                     />
                                                                 )}
                                                             </div>
-                                                        </Tooltip>
+                                                            </Tooltip>
+                                                        </React.Fragment>
                                                     );
                                                 })}
                                             </div>


### PR DESCRIPTION
## Résumé
- Les interventions du planning hebdomadaire sont désormais regroupées par technicien (tri par technicien puis par heure de début) au lieu d'être empilées dans un ordre arbitraire.
- Une ligne de séparation visuelle s'affiche entre deux groupes de techniciens différents pour améliorer la lisibilité.
- Ajout du nom du technicien dans le tooltip de chaque intervention.

Closes #446

## Test plan
- [x] Vérifier que le tooltip affiche bien le nom du technicien (testé en local : tooltip affiche "Technicien : Noah Onofre")
- [x] Vérifier qu'une journée avec un seul technicien n'affiche aucune ligne de séparation (testé en local : journée avec 1 seule intervention, aucune ligne affichée)
- [x] Vérifier que le tri par technicien puis par heure de début fonctionne correctement (revue de code : `planning.tsx`, tri stable sur `technicienId` puis `startTime`)
- [x] Vérifier sur le planning hebdomadaire qu'une journée avec plusieurs techniciens affiche bien une ligne de séparation entre les groupes (revue de code : la ligne s'affiche dès que `previousEv.technicienId !== ev.technicienId`, logique correcte par construction ; non reproduit en direct faute de deuxième technicien avec intervention planifiée le même jour dans les données de test locales)