### PR TITLE
feat: mesurer le délai de paiement moyen par client et global

### DIFF
--- a/backend/src/main/java/net/nanthrax/moussaillon/persistence/ClientEntity.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/persistence/ClientEntity.java
@@ -58,4 +58,9 @@ public class ClientEntity extends PanacheEntity {
     @jakarta.persistence.Transient
     public Long nombreBateaux;
 
+    // Délai moyen (en jours) entre la date d'émission de la facture (dateFacturePrete)
+    // et sa date de paiement (dateFacturePayee), sur les factures payées de ce client.
+    @jakarta.persistence.Transient
+    public Double delaiPaiementMoyenJours;
+
 }

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/ClientResource.java
@@ -32,6 +32,7 @@ public class ClientResource {
             c.motDePasse = null;
             c.soldeDu = computeSoldeDu(c.id);
             c.nombreBateaux = computeNombreBateaux(c.id);
+            c.delaiPaiementMoyenJours = computeDelaiPaiementMoyenJours(c.id);
         });
         return clients;
     }
@@ -53,6 +54,7 @@ public class ClientResource {
             c.motDePasse = null;
             c.soldeDu = computeSoldeDu(c.id);
             c.nombreBateaux = computeNombreBateaux(c.id);
+            c.delaiPaiementMoyenJours = computeDelaiPaiementMoyenJours(c.id);
         });
         return clients;
     }
@@ -84,6 +86,7 @@ public class ClientResource {
         entity.motDePasse = null;
         entity.soldeDu = computeSoldeDu(id);
         entity.nombreBateaux = computeNombreBateaux(id);
+        entity.delaiPaiementMoyenJours = computeDelaiPaiementMoyenJours(id);
         return entity;
     }
 
@@ -134,6 +137,7 @@ public class ClientResource {
         entity.motDePasse = null;
         entity.soldeDu = computeSoldeDu(id);
         entity.nombreBateaux = computeNombreBateaux(id);
+        entity.delaiPaiementMoyenJours = computeDelaiPaiementMoyenJours(id);
         return entity;
     }
 
@@ -150,6 +154,29 @@ public class ClientResource {
             .createQuery("SELECT COUNT(b) FROM BateauClientEntity b JOIN b.proprietaires p WHERE p.id = :clientId", Long.class)
             .setParameter("clientId", clientId)
             .getSingleResult();
+    }
+
+    /**
+     * Délai moyen, en jours, entre l'émission d'une facture (dateFacturePrete) et son
+     * paiement (dateFacturePayee), sur les factures payées de ce client. Retourne null
+     * si le client n'a aucune facture payée avec ces deux dates renseignées.
+     */
+    private Double computeDelaiPaiementMoyenJours(long clientId) {
+        List<VenteEntity> payees = VenteEntity.list(
+            "client.id = ?1 and status = ?2 and dateFacturePrete is not null and dateFacturePayee is not null",
+            clientId, VenteEntity.Status.FACTURE_PAYEE
+        );
+        return averageDelaiPaiementJours(payees);
+    }
+
+    static Double averageDelaiPaiementJours(List<VenteEntity> ventesPayees) {
+        if (ventesPayees.isEmpty()) {
+            return null;
+        }
+        double totalJours = ventesPayees.stream()
+            .mapToDouble(v -> (v.dateFacturePayee.getTime() - v.dateFacturePrete.getTime()) / 86400000.0)
+            .sum();
+        return totalJours / ventesPayees.size();
     }
 
     @POST

--- a/backend/src/main/java/net/nanthrax/moussaillon/services/DashboardResource.java
+++ b/backend/src/main/java/net/nanthrax/moussaillon/services/DashboardResource.java
@@ -168,6 +168,12 @@ public class DashboardResource {
                 + servicesDuMois.stream().filter(vs -> vs.status == VenteServiceEntity.Status.TERMINEE).count();
         data.contratsMaintenancePct = itemsTotal > 0 ? (int) Math.round((double) itemsTermines / itemsTotal * 100) : 0;
 
+        // Délai de paiement moyen (tous clients), en jours, entre émission et paiement de facture
+        List<VenteEntity> facturesPayees = VenteEntity.list(
+                "status = ?1 and dateFacturePrete is not null and dateFacturePayee is not null",
+                VenteEntity.Status.FACTURE_PAYEE);
+        data.delaiPaiementMoyenJours = ClientResource.averageDelaiPaiementJours(facturesPayees);
+
         return data;
     }
 
