### PR TITLE
feat: chatbot IA en widget flottant contextuel sur toutes les pages

### DIFF
--- a/chantier-ui/src/dashboard.tsx
+++ b/chantier-ui/src/dashboard.tsx
@@ -1,11 +1,10 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useCallback, useEffect, useState } from 'react';
-import { ArrowDownOutlined, ArrowUpOutlined, ClockCircleOutlined, WarningOutlined, AimOutlined, PlusOutlined, CalendarOutlined, ReloadOutlined, RobotOutlined, DownOutlined, UpOutlined } from '@ant-design/icons';
+import { ArrowDownOutlined, ArrowUpOutlined, ClockCircleOutlined, WarningOutlined, AimOutlined, PlusOutlined, CalendarOutlined, ReloadOutlined } from '@ant-design/icons';
 import { Alert, Badge, Button, Card, Col, Empty, List, Progress, Row, Space, Spin, Statistic, Table, Tag, Typography } from 'antd';
 import { Column, Pie } from '@ant-design/charts';
 import dayjs from 'dayjs';
 import { useNavigation } from './navigation-context.tsx';
-import Home from './home.tsx';
 import { VERSION_LABEL } from './version.ts';
 
 const { Title, Paragraph, Text } = Typography;
@@ -216,7 +215,6 @@ export default function Dashboard({ user }: { user?: string }) {
     const [canalData, setCanalData] = useState<{ canal: string; count: number }[]>([]);
     const [ventesParJour, setVentesParJour] = useState<{ date: string; ventes: number }[]>([]);
     const [caParJour, setCaParJour] = useState<{ date: string; ca: number }[]>([]);
-    const [assistantOpen, setAssistantOpen] = useState(false);
     const { navigate } = useNavigation();
 
     const loadData = useCallback(() => {
@@ -350,70 +348,6 @@ export default function Dashboard({ user }: { user?: string }) {
                     </Col>
                 </Row>
             </Card>
-
-            {assistantOpen ? (
-                <div>
-                    <Card
-                        hoverable
-                        onClick={() => setAssistantOpen(false)}
-                        style={{ cursor: 'pointer', marginBottom: 8 }}
-                        styles={{ body: { padding: '12px 16px' } }}
-                    >
-                        <Row align="middle" justify="space-between">
-                            <Space>
-                                <div style={{
-                                    width: 36, height: 36, borderRadius: 10,
-                                    background: 'linear-gradient(135deg, #722ed1, #9254de)',
-                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                }}>
-                                    <RobotOutlined style={{ color: '#fff', fontSize: 18 }} />
-                                </div>
-                                <div>
-                                    <div style={{ fontWeight: 600, fontSize: 15 }}>Assistant IA</div>
-                                    <div style={{ color: '#8c8c8c', fontSize: 12 }}>
-                                        Cliquez pour masquer l'assistant
-                                    </div>
-                                </div>
-                            </Space>
-                            <Button
-                                type="text"
-                                size="small"
-                                icon={<UpOutlined />}
-                                onClick={(e) => { e.stopPropagation(); setAssistantOpen(false); }}
-                            >
-                                Masquer l'assistant
-                            </Button>
-                        </Row>
-                    </Card>
-                    <Home />
-                </div>
-            ) : (
-                <Card
-                    hoverable
-                    onClick={() => setAssistantOpen(true)}
-                    style={{ cursor: 'pointer' }}
-                    styles={{ body: { padding: '12px 16px' } }}
-                >
-                    <Row align="middle" justify="space-between">
-                        <Space>
-                            <div style={{
-                                width: 36, height: 36, borderRadius: 10,
-                                background: 'linear-gradient(135deg, #722ed1, #9254de)',
-                                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                            }}>
-                                <RobotOutlined style={{ color: '#fff', fontSize: 18 }} />
-                            </div>
-                            <div>
-                                <div style={{ fontWeight: 600, fontSize: 15 }}>Assistant IA</div>
-                                <div style={{ color: '#8c8c8c', fontSize: 12 }}>
-                                    Cliquez pour poser une question ou taper une commande
-                                </div>
-                            </div>
-                        </Space>
-                        <DownOutlined style={{ color: '#8c8c8c' }} />
-                    </Row>
-                </Card>
-            )}
 
             <Card title="Actions rapides">
                 <Row gutter={[12, 12]}>

--- a/chantier-ui/src/home.tsx
+++ b/chantier-ui/src/home.tsx
@@ -1,11 +1,41 @@
 import { fetchWithAuth } from './api.ts';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Typography, Row, Card, Input, Button, Space, Divider, Tag, Modal, theme } from 'antd';
+import { Typography, Row, Input, Button, Space, Tag, Modal, theme } from 'antd';
 import {
     RobotOutlined, SendOutlined, QuestionCircleOutlined,
-    AudioOutlined, AudioMutedOutlined
+    AudioOutlined, AudioMutedOutlined, CloseOutlined
 } from '@ant-design/icons';
 import { useNavigation } from './navigation-context.tsx';
+
+const PAGE_LABELS: Record<string, string> = {
+    '/dashboard': "le tableau de bord",
+    '/comptoir': "le comptoir",
+    '/prestations': "les prestations",
+    '/avoirs': "les avoirs",
+    '/clients': "les clients",
+    '/clients/bateaux': "les bateaux des clients",
+    '/clients/moteurs': "les moteurs des clients",
+    '/clients/remorques': "les remorques des clients",
+    '/catalogue/produits': "le catalogue produits",
+    '/catalogue/bateaux': "le catalogue bateaux",
+    '/catalogue/moteurs': "le catalogue moteurs",
+    '/catalogue/helices': "le catalogue hélices",
+    '/catalogue/remorques': "le catalogue remorques",
+    '/catalogue/fournisseurs': "les fournisseurs",
+    '/commandes-fournisseur': "les commandes fournisseur",
+    '/main-oeuvres': "les mains d'oeuvre",
+    '/forfaits': "les forfaits",
+    '/techniciens': "l'équipe technique",
+    '/planning': "le planning",
+    '/annonces': "les petites annonces",
+    '/campagnes': "les campagnes marketing",
+    '/societe': "la société",
+    '/facturation': "la facturation",
+    '/utilisateurs': "les utilisateurs",
+    '/emails': "les emails",
+    '/sequence-emails': "les séquences d'emails",
+    '/reference-valeurs': "les valeurs de référence"
+};
 
 const { Paragraph } = Typography;
 const { TextArea } = Input;
@@ -136,13 +166,15 @@ const renderJsonNode = (
     );
 };
 
-export default function Home() {
+export default function ChatbotWidget({ currentPage }: { currentPage?: string }) {
     const { navigate } = useNavigation();
     const { token } = theme.useToken();
+    const currentPageLabel = (currentPage && PAGE_LABELS[currentPage]) || '';
     const initialAssistantMessage =
         "Bonjour, je suis moussAIllon, votre assistant de gestion de chantier naval.\n\n" +
         "Comment puis-je vous aider aujourd'hui ?\n\n";
 
+    const [ open, setOpen ] = useState(false);
     const [ prompt, setPrompt ] = useState('');
     const [ loading, setLoading ] = useState(false);
     const [ listening, setListening ] = useState(false);
@@ -382,6 +414,9 @@ export default function Home() {
 
     const buildPlannerPrompt = (userInput: string) =>
         "Tu es un moussAIllon, un assistant de gestion de chantier naval.\n" +
+        (currentPageLabel
+            ? "L'utilisateur consulte actuellement " + currentPageLabel + ". Tiens compte de ce contexte.\n"
+            : "") +
         "Réponds UNIQUEMENT en JSON valide, sans texte hors JSON.\n" +
         "Si une action API est utile, renvoie:\n" +
         "{\"action\":\"mcp_call\",\"method\":\"GET|POST|PUT|DELETE\",\"path\":\"/...\",\"query\":{...},\"body\":{...}}\n" +
@@ -741,16 +776,54 @@ export default function Home() {
 
     return (
         <>
-            {/* AI Assistant Chat */}
-            <Card
+            {/* Floating launcher button, present on top of every page */}
+            <Button
+                type="primary"
+                shape="circle"
+                size="large"
+                onClick={() => setOpen((v) => !v)}
+                title={open ? "Fermer l'assistant IA" : "Ouvrir l'assistant IA"}
+                aria-label={open ? "Fermer l'assistant IA" : "Ouvrir l'assistant IA"}
+                icon={open ? <CloseOutlined style={{ fontSize: 20 }} /> : <RobotOutlined style={{ fontSize: 22 }} />}
                 style={{
-                    borderRadius: 12,
-                    border: `1px solid ${token.colorBorderSecondary}`,
-                    overflow: 'hidden',
+                    position: 'fixed',
+                    right: 24,
+                    bottom: 24,
+                    width: 56,
+                    height: 56,
+                    zIndex: 1001,
+                    border: 'none',
+                    background: 'linear-gradient(135deg, #722ed1, #9254de)',
+                    boxShadow: '0 6px 20px rgba(114, 46, 209, 0.45)',
                 }}
-                styles={{ header: { borderBottom: `1px solid ${token.colorBorderSecondary}` } }}
-                title={
-                    <Row align="middle" justify="space-between">
+            />
+
+            {open && (
+            <div
+                style={{
+                    position: 'fixed',
+                    right: 24,
+                    bottom: 92,
+                    zIndex: 1001,
+                    width: 400,
+                    maxWidth: 'calc(100vw - 32px)',
+                    height: 560,
+                    maxHeight: 'calc(100vh - 140px)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    borderRadius: 14,
+                    overflow: 'hidden',
+                    background: token.colorBgContainer,
+                    border: `1px solid ${token.colorBorderSecondary}`,
+                    boxShadow: '0 12px 40px rgba(0, 0, 0, 0.24)',
+                }}
+            >
+                {/* Header */}
+                <div style={{
+                    padding: '12px 16px',
+                    borderBottom: `1px solid ${token.colorBorderSecondary}`,
+                }}>
+                    <Row align="middle" justify="space-between" wrap={false}>
                         <Space>
                             <div style={{
                                 width: 36, height: 36, borderRadius: 10,
@@ -769,18 +842,29 @@ export default function Home() {
                                 </Tag>
                             </div>
                         </Space>
-                        <Tag color="purple" style={{ borderRadius: 10 }}>Claude (Anthropic)</Tag>
+                        <Button
+                            type="text"
+                            size="small"
+                            icon={<CloseOutlined />}
+                            onClick={() => setOpen(false)}
+                            aria-label="Fermer"
+                        />
                     </Row>
-                }
-            >
+                    {currentPageLabel && (
+                        <div style={{ marginTop: 8 }}>
+                            <Tag color="purple" style={{ borderRadius: 10, fontSize: 11 }}>
+                                Contexte : {currentPageLabel}
+                            </Tag>
+                        </div>
+                    )}
+                </div>
 
                 <div
                     ref={chatMessagesRef}
                     style={{
-                        height: 220,
-                        maxHeight: 220,
+                        flex: 1,
+                        minHeight: 0,
                         overflowY: 'auto',
-                        borderRadius: 10,
                         padding: 16,
                         background: token.colorFillQuaternary,
                     }}
@@ -835,54 +919,60 @@ export default function Home() {
                     ))}
                 </div>
 
-                <Divider style={{ margin: '16px 0 12px' }} />
-
-                <Space direction="vertical" style={{ width: '100%' }}>
-                    <TextArea
-                        value={prompt}
-                        onChange={(e) => setPrompt(e.target.value)}
-                        placeholder={"Posez une question ou tapez une commande..."}
-                        autoSize={{ minRows: 2, maxRows: 6 }}
-                        style={{
-                            background: token.colorBgContainer,
-                            color: token.colorText,
-                            borderRadius: 10,
-                        }}
-                        onPressEnter={(e) => {
-                            if (!e.shiftKey) {
-                                e.preventDefault();
-                                onSend();
-                            }
-                        }}
-                    />
-                    <Row justify="space-between" align="middle">
-                        <Space>
-                            <Button icon={<QuestionCircleOutlined />} onClick={() => setIsHelpOpen(true)} style={{ borderRadius: 8 }}>
-                                Aide
-                            </Button>
-                            <Button onClick={() => setPrompt('resources')} style={{ borderRadius: 8 }}>Resources</Button>
+                <div style={{
+                    padding: '12px 16px',
+                    borderTop: `1px solid ${token.colorBorderSecondary}`,
+                    background: token.colorBgContainer,
+                }}>
+                    <Space direction="vertical" style={{ width: '100%' }}>
+                        <TextArea
+                            value={prompt}
+                            onChange={(e) => setPrompt(e.target.value)}
+                            placeholder={"Posez une question ou tapez une commande..."}
+                            autoSize={{ minRows: 2, maxRows: 6 }}
+                            style={{
+                                background: token.colorBgContainer,
+                                color: token.colorText,
+                                borderRadius: 10,
+                            }}
+                            onPressEnter={(e) => {
+                                if (!e.shiftKey) {
+                                    e.preventDefault();
+                                    onSend();
+                                }
+                            }}
+                        />
+                        <Row justify="space-between" align="middle">
+                            <Space size={4}>
+                                <Button size="small" icon={<QuestionCircleOutlined />} onClick={() => setIsHelpOpen(true)} style={{ borderRadius: 8 }}>
+                                    Aide
+                                </Button>
+                                <Button size="small" onClick={() => setPrompt('resources')} style={{ borderRadius: 8 }}>Resources</Button>
+                                <Button
+                                    size="small"
+                                    icon={listening ? <AudioMutedOutlined /> : <AudioOutlined />}
+                                    danger={listening}
+                                    onClick={onToggleVoice}
+                                    title={listening ? 'Arrêter l\'écoute' : 'Dicter un message'}
+                                    style={{ borderRadius: 8 }}
+                                >
+                                    {listening ? 'Écoute...' : 'Voix'}
+                                </Button>
+                            </Space>
                             <Button
-                                icon={listening ? <AudioMutedOutlined /> : <AudioOutlined />}
-                                danger={listening}
-                                onClick={onToggleVoice}
-                                title={listening ? 'Arrêter l\'écoute' : 'Dicter un message'}
+                                type="primary"
+                                icon={<SendOutlined />}
+                                loading={loading}
+                                onClick={onSend}
                                 style={{ borderRadius: 8 }}
                             >
-                                {listening ? 'Écoute...' : 'Voix'}
+                                Envoyer
                             </Button>
-                        </Space>
-                        <Button
-                            type="primary"
-                            icon={<SendOutlined />}
-                            loading={loading}
-                            onClick={onSend}
-                            style={{ borderRadius: 8, paddingInline: 24 }}
-                        >
-                            Envoyer
-                        </Button>
-                    </Row>
-                </Space>
-            </Card>
+                        </Row>
+                    </Space>
+                </div>
+            </div>
+            )}
 
             <Modal
                 title="Aide du chatbot moussAIllon"

--- a/chantier-ui/src/workspace.tsx
+++ b/chantier-ui/src/workspace.tsx
@@ -38,6 +38,7 @@ import CommandesFournisseur from './commandes-fournisseur.tsx';
 import Emails from './emails.tsx';
 import SequenceEmails from './sequence-emails.tsx';
 import ReferenceValeurs from './reference-valeurs.tsx';
+import ChatbotWidget from './home.tsx';
 
 export function demo() {
     message.warning("Vous êtes sur une version de démonstration de moussAIllon. Il n'est pas possible d'ajouter ou supprimer des éléments.")
@@ -543,6 +544,7 @@ export default function Workspace(props) {
                   {VERSION_LABEL}
               </Layout.Footer>
             </Layout>
+            <ChatbotWidget currentPage={currentPage} />
             </NavigationContext.Provider>
         </ConfigProvider>
     );


### PR DESCRIPTION
## Contexte

Dans `chantier-ui`, le chatbot IA était affiché uniquement sur la page d'accueil (dashboard). Il est désormais accessible **par-dessus toutes les pages** via une icône flottante, et il ouvre le chatbot de manière **contextuelle**.

## Changements

- **`home.tsx`** : le composant `Home` devient `ChatbotWidget`.
  - Bouton flottant (rond, dégradé violet, icône robot) fixé en bas à droite, visible sur toutes les pages, qui ouvre/ferme le chatbot.
  - Panneau flottant de style chat (en-tête, historique des messages, zone de saisie).
  - Toute la logique existante est conservée : MCP, planner Claude, langage naturel, commandes API directes, dictée vocale, aide.
  - **Conscience du contexte** : le widget reçoit la page courante, l'affiche sous forme de tag « Contexte : … » dans l'en-tête et l'injecte dans le prompt du planner IA pour des réponses adaptées à la page consultée.
- **`workspace.tsx`** : montage de `<ChatbotWidget currentPage={currentPage} />` au niveau du `Layout` (dans le `NavigationContext.Provider`), donc présent sur toutes les pages.
- **`dashboard.tsx`** : suppression de l'intégration du chatbot (bloc déroulant repliable, état `assistantOpen` et imports d'icônes devenus inutiles).

## Validation

- Build de production `npm run build` OK (seuls des avertissements de source-map préexistants d'`@antv`, sans rapport avec ces changements).