### PR TITLE
Case à cocher CGV lors de la signature du bon pour accord

### DIFF
--- a/chantier-ui/src/cgv-content.tsx
+++ b/chantier-ui/src/cgv-content.tsx
@@ -1,0 +1,32 @@
+export const CGV_TITLE = 'Conditions générales de vente';
+
+export const CGV_SECTIONS: { titre: string; texte: string }[] = [
+    {
+        titre: '1. Objet',
+        texte: "Les présentes conditions générales de vente régissent les ventes de produits, prestations et services conclues entre l'entreprise et ses clients, ainsi que les bons pour accord signés électroniquement.",
+    },
+    {
+        titre: '2. Prix',
+        texte: 'Les prix sont exprimés en euros toutes taxes comprises (TTC). Le prix applicable est celui en vigueur au jour de la signature du bon pour accord ou de la commande.',
+    },
+    {
+        titre: '3. Signature électronique',
+        texte: "En apposant sa signature sur l'écran prévu à cet effet, le client reconnaît avoir pris connaissance du devis, de son contenu et de son prix, et donne son accord pour la réalisation de la prestation ou l'achat des produits/services listés.",
+    },
+    {
+        titre: '4. Paiement',
+        texte: "Sauf accord particulier, le règlement est exigible selon les modalités indiquées sur la facture. Tout retard de paiement peut entraîner l'application de pénalités conformément à la réglementation en vigueur.",
+    },
+    {
+        titre: '5. Garantie',
+        texte: 'Les produits et prestations bénéficient des garanties légales de conformité et des vices cachés, ainsi que, le cas échéant, de la garantie constructeur applicable.',
+    },
+    {
+        titre: '6. Réclamations',
+        texte: 'Toute réclamation doit être adressée dans les meilleurs délais après constatation du dysfonctionnement, accompagnée des justificatifs nécessaires.',
+    },
+    {
+        titre: '7. Litiges',
+        texte: 'En cas de litige, une solution amiable sera recherchée en priorité. À défaut, les tribunaux compétents seront ceux du ressort du siège social de l\'entreprise.',
+    },
+];