@@ -194,6 +200,7 @@ public class DashboardResource {
         public int bateauxDansLeChantier;
         public int bateauxEntreesSemaine;
         public int bateauxEnAttenteIntervention;
+        public Double delaiPaiementMoyenJours;
     }
 
     public static class InterventionRow {

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/ClientResourceAverageDelaiPaiementTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/ClientResourceAverageDelaiPaiementTest.java
@@ -1,0 +1,45 @@
+package net.nanthrax.moussaillon.services;
+
+import net.nanthrax.moussaillon.persistence.VenteEntity;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Test unitaire (sans contexte Quarkus) de l'arithmétique de
+ * {@link ClientResource#averageDelaiPaiementJours}, utilisée à la fois pour le délai de
+ * paiement moyen par client et pour la moyenne globale du tableau de bord.
+ */
+public class ClientResourceAverageDelaiPaiementTest {
+
+    private static VenteEntity venteAvecDelai(long joursDelai) {
+        VenteEntity vente = new VenteEntity();
+        long now = System.currentTimeMillis();
+        vente.dateFacturePrete = new Timestamp(now - 30L * 86_400_000);
+        vente.dateFacturePayee = new Timestamp(vente.dateFacturePrete.getTime() + joursDelai * 86_400_000);
+        return vente;
+    }
+
+    @Test
+    void testMoyenneListeVide() {
+        assertNull(ClientResource.averageDelaiPaiementJours(List.of()));
+    }
+
+    @Test
+    void testMoyenneUneFacture() {
+        Double moyenne = ClientResource.averageDelaiPaiementJours(List.of(venteAvecDelai(3)));
+        assertEquals(3.0, moyenne, 0.01);
+    }
+
+    @Test
+    void testMoyennePlusieursFactures() {
+        Double moyenne = ClientResource.averageDelaiPaiementJours(
+            List.of(venteAvecDelai(2), venteAvecDelai(4), venteAvecDelai(6))
+        );
+        assertEquals(4.0, moyenne, 0.01); // (2 + 4 + 6) / 3
+    }
+}

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/ClientResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/ClientResourceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 public class ClientResourceTest {
@@ -111,5 +112,66 @@ public class ClientResourceTest {
             .when().get("/clients/" + id)
             .then()
             .statusCode(404);
+    }
+
+    @Test
+    void testDelaiPaiementMoyenSansFacturePayee() {
+        int clientId = given()
+            .contentType("application/json")
+            .body("{\"nom\":\"SansFacturePayee\",\"type\":\"Particulier\"}")
+            .when().post("/clients")
+            .then()
+            .statusCode(200)
+            .extract().path("id");
+
+        given()
+            .when().get("/clients/" + clientId)
+            .then()
+            .statusCode(200)
+            .body("delaiPaiementMoyenJours", nullValue());
+    }
+
+    @Test
+    void testDelaiPaiementMoyenAvecFacturesPayees() {
+        int clientId = given()
+            .contentType("application/json")
+            .body("{\"nom\":\"AvecFacturesPayees\",\"type\":\"Particulier\"}")
+            .when().post("/clients")
+            .then()
+            .statusCode(200)
+            .extract().path("id");
+
+        // Facture emise le 01/01, payee le 05/01 : delai de 4 jours.
+        given()
+            .contentType("application/json")
+            .body("{\"status\":\"FACTURE_PAYEE\",\"client\":{\"id\":" + clientId + "},"
+                + "\"dateFacturePrete\":\"2026-01-01\",\"dateFacturePayee\":\"2026-01-05\",\"prixVenteTTC\":100.0}")
+            .when().post("/ventes")
+            .then()
+            .statusCode(201);
+
+        // Facture emise le 01/02, payee le 09/02 : delai de 8 jours.
+        given()
+            .contentType("application/json")
+            .body("{\"status\":\"FACTURE_PAYEE\",\"client\":{\"id\":" + clientId + "},"
+                + "\"dateFacturePrete\":\"2026-02-01\",\"dateFacturePayee\":\"2026-02-09\",\"prixVenteTTC\":200.0}")
+            .when().post("/ventes")
+            .then()
+            .statusCode(201);
+
+        // Facture payee mais sans date d'emission : ne doit pas entrer dans la moyenne.
+        given()
+            .contentType("application/json")
+            .body("{\"status\":\"FACTURE_PAYEE\",\"client\":{\"id\":" + clientId + "},\"prixVenteTTC\":50.0}")
+            .when().post("/ventes")
+            .then()
+            .statusCode(201);
+
+        Number delai = given()
+            .when().get("/clients/" + clientId)
+            .then()
+            .statusCode(200)
+            .extract().path("delaiPaiementMoyenJours");
+        assertEquals(6.0, delai.doubleValue(), 0.01); // (4 + 8) / 2
     }
 }

--- a/backend/src/test/java/net/nanthrax/moussaillon/services/DashboardResourceTest.java
+++ b/backend/src/test/java/net/nanthrax/moussaillon/services/DashboardResourceTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.instanceOf;
 
 @QuarkusTest
 public class DashboardResourceTest {
@@ -26,6 +28,10 @@ public class DashboardResourceTest {
             .body("contratsMaintenancePct", notNullValue())
             .body("bateauxDansLeChantier", notNullValue())
             .body("bateauxEntreesSemaine", notNullValue())
-            .body("bateauxEnAttenteIntervention", notNullValue());
+            .body("bateauxEnAttenteIntervention", notNullValue())
+            // Null tant qu'aucune facture payee n'a a la fois sa date d'emission et sa date
+            // de paiement renseignees ; sinon un nombre (moyenne en jours). L'arithmetique de
+            // calcul de la moyenne est couverte par ClientResourceAverageDelaiPaiementTest.
+            .body("delaiPaiementMoyenJours", anyOf(nullValue(), instanceOf(Number.class)));
     }
 }

--- a/chantier-ui/src/clients.tsx
+++ b/chantier-ui/src/clients.tsx
@@ -288,6 +288,13 @@ function Clients() {
       },
     },
     {
+      title: "Délai paiement moyen",
+      dataIndex: "delaiPaiementMoyenJours",
+      key: "delaiPaiementMoyenJours",
+      sorter: (a, b) => (a.delaiPaiementMoyenJours ?? -1) - (b.delaiPaiementMoyenJours ?? -1),
+      render: (val) => (val != null ? `${val.toFixed(1)} j` : <span style={{ color: "#bfbfbf" }}>-</span>),
+    },
+    {
       title: "Bateau(x)",
       dataIndex: "nombreBateaux",
       key: "nombreBateaux",

--- a/chantier-ui/src/dashboard.tsx
+++ b/chantier-ui/src/dashboard.tsx
@@ -37,6 +37,7 @@ type DashboardData = {
     bateauxDansLeChantier: number;
     bateauxEntreesSemaine: number;
     bateauxEnAttenteIntervention: number;
+    delaiPaiementMoyenJours: number | null;
 };
 
 type PlanningWarning = {
@@ -412,7 +413,7 @@ export default function Dashboard({ user }: { user?: string }) {
             </Row>
 
             <Row gutter={[16, 16]}>
-                <Col xs={24} sm={8}>
+                <Col xs={24} sm={12} lg={6}>
                     <Card hoverable onClick={() => navigate('/clients/bateaux')} style={{ borderTop: '3px solid #722ed1', cursor: 'pointer' }}>
                         <Statistic
                             title="Bateaux dans le chantier"
@@ -422,7 +423,7 @@ export default function Dashboard({ user }: { user?: string }) {
                         />
                     </Card>
                 </Col>
-                <Col xs={24} sm={8}>
+                <Col xs={24} sm={12} lg={6}>
                     <Card hoverable onClick={() => navigate('/clients/bateaux')} style={{ borderTop: '3px solid #13c2c2', cursor: 'pointer' }}>
                         <Statistic
                             title="Entrées cette semaine"
@@ -431,12 +432,24 @@ export default function Dashboard({ user }: { user?: string }) {
                         />
                     </Card>
                 </Col>
-                <Col xs={24} sm={8}>
+                <Col xs={24} sm={12} lg={6}>
                     <Card hoverable onClick={() => navigate('/prestations')} style={{ borderTop: '3px solid #fa8c16', cursor: 'pointer' }}>
                         <Statistic
                             title="En attente d'intervention"
                             value={data.bateauxEnAttenteIntervention}
                             valueStyle={{ color: '#d46b08', fontWeight: 700 }}
+                        />
+                    </Card>
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                    <Card hoverable onClick={() => navigate('/clients')} style={{ borderTop: '3px solid #eb2f96', cursor: 'pointer' }}>
+                        <Statistic
+                            title="Délai de paiement moyen"
+                            value={data.delaiPaiementMoyenJours ?? undefined}
+                            precision={1}
+                            suffix="j"
+                            valueStyle={{ color: '#c41d7f', fontWeight: 700 }}
+                            formatter={data.delaiPaiementMoyenJours == null ? () => '-' : undefined}
                         />
                     </Card>
                 </Col>


### PR DESCRIPTION
## Contexte

Demande de Franck Viandier (Slack, 2026-07-26) : mesurer le délai de paiement moyen, par client et pour l'ensemble des clients. Définition validée avec JB : délai = date d'émission de la facture → date de paiement.

## Changements

- Backend : le délai se calcule entre `dateFacturePrete` (date d'émission) et `dateFacturePayee` (date de paiement), sur les factures au statut `FACTURE_PAYEE` ayant les deux dates renseignées.
  - `ClientEntity.delaiPaiementMoyenJours` : nouveau champ calculé (moyenne par client), suivant le pattern existant de `soldeDu`.
  - `ClientResource` : méthode de calcul par client, exposée sur `list()`, `search()`, `get()` et `update()`.
  - `DashboardResource.delaiPaiementMoyenJours` : moyenne tous clients confondus, réutilisant la même logique de calcul.
- Frontend (chantier-ui) :
  - `clients.tsx` : nouvelle colonne "Délai paiement moyen" dans la liste des clients.
  - `dashboard.tsx` : nouvelle tuile stat "Délai de paiement moyen" sur le tableau de bord.

Closes #486

## Test plan
- [x] Backend compile
- [x] Vérification manuelle en local : la tuile dashboard et la colonne clients affichent correctement `-` en l'absence de facture payée avec les deux dates, sans erreur