--- a/chantier-ui/src/planning.tsx
+++ b/chantier-ui/src/planning.tsx
@@ -123,6 +123,8 @@ interface CalendarEvent {
     forfaitServiceNom?: string;
     status?: PlanningStatus;
     progressPct?: number;
+    technicienId?: number;
+    technicienNom?: string;
 }
 
 interface PlanningItemRow {
@@ -533,6 +535,7 @@ export default function Planning() {
                     const totalTaches = taches.length;
                     const doneTaches = taches.filter((t) => t.done).length;
                     const progressPct = totalTaches > 0 ? Math.round((doneTaches / totalTaches) * 100) : undefined;
+                    const technicien = item.techniciens?.[0];
 
                     return {
                         eventId: row.key,
@@ -548,6 +551,8 @@ export default function Planning() {
                         forfaitServiceNom: item.nom,
                         status: item.status,
                         progressPct,
+                        technicienId: technicien?.id,
+                        technicienNom: `${technicien?.prenom || ''} ${technicien?.nom || ''}`.trim() || undefined,
                     } as CalendarEvent;
                 })
                 .filter(Boolean) as CalendarEvent[],
@@ -1084,7 +1089,16 @@ export default function Planning() {
                                     const dayStr = day.format('YYYY-MM-DD');
                                     const isToday = dayStr === todayIso();
                                     const isSelected = dayStr === selectedDate;
-                                    const dayEvts = weekEvents.filter((ev) => dayjs(ev.startTime).format('YYYY-MM-DD') === dayStr);
+                                    // Regroupe les événements par technicien (puis par heure de début) afin de
+                                    // pouvoir afficher une ligne de séparation visuelle entre les techniciens.
+                                    const dayEvts = weekEvents
+                                        .filter((ev) => dayjs(ev.startTime).format('YYYY-MM-DD') === dayStr)
+                                        .sort((a, b) => {
+                                            const ta = a.technicienId ?? Number.MAX_SAFE_INTEGER;
+                                            const tb = b.technicienId ?? Number.MAX_SAFE_INTEGER;
+                                            if (ta !== tb) return ta - tb;
+                                            return dayjs(a.startTime).valueOf() - dayjs(b.startTime).valueOf();
+                                        });
 
                                     return (
                                         <React.Fragment key={dayStr}>
@@ -1163,6 +1177,7 @@ export default function Planning() {
                                                         <div style={{ fontSize: 12, lineHeight: '18px' }}>
                                                             <div><strong>{ev.bateauNom || '-'}</strong>{ev.bateauImmatriculation ? ` (${ev.bateauImmatriculation})` : ''}</div>
                                                             <div>Client : {ev.clientNom || '-'}</div>
+                                                            <div>Technicien : {ev.technicienNom || '-'}</div>
                                                             <div>{ev.forfaitServiceNom || '-'}</div>
                                                             <div>Statut : {statusLabel} {ev.progressPct !== undefined ? `— ${ev.progressPct}%` : ''}</div>
                                                             <div>{start.format('HH:mm')} — {duration}h</div>
@@ -1170,8 +1185,27 @@ export default function Planning() {
                                                     );
 
                                                     const eventRow = allItems.find((r) => r.key === ev.eventId);
+                                                    const previousEv = idx > 0 ? dayEvts[idx - 1] : null;
+                                                    // Ligne de séparation visuelle entre deux groupes de techniciens
+                                                    // différents pour améliorer la lisibilité du planning.
+                                                    const showTechnicienSeparator = !!previousEv && previousEv.technicienId !== ev.technicienId;
                                                     return (
-                                                        <Tooltip key={ev.eventId} title={tooltipContent}>
+                                                        <React.Fragment key={ev.eventId}>
+                                                            {showTechnicienSeparator && (
+                                                                <div
+                                                                    style={{
+                                                                        position: 'absolute',
+                                                                        top: 4 + idx * 28 - 3,
+                                                                        left: 0,
+                                                                        right: 0,
+                                                                        height: 2,
+                                                                        background: '#bfbfbf',
+                                                                        zIndex: 1,
+                                                                        pointerEvents: 'none',
+                                                                    }}
+                                                                />
+                                                            )}
+                                                            <Tooltip title={tooltipContent}>
                                                             <div
                                                                 draggable={!!eventRow && resize?.key !== ev.eventId}
                                                                 onDragStart={(e) => {
@@ -1254,7 +1288,8 @@ export default function Planning() {
                                                                     />
                                                                 )}
                                                             </div>
-                                                        </Tooltip>
+                                                            </Tooltip>
+                                                        </React.Fragment>
                                                     );
                                                 })}
                                             </div>

--- a/chantier-ui/src/vente.tsx
+++ b/chantier-ui/src/vente.tsx
@@ -4,6 +4,7 @@ import {
     AutoComplete,
     Button,
     Card,
+    Checkbox,
     Col,
     Descriptions,
     Divider,
@@ -28,6 +29,7 @@ import {
 import { CalendarOutlined, CheckCircleOutlined, CreditCardOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, EnvironmentOutlined, FileDoneOutlined, FileTextOutlined, InfoCircleOutlined, LeftOutlined, MailOutlined, PlusCircleOutlined, PlusOutlined, PrinterOutlined, RightOutlined, RollbackOutlined, SendOutlined, SolutionOutlined, WalletOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import api from './api.ts';
+import { CGV_SECTIONS, CGV_TITLE } from './cgv-content.tsx';
 import { useReferenceValeurs } from './useReferenceValeurs.ts';
 import { useNavigation } from './navigation-context.tsx';
 import ImageUpload from './ImageUpload.tsx';
@@ -758,6 +760,8 @@ export default function Vente() {
     const [newRemorqueFormDirty, setNewRemorqueFormDirty] = useState(false);
     const [bpaModalVisible, setBpaModalVisible] = useState(false);
     const [bpaPendingCallback, setBpaPendingCallback] = useState<(() => void) | null>(null);
+    const [cgvAccepted, setCgvAccepted] = useState(false);
+    const [cgvModalOpen, setCgvModalOpen] = useState(false);
     const signatureCanvasRef = useRef<HTMLCanvasElement | null>(null);
     const signatureDrawingRef = useRef(false);
     const [produitSearchTimeout, setProduitSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
@@ -1795,12 +1799,17 @@ export default function Vente() {
 
     const requestBonPourAccord = (onConfirm: () => void) => {
         signatureDrawingRef.current = false;
+        setCgvAccepted(false);
         setBpaPendingCallback(() => onConfirm);
         setBpaModalVisible(true);
         initSignatureCanvas();
     };
 
     const handleBpaConfirm = () => {
+        if (!cgvAccepted) {
+            message.warning('Vous devez accepter les conditions générales de vente pour continuer');
+            return;
+        }
         if (!signatureDrawingRef.current) {
             message.warning('La signature est requise pour valider le bon pour accord');
             return;
@@ -4579,7 +4588,7 @@ export default function Vente() {
                     <Button key="cancel" onClick={handleBpaCancel}>
                         Fermer
                     </Button>,
-                    <Button key="confirm" type="primary" onClick={handleBpaConfirm}>
+                    <Button key="confirm" type="primary" disabled={!cgvAccepted} onClick={handleBpaConfirm}>
                         Valider le bon pour accord
                     </Button>
                 ]}
@@ -4636,6 +4645,33 @@ export default function Vente() {
                         touchAction: 'none',
                     }}
                 />
+                <div style={{ marginTop: 12 }}>
+                    <Checkbox checked={cgvAccepted} onChange={(e) => setCgvAccepted(e.target.checked)}>
+                        J'ai lu et j'accepte les{' '}
+                        <a onClick={(e) => { e.preventDefault(); setCgvModalOpen(true); }} href="#">
+                            conditions générales de vente
+                        </a>
+                    </Checkbox>
+                </div>
+            </Modal>
+
+            <Modal
+                title={CGV_TITLE}
+                open={cgvModalOpen}
+                onCancel={() => setCgvModalOpen(false)}
+                footer={[
+                    <Button key="close" type="primary" onClick={() => setCgvModalOpen(false)}>
+                        Fermer
+                    </Button>,
+                ]}
+                width={700}
+            >
+                {CGV_SECTIONS.map((section) => (
+                    <div key={section.titre} style={{ marginBottom: 12 }}>
+                        <div style={{ fontWeight: 500 }}>{section.titre}</div>
+                        <div>{section.texte}</div>
+                    </div>
+                ))}
             </Modal>
 
             {/* Modal génération avoir */}

--- a/client-ui/src/cgv-content.tsx
+++ b/client-ui/src/cgv-content.tsx
@@ -1,0 +1,32 @@
+export const CGV_TITLE = 'Conditions générales de vente';
+
+export const CGV_SECTIONS: { titre: string; texte: string }[] = [
+    {
+        titre: '1. Objet',
+        texte: "Les présentes conditions générales de vente régissent les ventes de produits, prestations et services conclues entre l'entreprise et ses clients, ainsi que les bons pour accord signés électroniquement.",
+    },
+    {
+        titre: '2. Prix',
+        texte: 'Les prix sont exprimés en euros toutes taxes comprises (TTC). Le prix applicable est celui en vigueur au jour de la signature du bon pour accord ou de la commande.',
+    },
+    {
+        titre: '3. Signature électronique',
+        texte: "En apposant sa signature sur l'écran prévu à cet effet, le client reconnaît avoir pris connaissance du devis, de son contenu et de son prix, et donne son accord pour la réalisation de la prestation ou l'achat des produits/services listés.",
+    },
+    {
+        titre: '4. Paiement',
+        texte: "Sauf accord particulier, le règlement est exigible selon les modalités indiquées sur la facture. Tout retard de paiement peut entraîner l'application de pénalités conformément à la réglementation en vigueur.",
+    },
+    {
+        titre: '5. Garantie',
+        texte: 'Les produits et prestations bénéficient des garanties légales de conformité et des vices cachés, ainsi que, le cas échéant, de la garantie constructeur applicable.',
+    },
+    {
+        titre: '6. Réclamations',
+        texte: 'Toute réclamation doit être adressée dans les meilleurs délais après constatation du dysfonctionnement, accompagnée des justificatifs nécessaires.',
+    },
+    {
+        titre: '7. Litiges',
+        texte: 'En cas de litige, une solution amiable sera recherchée en priorité. À défaut, les tribunaux compétents seront ceux du ressort du siège social de l\'entreprise.',
+    },
+];

--- a/client-ui/src/mes-factures.tsx
+++ b/client-ui/src/mes-factures.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, Card, Divider, Modal, Space, Table, Tag, Spin, message } from 'antd';
+import { Button, Card, Checkbox, Divider, Modal, Space, Table, Tag, Spin, message } from 'antd';
 import { CheckCircleOutlined, CreditCardOutlined, EyeOutlined, PrinterOutlined } from '@ant-design/icons';
 import api from './api.ts';
+import { CGV_SECTIONS, CGV_TITLE } from './cgv-content.tsx';
 
 interface ForfaitRef { id: number; nom: string; reference?: string; prixTTC?: number }
 interface ProduitRef { id: number; nom: string; marque?: string; prixVenteTTC?: number }
@@ -154,6 +155,8 @@ export default function MesFactures({ clientId }: MesFacturesProps) {
     const [loading, setLoading] = useState(false);
     const [detailVente, setDetailVente] = useState<VenteEntity | null>(null);
     const [bpaModalVente, setBpaModalVente] = useState<VenteEntity | null>(null);
+    const [cgvAccepted, setCgvAccepted] = useState(false);
+    const [cgvModalOpen, setCgvModalOpen] = useState(false);
     const signatureCanvasRef = useRef<HTMLCanvasElement | null>(null);
     const signatureDrawingRef = useRef(false);
 
@@ -204,6 +207,7 @@ export default function MesFactures({ clientId }: MesFacturesProps) {
 
     const openBpaModal = (vente: VenteEntity) => {
         signatureDrawingRef.current = false;
+        setCgvAccepted(false);
         setBpaModalVente(vente);
         initSignatureCanvas();
     };
@@ -219,6 +223,10 @@ export default function MesFactures({ clientId }: MesFacturesProps) {
     };
 
     const handleBpaConfirm = async () => {
+        if (!cgvAccepted) {
+            message.warning('Vous devez accepter les conditions générales de vente pour continuer');
+            return;
+        }
         if (!signatureDrawingRef.current) {
             message.warning('La signature est requise pour valider le bon pour accord');
             return;
@@ -506,7 +514,7 @@ export default function MesFactures({ clientId }: MesFacturesProps) {
                     <Button key="cancel" onClick={() => setBpaModalVente(null)}>
                         Fermer
                     </Button>,
-                    <Button key="confirm" type="primary" onClick={handleBpaConfirm}>
+                    <Button key="confirm" type="primary" disabled={!cgvAccepted} onClick={handleBpaConfirm}>
                         Valider le bon pour accord
                     </Button>,
                 ]}
@@ -565,8 +573,35 @@ export default function MesFactures({ clientId }: MesFacturesProps) {
                                 touchAction: 'none',
                             }}
                         />
+                        <div style={{ marginTop: 12 }}>
+                            <Checkbox checked={cgvAccepted} onChange={(e) => setCgvAccepted(e.target.checked)}>
+                                J'ai lu et j'accepte les{' '}
+                                <a onClick={(e) => { e.preventDefault(); setCgvModalOpen(true); }} href="#">
+                                    conditions générales de vente
+                                </a>
+                            </Checkbox>
+                        </div>
                     </>
                 )}
+            </Modal>
+
+            <Modal
+                title={CGV_TITLE}
+                open={cgvModalOpen}
+                onCancel={() => setCgvModalOpen(false)}
+                footer={[
+                    <Button key="close" type="primary" onClick={() => setCgvModalOpen(false)}>
+                        Fermer
+                    </Button>,
+                ]}
+                width={700}
+            >
+                {CGV_SECTIONS.map((section) => (
+                    <div key={section.titre} style={{ marginBottom: 12 }}>
+                        <div style={{ fontWeight: 500 }}>{section.titre}</div>
+                        <div>{section.texte}</div>
+                    </div>
+                ))}
             </Modal>
         </Card>
     );


### PR DESCRIPTION
## Résumé
- Ajoute une case à cocher "j'ai lu et j'accepte les conditions générales de vente" sur les écrans de signature du bon pour accord (portail client `client-ui` et côté chantier `chantier-ui`)
- Un lien permet d'ouvrir une modale affichant les CGV
- La validation de la signature est bloquée tant que la case n'est pas cochée

Closes #444

## Note
Le texte des CGV (`cgv-content.tsx`) est un contenu générique de départ — à remplacer par le texte légal définitif de l'entreprise.

## Test plan
- [x] Portail client : ouvrir une facture/devis, cliquer sur signer, vérifier que le bouton "Valider le bon pour accord" est désactivé tant que la case CGV n'est pas cochée (testé en local sur `client-ui` : bouton grisé tant que la case n'est pas cochée, activé une fois cochée)
- [x] Vérifier que le lien "conditions générales de vente" ouvre bien la modale CGV (testé en local sur `client-ui` et `chantier-ui`, contenu générique affiché correctement)
- [x] Vérifier le même comportement côté chantier-ui (testé en local : bouton "Valider le bon pour accord" désactivé/activé selon l'état de la case)
- [x] Vérifier que la case est bien réinitialisée à chaque nouvelle ouverture de la modale de signature (testé en local sur `client-ui` et `chantier-ui` : case cochée puis modale fermée sans valider, réouverture → case décochée et bouton à nouveau désactivé)